### PR TITLE
fix: prevent grid book cover from overflowing item container

### DIFF
--- a/apps/web/src/books/lists/BookListItemVertical.tsx
+++ b/apps/web/src/books/lists/BookListItemVertical.tsx
@@ -84,7 +84,16 @@ export const BookListItemVertical = memo(function BookListItemVertical({
         selectionEnabled={selectionEnabled}
         controlProps={controlProps}
         itemLabel="book"
-        sx={{ flex: 1, display: "flex" }}
+        sx={{
+          flex: 1,
+          display: "flex",
+          // Allow this flex child to shrink below its content's intrinsic
+          // height so the fixed bottom bar stays pinned. Without this, the
+          // cover's intrinsic image size can push the item past its
+          // container-query-derived height.
+          minHeight: 0,
+          overflow: "hidden",
+        }}
       >
         <BookCoverCard
           bookId={bookId}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the book library grid (view mode `grid`), cards with a tall cover image were breaking out of their cell: the cover pushed the fixed-height bottom bar (title / author) down, causing it to visually spill into the neighbouring row.

This is a regression from the multi-select refactor (`bf7973d` — "feat: multi select cards"). That change introduced a new `SelectableCardOverlay` wrapper between the `BookListItemVertical` flex column and the `BookCoverCard`. The overlay was styled with `sx={{ flex: 1, display: "flex" }}` but without `min-height: 0`.

Because flex items default to `min-height: auto`, the overlay refused to shrink below the cover's intrinsic image height. The cell itself has its height computed from a container query (`gridItemHeightCss`), so the overlay's overflow pushed the subsequent bottom bar out of the clipped region.

Previously, `BookCoverCard` was the direct flex child and already set `min-height: 0` + `overflow: hidden` on its internal `Card`, which is why the layout stayed stable.

## Fix

Propagate the shrink-to-fit behaviour to the new intermediate flex item: add `minHeight: 0` (and `overflow: hidden` for safety) to the `SelectableCardOverlay` in `BookListItemVertical`. This restores the pre-refactor invariant that the cover region respects the flex-allocated height and the bottom bar stays pinned inside the cell.

## Scope

- Only affects `BookListItemVertical` (grid / horizontal carousel vertical card layout).
- No behaviour change for list / compact view modes.
- No change to selection UX — the overlay region keeps its `position: relative` + overlay pseudo-element; only its flex sizing rules are tightened.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de0340fc-51a8-489d-bc0b-4db59f296be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de0340fc-51a8-489d-bc0b-4db59f296be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

