### PR TITLE
refactor: migrate web download to useDownload hook

### DIFF
--- a/apps/web/src/connectors/useExtractConnectorData.ts
+++ b/apps/web/src/connectors/useExtractConnectorData.ts
@@ -1,5 +1,6 @@
+import type { DefaultError } from "@tanstack/react-query"
 import { from, map, switchMap } from "rxjs"
-import { useMutation$ } from "reactjrx"
+import { useMutation$, type UseMutation$Options } from "reactjrx"
 import { useRequestMasterKey } from "../secrets/useRequestMasterKey"
 import { getLatestDatabase } from "../rxdb/RxDbProvider"
 import { throwIfNotDefined } from "../common/rxjs/operators"
@@ -12,12 +13,22 @@ import { isConnectorOfType } from "../rxdb/collections/settings"
 
 export const useExtractConnectorData = <
   T extends SettingsConnectorDocType["type"],
->({
-  type,
-}: {
-  type: T
-}) => {
-  const { mutateAsync: requestMasterKey } = useRequestMasterKey()
+>(
+  { type }: { type: T },
+  options?: Omit<
+    UseMutation$Options<
+      { data: SettingsResolvedConnectorData<T> },
+      DefaultError,
+      { connectorId: string }
+    >,
+    "mutationFn"
+  >,
+) => {
+  // Forward only the toast-suppression policy down to the nested master-key
+  // request so a single consumer-level `meta` silences the whole subtree.
+  const { mutateAsync: requestMasterKey } = useRequestMasterKey({
+    meta: options?.meta,
+  })
 
   return useMutation$({
     mutationFn: ({ connectorId }: { connectorId: string }) =>
@@ -62,5 +73,6 @@ export const useExtractConnectorData = <
           ),
         ),
       ),
+    ...options,
   })
 }

--- a/apps/web/src/connectors/useExtractConnectorData.ts
+++ b/apps/web/src/connectors/useExtractConnectorData.ts
@@ -24,8 +24,6 @@ export const useExtractConnectorData = <
     "mutationFn"
   >,
 ) => {
-  // Forward only the toast-suppression policy down to the nested master-key
-  // request so a single consumer-level `meta` silences the whole subtree.
   const { mutateAsync: requestMasterKey } = useRequestMasterKey({
     meta: options?.meta,
   })

--- a/apps/web/src/download/flow/DownloadFlowRequestItem.tsx
+++ b/apps/web/src/download/flow/DownloadFlowRequestItem.tsx
@@ -10,7 +10,6 @@ import { dexieDb } from "../../rxdb/dexie"
 import { bytesToMb } from "../../common/utils"
 import { DownloadState, booksDownloadStateSignal } from "../states"
 import { Logger } from "../../debug/logger.shared"
-import { notifyError } from "../../notifications/toasts"
 import type { DownloadFlowRequest } from "./types"
 
 type DownloadLink = NonNullable<Awaited<ReturnType<typeof getLinkStateAsync>>>
@@ -80,10 +79,6 @@ export const DownloadFlowRequestItem = memo(
           reject(error)
 
           return
-        }
-
-        if (error) {
-          notifyError(error)
         }
 
         reject(toError(error, "Download failed"))

--- a/apps/web/src/download/flow/DownloadFlowRequestItem.tsx
+++ b/apps/web/src/download/flow/DownloadFlowRequestItem.tsx
@@ -14,9 +14,6 @@ import type { DownloadFlowRequest } from "./types"
 
 type DownloadLink = NonNullable<Awaited<ReturnType<typeof getLinkStateAsync>>>
 
-const toError = (error: unknown, fallbackMessage: string) =>
-  error instanceof Error ? error : new Error(fallbackMessage)
-
 const setDownloadData = (
   bookId: string,
   data: ReturnType<typeof booksDownloadStateSignal.getValue>[number],
@@ -75,13 +72,7 @@ export const DownloadFlowRequestItem = memo(
           downloadState: DownloadState.None,
         })
 
-        if (error instanceof CancelError) {
-          reject(error)
-
-          return
-        }
-
-        reject(toError(error, "Download failed"))
+        reject(error)
       },
       [bookId, onSettled, reject, resolve],
     )
@@ -120,9 +111,7 @@ export const DownloadFlowRequestItem = memo(
             settle({ success: true })
           })
           .catch((error) => {
-            settle({
-              error: toError(error, "Unable to persist downloaded file."),
-            })
+            settle({ error })
           })
       },
       [persistDownloadResult, settle],
@@ -166,7 +155,7 @@ export const DownloadFlowRequestItem = memo(
               })
               settle({ success: true })
             } catch (error) {
-              onError(toError(error, "Unable to persist downloaded file."))
+              onError(error)
             }
 
             return
@@ -199,7 +188,7 @@ export const DownloadFlowRequestItem = memo(
             setLink(resolvedLink)
             setIsPreparing(false)
           } catch (error) {
-            onError(toError(error, "Unable to prepare the download."))
+            onError(error)
           }
         })()
       },

--- a/apps/web/src/download/flow/types.ts
+++ b/apps/web/src/download/flow/types.ts
@@ -4,6 +4,6 @@ export type DownloadFlowRequest = {
   file?: File
   id: string
   links: readonly string[]
-  reject: (error: Error) => void
+  reject: (error: unknown) => void
   resolve: () => void
 }

--- a/apps/web/src/http/httpClient.web.ts
+++ b/apps/web/src/http/httpClient.web.ts
@@ -89,7 +89,7 @@ type XhrParams = {
   onDownloadProgress?: (event: ProgressEvent<EventTarget>) => void
 }
 
-const sendXhr = <T>(
+export const sendXhr = <T>(
   {
     url,
     method,
@@ -171,11 +171,6 @@ export class HttpClientWeb extends HttpClient {
 
       return () => controller.abort()
     })
-
-  // `xhr.response` is typed `any` because its runtime shape depends on
-  // `responseType`; callers pick `T` via the generic to constrain it.
-  download = <T>(params: DownloadParams) =>
-    sendXhr<T>({ ...params, method: "GET" }, (xhr) => xhr.response as T)
 }
 
 export const httpClientWeb = new HttpClientWeb()

--- a/apps/web/src/http/useDownload.ts
+++ b/apps/web/src/http/useDownload.ts
@@ -1,0 +1,24 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query"
+import {
+  type DownloadParams,
+  type XhrResponse,
+  sendXhr,
+} from "./httpClient.web"
+
+type DownloadOptions = Omit<
+  UseMutationOptions<XhrResponse<Blob>, unknown, DownloadParams>,
+  "mutationFn"
+>
+
+export const useDownload = (options?: DownloadOptions) =>
+  useMutation({
+    mutationFn: (params: DownloadParams) =>
+      sendXhr<Blob>(
+        { ...params, method: "GET" },
+        (xhr) => xhr.response as Blob,
+      ),
+    gcTime: 0,
+    ...options,
+  })
+
+export type Download = ReturnType<typeof useDownload>["mutateAsync"]

--- a/apps/web/src/http/useDownload.ts
+++ b/apps/web/src/http/useDownload.ts
@@ -13,10 +13,13 @@ type DownloadOptions = Omit<
 export const useDownload = (options?: DownloadOptions) =>
   useMutation({
     mutationFn: (params: DownloadParams) =>
-      sendXhr<Blob>(
-        { ...params, method: "GET" },
-        (xhr) => xhr.response as Blob,
-      ),
+      sendXhr<Blob>({ ...params, method: "GET" }, (xhr) => {
+        if (!(xhr.response instanceof Blob)) {
+          throw new Error("Expected download response to be a Blob")
+        }
+
+        return xhr.response
+      }),
     gcTime: 0,
     ...options,
   })

--- a/apps/web/src/notifications/inbox/LocalNotificationCard.tsx
+++ b/apps/web/src/notifications/inbox/LocalNotificationCard.tsx
@@ -1,0 +1,19 @@
+import { memo } from "react"
+import { Alert, AlertTitle } from "@mui/material"
+import type { LocalNotification } from "./useLocalNotifications"
+
+export const LocalNotificationCard = memo(function LocalNotificationCard({
+  notification,
+}: {
+  notification: LocalNotification
+}) {
+  return (
+    <Alert
+      severity={notification.severity}
+      sx={{ "& .MuiAlert-message": { flexGrow: 1 } }}
+    >
+      <AlertTitle>{notification.title}</AlertTitle>
+      {notification.body}
+    </Alert>
+  )
+})

--- a/apps/web/src/notifications/inbox/NotificationsScreen.tsx
+++ b/apps/web/src/notifications/inbox/NotificationsScreen.tsx
@@ -2,6 +2,8 @@ import { memo } from "react"
 import { Alert, Button, Stack, Typography } from "@mui/material"
 import { Page } from "../../common/Page"
 import { TopBarNavigation } from "../../navigation/TopBarNavigation"
+import { useLocalNotifications } from "./useLocalNotifications"
+import { LocalNotificationCard } from "./LocalNotificationCard"
 import { useInboxNotifications } from "./useInboxNotifications"
 import { useMarkAllNotificationsAsSeen } from "./useMarkAllNotificationsAsSeen"
 import { useUnreadNotificationsCount } from "./useUnreadNotificationsCount"
@@ -11,6 +13,7 @@ export const NotificationsScreen = memo(function NotificationsScreen() {
   const notificationsQuery = useInboxNotifications()
   const { unreadCount } = useUnreadNotificationsCount()
   const markAllNotificationsAsSeen = useMarkAllNotificationsAsSeen()
+  const localNotifications = useLocalNotifications()
 
   return (
     <Page>
@@ -37,6 +40,13 @@ export const NotificationsScreen = memo(function NotificationsScreen() {
           gap: 2,
         }}
       >
+        {localNotifications.map((notification) => (
+          <LocalNotificationCard
+            key={notification.id}
+            notification={notification}
+          />
+        ))}
+
         {notificationsQuery.isLoading && (
           <Typography
             sx={{
@@ -47,12 +57,13 @@ export const NotificationsScreen = memo(function NotificationsScreen() {
           </Typography>
         )}
 
-        {notificationsQuery.error && (
+        {notificationsQuery.error && localNotifications.length === 0 && (
           <Alert severity="error">{notificationsQuery.error.message}</Alert>
         )}
 
         {notificationsQuery.data?.length === 0 &&
-          !notificationsQuery.isLoading && (
+          !notificationsQuery.isLoading &&
+          localNotifications.length === 0 && (
             <Alert severity="info">
               You do not have any notifications right now.
             </Alert>

--- a/apps/web/src/notifications/inbox/useLocalNotifications.ts
+++ b/apps/web/src/notifications/inbox/useLocalNotifications.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react"
+import type { NotificationSeverity } from "@oboku/shared"
+import { useSignalValue } from "reactjrx"
+import { authStateSignal } from "../../auth/states.web"
+
+/**
+ * A notification produced entirely on the client (no server backing).
+ * Unlike inbox notifications it has no persisted id / seen / archived state:
+ * it lives only as long as the condition that produced it.
+ */
+export type LocalNotification = {
+  id: string
+  severity: NotificationSeverity
+  title: string
+  body: string | null
+}
+
+/**
+ * Client-side notifications derived from local app state. This is the only
+ * place that knows about `needsRelogin` (and any future local conditions),
+ * keeping the inbox/badge code generic.
+ */
+export const useLocalNotifications = (): LocalNotification[] => {
+  const needsRelogin = useSignalValue(authStateSignal)?.needsRelogin ?? false
+
+  return useMemo(() => {
+    const notifications: LocalNotification[] = []
+
+    if (needsRelogin) {
+      notifications.push({
+        id: "session_expired",
+        severity: "warning",
+        title: "Session expired",
+        body: "Your session has expired. Please sign in again to continue.",
+      })
+    }
+
+    return notifications
+  }, [needsRelogin])
+}

--- a/apps/web/src/notifications/inbox/useLocalNotifications.ts
+++ b/apps/web/src/notifications/inbox/useLocalNotifications.ts
@@ -3,11 +3,6 @@ import type { NotificationSeverity } from "@oboku/shared"
 import { useSignalValue } from "reactjrx"
 import { authStateSignal } from "../../auth/states.web"
 
-/**
- * A notification produced entirely on the client (no server backing).
- * Unlike inbox notifications it has no persisted id / seen / archived state:
- * it lives only as long as the condition that produced it.
- */
 export type LocalNotification = {
   id: string
   severity: NotificationSeverity
@@ -15,11 +10,6 @@ export type LocalNotification = {
   body: string | null
 }
 
-/**
- * Client-side notifications derived from local app state. This is the only
- * place that knows about `needsRelogin` (and any future local conditions),
- * keeping the inbox/badge code generic.
- */
 export const useLocalNotifications = (): LocalNotification[] => {
   const needsRelogin = useSignalValue(authStateSignal)?.needsRelogin ?? false
 

--- a/apps/web/src/notifications/inbox/useNotificationsQueries.test.ts
+++ b/apps/web/src/notifications/inbox/useNotificationsQueries.test.ts
@@ -90,6 +90,9 @@ describe("notifications queries", () => {
         useQuery,
       }
     })
+    vi.doMock("./useLocalNotifications", () => ({
+      useLocalNotifications: () => [],
+    }))
 
     const { useUnreadNotificationsCount } = await import(
       "./useUnreadNotificationsCount"

--- a/apps/web/src/notifications/inbox/useUnreadNotificationsCount.ts
+++ b/apps/web/src/notifications/inbox/useUnreadNotificationsCount.ts
@@ -2,9 +2,11 @@ import { useQuery } from "@tanstack/react-query"
 import type { GetUnreadNotificationsCountResponse } from "@oboku/shared"
 import { configuration } from "../../config/configuration"
 import { httpClientApi } from "../../http/httpClientApi.web"
+import { useLocalNotifications } from "./useLocalNotifications"
 import { unreadCountQueryKey } from "./queryKeys"
 
 export const useUnreadNotificationsCount = () => {
+  const localNotifications = useLocalNotifications()
   const query = useQuery({
     queryKey: unreadCountQueryKey,
     queryFn: async (): Promise<GetUnreadNotificationsCountResponse> => {
@@ -22,6 +24,6 @@ export const useUnreadNotificationsCount = () => {
 
   return {
     ...query,
-    unreadCount: query.data?.count ?? 0,
+    unreadCount: (query.data?.count ?? 0) + localNotifications.length,
   }
 }

--- a/apps/web/src/plugins/dropbox/DownloadBook.tsx
+++ b/apps/web/src/plugins/dropbox/DownloadBook.tsx
@@ -61,6 +61,7 @@ export const DownloadBook = memo(
         ),
       onSuccess: onResolve,
       onError,
+      meta: { suppressGlobalErrorToast: true },
     })
 
     useEffectWithUnmount$(

--- a/apps/web/src/plugins/google/DownloadBook.tsx
+++ b/apps/web/src/plugins/google/DownloadBook.tsx
@@ -12,7 +12,7 @@ import {
   throwIfEmpty,
   type Observable,
 } from "rxjs"
-import { httpClientWeb } from "../../http/httpClient.web"
+import { useDownload } from "../../http/useDownload"
 import { CancelError } from "../../errors/errors.shared"
 import { fromAbortSignal } from "../../common/rxjs/fromAbortSignal"
 import { useEffectWithUnmount$ } from "../../common/rxjs/useEffectWithUnmount$"
@@ -43,6 +43,9 @@ export const DownloadBook = memo(
       requestPopup,
     })
     const getDriveFile = useDriveFilesGet()
+    const { mutateAsync: downloadBlob } = useDownload({
+      meta: { suppressGlobalErrorToast: true },
+    })
     const { mutate: download } = useMutation$({
       mutationFn: ({ onUnmount$ }: { onUnmount$: Observable<void> }) => {
         const { fileId } = link.data
@@ -62,7 +65,7 @@ export const DownloadBook = memo(
                 }).pipe(
                   mergeMap((info) =>
                     from(
-                      httpClientWeb.download<Blob>({
+                      downloadBlob({
                         headers: {
                           Authorization: `Bearer ${gapi.auth.getToken().access_token}`,
                         },

--- a/apps/web/src/plugins/google/DownloadBook.tsx
+++ b/apps/web/src/plugins/google/DownloadBook.tsx
@@ -106,6 +106,7 @@ export const DownloadBook = memo(
       },
       onSuccess: onResolve,
       onError,
+      meta: { suppressGlobalErrorToast: true },
     })
 
     useEffectWithUnmount$(

--- a/apps/web/src/plugins/google/DownloadBook.tsx
+++ b/apps/web/src/plugins/google/DownloadBook.tsx
@@ -38,7 +38,9 @@ export const DownloadBook = memo(
     signal,
   }: DownloadBookComponentProps<"DRIVE">) => {
     const requestPopup = useRequestPopupDialog(PLUGIN_NAME)
-    const { getGoogleScripts } = useGoogleScripts()
+    const { getGoogleScripts } = useGoogleScripts({
+      meta: { suppressGlobalErrorToast: true },
+    })
     const requestFilesAccess = useRequestFilesAccess({
       requestPopup,
     })

--- a/apps/web/src/plugins/google/lib/gapi.ts
+++ b/apps/web/src/plugins/google/lib/gapi.ts
@@ -1,4 +1,9 @@
-import { signal, useSignalValue, useSwitchMutation$ } from "reactjrx"
+import {
+  signal,
+  type UseMutation$Options,
+  useSignalValue,
+  useSwitchMutation$,
+} from "reactjrx"
 import { catchError, combineLatest, defer, from, map, mergeMap } from "rxjs"
 import { GapiNotAvailableError } from "./errors"
 import { loadScript, retryOnFailure } from "../../../common/scripts"
@@ -75,9 +80,12 @@ const initClient = () =>
     ),
   )
 
-export const useLoadGapi = () => {
+export const useLoadGapi = (
+  options?: Pick<UseMutation$Options<unknown>, "meta">,
+) => {
   return useSwitchMutation$({
     mutationKey: ["pluginGoogleScriptMutation"],
+    ...options,
     mutationFn: () => {
       return loadScript({
         id: ID,

--- a/apps/web/src/plugins/google/lib/scripts.ts
+++ b/apps/web/src/plugins/google/lib/scripts.ts
@@ -1,11 +1,14 @@
 import { catchError, combineLatest, first } from "rxjs"
+import type { UseMutation$Options } from "reactjrx"
 import { gsiOrThrow$ } from "../../../google/gsi"
 import { gapiOrThrow$, useLoadGapi } from "./gapi"
 import { showDialog } from "../../../common/dialogs/createDialog"
 import { useCallback } from "react"
 
-export const useGoogleScripts = () => {
-  const { mutate: loadGapi } = useLoadGapi()
+export const useGoogleScripts = (
+  options?: Pick<UseMutation$Options<unknown>, "meta">,
+) => {
+  const { mutate: loadGapi } = useLoadGapi(options)
 
   const getGoogleScripts = useCallback(
     () =>

--- a/apps/web/src/plugins/one-drive/DownloadBook.tsx
+++ b/apps/web/src/plugins/one-drive/DownloadBook.tsx
@@ -8,7 +8,8 @@ import {
   throwIfEmpty,
   type Observable,
 } from "rxjs"
-import { type DownloadParams, httpClientWeb } from "../../http/httpClient.web"
+import type { DownloadParams } from "../../http/httpClient.web"
+import { useDownload } from "../../http/useDownload"
 import { CancelError } from "../../errors/errors.shared"
 import { fromAbortSignal } from "../../common/rxjs/fromAbortSignal"
 import { useEffectWithUnmount$ } from "../../common/rxjs/useEffectWithUnmount$"
@@ -28,6 +29,9 @@ export const DownloadBook = memo(function DownloadBook({
   signal,
 }: DownloadBookComponentProps<"one-drive">) {
   const requestPopup = useRequestPopupDialog(ONE_DRIVE_PLUGIN_NAME)
+  const { mutateAsync: downloadBlob } = useDownload({
+    meta: { suppressGlobalErrorToast: true },
+  })
 
   const { mutate: download } = useMutation({
     mutationFn: async ({
@@ -39,7 +43,7 @@ export const DownloadBook = memo(function DownloadBook({
       fileName: string
       size?: number
     }) => {
-      const response = await httpClientWeb.download<Blob>({
+      const response = await downloadBlob({
         onDownloadProgress: (event) => {
           const totalSize = size || event.total || 1
 

--- a/apps/web/src/plugins/one-drive/DownloadBook.tsx
+++ b/apps/web/src/plugins/one-drive/DownloadBook.tsx
@@ -61,6 +61,7 @@ export const DownloadBook = memo(function DownloadBook({
     },
     onSuccess: onResolve,
     onError,
+    meta: { suppressGlobalErrorToast: true },
   })
 
   const { mutate: resolve } = useMutation$({
@@ -92,6 +93,7 @@ export const DownloadBook = memo(function DownloadBook({
       })
     },
     onError,
+    meta: { suppressGlobalErrorToast: true },
   })
 
   useEffectWithUnmount$(

--- a/apps/web/src/plugins/synology-drive/DownloadBook.tsx
+++ b/apps/web/src/plugins/synology-drive/DownloadBook.tsx
@@ -21,6 +21,7 @@ import {
 } from "./auth/auth"
 import type { SynologyDriveSession } from "./client"
 import { isXMLHttpResponseError } from "../../http/httpClient.web"
+import { useDownload } from "../../http/useDownload"
 import { downloadSynologyDriveBlob } from "./download/client"
 
 export const DownloadBook = memo(
@@ -32,6 +33,9 @@ export const DownloadBook = memo(
     signal,
   }: DownloadBookComponentProps<"synology-drive">) => {
     const requestSynologyDriveSession = useRequestSynologyDriveSession()
+    const { mutateAsync: downloadBlob } = useDownload({
+      meta: { suppressGlobalErrorToast: true },
+    })
     const onErrorRef = useLiveRef(onError)
     const connectorId = link.data.connectorId
 
@@ -57,6 +61,7 @@ export const DownloadBook = memo(
         ).pipe(
           mergeMap(async (session: SynologyDriveSession) => {
             return await downloadSynologyDriveBlob({
+              download: downloadBlob,
               fileId,
               onDownloadProgress,
               session,

--- a/apps/web/src/plugins/synology-drive/DownloadBook.tsx
+++ b/apps/web/src/plugins/synology-drive/DownloadBook.tsx
@@ -32,7 +32,9 @@ export const DownloadBook = memo(
     onResolve,
     signal,
   }: DownloadBookComponentProps<"synology-drive">) => {
-    const requestSynologyDriveSession = useRequestSynologyDriveSession()
+    const requestSynologyDriveSession = useRequestSynologyDriveSession({
+      meta: { suppressGlobalErrorToast: true },
+    })
     const { mutateAsync: downloadBlob } = useDownload({
       meta: { suppressGlobalErrorToast: true },
     })
@@ -96,6 +98,7 @@ export const DownloadBook = memo(
         clearSynologyDriveSession()
         onError(error)
       },
+      meta: { suppressGlobalErrorToast: true },
     })
 
     useEffectWithUnmount$(

--- a/apps/web/src/plugins/synology-drive/auth/auth.ts
+++ b/apps/web/src/plugins/synology-drive/auth/auth.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react"
-import { signal } from "reactjrx"
+import { signal, type UseMutation$Options } from "reactjrx"
 import { signInSynologyDrive, type SynologyDriveSession } from "../client"
 import { useExtractConnectorData } from "../../../connectors/useExtractConnectorData"
 
@@ -55,10 +55,13 @@ export const clearSynologyDriveSession = () => {
   synologyDriveSessionSignal.setValue(undefined)
 }
 
-export const useRequestSynologyDriveSession = () => {
-  const { mutateAsync: extractConnectorData } = useExtractConnectorData({
-    type: "synology-drive",
-  })
+export const useRequestSynologyDriveSession = (
+  options?: Pick<UseMutation$Options<unknown>, "meta">,
+) => {
+  const { mutateAsync: extractConnectorData } = useExtractConnectorData(
+    { type: "synology-drive" },
+    options,
+  )
 
   return useCallback(
     async (request: SynologyDriveRequest) => {

--- a/apps/web/src/plugins/synology-drive/download/client.ts
+++ b/apps/web/src/plugins/synology-drive/download/client.ts
@@ -1,7 +1,5 @@
-import {
-  httpClientWeb,
-  isXMLHttpResponseError,
-} from "../../../http/httpClient.web"
+import { isXMLHttpResponseError } from "../../../http/httpClient.web"
+import type { Download } from "../../../http/useDownload"
 import {
   getSynologyDriveBrowseItem,
   getSynologyDriveDownloadUrls,
@@ -29,15 +27,17 @@ const extractDownloadError = async (blob: Blob) => {
 }
 
 const downloadBlobFromUrl = async ({
+  download,
   onDownloadProgress,
   signal,
   url,
 }: {
+  download: Download
   onDownloadProgress: (progress: number) => void
   signal: AbortSignal
   url: string
 }) => {
-  const response = await httpClientWeb.download<Blob>({
+  const response = await download({
     headers: {
       Accept: "application/octet-stream",
     },
@@ -65,11 +65,13 @@ const downloadBlobFromUrl = async ({
 }
 
 export const downloadSynologyDriveBlob = async ({
+  download,
   fileId,
   onDownloadProgress,
   session,
   signal,
 }: {
+  download: Download
   fileId: string
   onDownloadProgress: (progress: number) => void
   session: SynologyDriveSession
@@ -92,6 +94,7 @@ export const downloadSynologyDriveBlob = async ({
   for (const url of urls) {
     try {
       const result = await downloadBlobFromUrl({
+        download,
         onDownloadProgress,
         signal,
         url,

--- a/apps/web/src/plugins/uri/DownloadBook.tsx
+++ b/apps/web/src/plugins/uri/DownloadBook.tsx
@@ -65,6 +65,7 @@ export const DownloadBook = memo(
       },
       onSuccess: onResolve,
       onError,
+      meta: { suppressGlobalErrorToast: true },
     })
 
     useEffectWithUnmount$(

--- a/apps/web/src/plugins/uri/DownloadBook.tsx
+++ b/apps/web/src/plugins/uri/DownloadBook.tsx
@@ -12,7 +12,7 @@ import { useMutation$ } from "reactjrx"
 import { resolveDownloadFileName } from "@oboku/shared"
 import type { DownloadBookComponentProps } from "../types"
 import { CancelError } from "../../errors/errors.shared"
-import { httpClientWeb } from "../../http/httpClient.web"
+import { useDownload } from "../../http/useDownload"
 import { fromAbortSignal } from "../../common/rxjs/fromAbortSignal"
 import { useEffectWithUnmount$ } from "../../common/rxjs/useEffectWithUnmount$"
 import { scheduleDelayedEffect } from "../../common/useDelayEffect"
@@ -25,6 +25,9 @@ export const DownloadBook = memo(
     onResolve,
     signal,
   }: DownloadBookComponentProps<"URI">) => {
+    const { mutateAsync: downloadBlob } = useDownload({
+      meta: { suppressGlobalErrorToast: true },
+    })
     const { mutate: download } = useMutation$({
       mutationFn: ({ onUnmount$ }: { onUnmount$: Observable<void> }) => {
         const abortController = new AbortController()
@@ -36,7 +39,7 @@ export const DownloadBook = memo(
         const downloadLink = link.data.url
 
         return from(
-          httpClientWeb.download<Blob>({
+          downloadBlob({
             responseType: "blob",
             signal: abortController.signal,
             url: downloadLink,

--- a/apps/web/src/plugins/webdav/DownloadBook.tsx
+++ b/apps/web/src/plugins/webdav/DownloadBook.tsx
@@ -40,9 +40,10 @@ export const WebdavDownloadBook = memo(function WebdavDownloadBook({
   filePath,
   webdavUrl,
 }: WebdavDownloadBookProps) {
-  const { mutateAsync: extractConnectorData } = useExtractConnectorData({
-    type: connectorType,
-  })
+  const { mutateAsync: extractConnectorData } = useExtractConnectorData(
+    { type: connectorType },
+    { meta: { suppressGlobalErrorToast: true } },
+  )
   const onErrorRef = useLiveRef(onError)
   const { mutate: download } = useMutation$({
     mutationFn: ({
@@ -86,6 +87,7 @@ export const WebdavDownloadBook = memo(function WebdavDownloadBook({
       ),
     onSuccess: onResolve,
     onError,
+    meta: { suppressGlobalErrorToast: true },
   })
 
   useEffectWithUnmount$(


### PR DESCRIPTION
## Summary

Stacked on `fix/expired-session-relogin`. Consolidates the web download path onto react-query and fixes multi-toast on download failure.

### 1. Migrate download to a `useDownload` hook
- Replace `HttpClientWeb.download` with a `useDownload` mutation hook (`apps/web/src/http/useDownload.ts`) wrapping the existing `sendXhr` GET (XHR is still required for download-progress events + `responseType: blob`, which `fetch` can't provide).
- `useDownload` accepts mutation options and spreads them, so toast-suppression policy is the **consumer's** call (no `meta` baked into the declaration).
- Route the plugin download consumers (google / one-drive / synology / uri) through it; synology's `downloadSynologyDriveBlob` takes the `download` function as a param (threaded like `useFetchCouch`/`fetchCouch`).
- Drop the migrated `download` method from `HttpClientWeb`, export `sendXhr`.
- Also includes the local notifications inbox surface.

### 2. One error toast per failed download
Previously a single failure could fire **up to three** toasts (plugin outer mutation + `settle()`'s manual `notifyError` + `useDownloadBook` rejecting). Now the top-level `useDownloadBook` mutation is the **sole notifier** via the global `MutationCache` handler:
- Removed `settle()`'s manual `notifyError`.
- Suppressed every other mutation in the download subtree via consumer-level `meta.suppressGlobalErrorToast`:
  - the 6 plugin outer mutations (uri, google, dropbox, one-drive ×2, synology, webdav)
  - the shared `useExtractConnectorData` → `useRequestMasterKey` and `useRequestSynologyDriveSession` (webdav/synology), via an optional `meta` passthrough — backward-compatible for the ~10 non-download callers
  - `useGoogleScripts` → `useLoadGapi` (google gapi script-load), same passthrough
- Error transformation preserved (synology friendly message, google 404→`ObokuSharedError`) since the transformed error still flows `settle → reject → useDownloadBook`.
- Cancel still shows no toast (CancelError guarded in the global handler).

## Verification
- `npx tsc -p apps/web/tsconfig.json --noEmit` clean.
- Web plugin/download/connector unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)