### PR TITLE
feat: show created date and password status in admin users list

### DIFF
--- a/apps/admin/src/features/users/AdminUsersSection.tsx
+++ b/apps/admin/src/features/users/AdminUsersSection.tsx
@@ -50,6 +50,25 @@ export const AdminUsersSection = () => {
           </Badge>
         ),
       },
+      {
+        field: "hasPassword",
+        headerName: "Password",
+        maxWidth: 160,
+        cellRenderer: (params: { value: boolean }) => (
+          <Badge color={params.value ? "blue" : "gray"} variant="light">
+            {params.value ? "set" : "none"}
+          </Badge>
+        ),
+      },
+      {
+        field: "createdAt",
+        headerName: "Created at",
+        flex: 1,
+        minWidth: 180,
+        filter: false,
+        valueFormatter: (params: { value: string | null | undefined }) =>
+          params.value ? new Date(params.value).toLocaleString() : "",
+      },
     ],
     [],
   )

--- a/apps/api/src/admin/admin.controller.ts
+++ b/apps/api/src/admin/admin.controller.ts
@@ -326,6 +326,8 @@ export class AdminController {
       email: user.email,
       username: user.username,
       emailVerified: Boolean(user.emailVerified),
+      hasPassword: Boolean(user.password),
+      createdAt: user.createdAt.toISOString(),
     }))
   }
 

--- a/apps/api/src/features/postgres/entities.ts
+++ b/apps/api/src/features/postgres/entities.ts
@@ -3,7 +3,13 @@ import type {
   NotificationSeverity,
   SyncFinishedNotificationData,
 } from "@oboku/shared"
-import { Column, Entity, Index, PrimaryGeneratedColumn } from "typeorm"
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from "typeorm"
 
 @Entity({ name: "sync_reports" })
 export class SyncReportPostgresEntity {
@@ -121,6 +127,9 @@ export class UserPostgresEntity {
    */
   @Column({ type: "boolean", default: false })
   emailVerified?: boolean
+
+  @CreateDateColumn({ type: "timestamp with time zone" })
+  createdAt!: Date
 }
 
 @Entity({ name: "refresh_tokens" })

--- a/apps/api/src/features/postgres/user-postgres.service.spec.ts
+++ b/apps/api/src/features/postgres/user-postgres.service.spec.ts
@@ -98,6 +98,7 @@ describe("UserPostgresService", () => {
       username: "Reader",
       password: "hashed-password",
       emailVerified: true,
+      createdAt: new Date(),
     }
     repository.save.mockResolvedValue(user)
 

--- a/apps/api/src/features/postgres/user-postgres.service.ts
+++ b/apps/api/src/features/postgres/user-postgres.service.ts
@@ -57,7 +57,7 @@ export class UserPostgresService {
     })
   }
 
-  async create(user: Omit<UserPostgresEntity, "id">) {
+  async create(user: Omit<UserPostgresEntity, "id" | "createdAt">) {
     const newUser = this.userRepository.create({
       ...user,
       email: normalizeEmail(user.email),
@@ -85,10 +85,20 @@ export class UserPostgresService {
   }
 
   async getAllUsers(): Promise<
-    Pick<UserPostgresEntity, "id" | "email" | "username" | "emailVerified">[]
+    Pick<
+      UserPostgresEntity,
+      "id" | "email" | "username" | "emailVerified" | "createdAt" | "password"
+    >[]
   > {
     return this.userRepository.find({
-      select: ["id", "email", "username", "emailVerified"],
+      select: [
+        "id",
+        "email",
+        "username",
+        "emailVerified",
+        "createdAt",
+        "password",
+      ],
       order: { id: "ASC" },
     })
   }

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -78,6 +78,7 @@ describe("UsersService", () => {
       username: "Reader",
       password: "hashed-password",
       emailVerified: true,
+      createdAt: new Date(),
     }
     userPostgresService.save.mockResolvedValue(user)
 

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -34,7 +34,7 @@ export class UsersService {
     return this.userPostgresService.findById(userId)
   }
 
-  async registerUser(user: Omit<UserPostgresEntity, "id">) {
+  async registerUser(user: Omit<UserPostgresEntity, "id" | "createdAt">) {
     return this.userPostgresService.create(user)
   }
 

--- a/packages/shared/src/api-types/admin.ts
+++ b/packages/shared/src/api-types/admin.ts
@@ -39,6 +39,8 @@ export type AdminUserSummary = {
   email: string
   username: string
   emailVerified: boolean
+  hasPassword: boolean
+  createdAt: string
 }
 
 export type GetAdminUsersResponse = AdminUserSummary[]


### PR DESCRIPTION
## Summary

Adds two columns to the admin users table:

- **Created at** — when the user account was created. Backed by a new `@CreateDateColumn` (`createdAt`) on `UserPostgresEntity`. Auto-created on next boot via TypeORM `synchronize: true`.
- **Password** — whether the user has a local password set ("set") vs being provider-only, e.g. Google ("none"). Derived from `Boolean(user.password)`; the raw hash never leaves the server.

## Notes

- Because `createdAt` is added now, existing rows are backfilled with the column-creation timestamp, not their true signup date (not recoverable). New users get an accurate timestamp.
- `create()` / `registerUser()` input types now exclude `createdAt` since it's auto-populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)