### PR TITLE
perf(web): precompute sort keys and hoist search regex in book/collection lists

### DIFF
--- a/apps/web/src/books/helpers.ts
+++ b/apps/web/src/books/helpers.ts
@@ -187,12 +187,13 @@ export const sortBooksBy = (
       })
     }
     case "alpha": {
-      return [...books].sort((a, b) =>
-        sortByTitleComparator(
-          getMetadataFromBook(a).title?.toString() ?? "",
-          getMetadataFromBook(b).title?.toString() ?? "",
-        ),
-      )
+      return books
+        .map((book) => ({
+          book,
+          title: getMetadataFromBook(book).title?.toString() ?? "",
+        }))
+        .sort((a, b) => sortByTitleComparator(a.title, b.title))
+        .map(({ book }) => book)
     }
     default:
       return books

--- a/apps/web/src/search/useBooksForSearch.ts
+++ b/apps/web/src/search/useBooksForSearch.ts
@@ -15,39 +15,35 @@ export const useBooksForSearch = (search: string) => {
     isNotInterested: notInterestedContents,
   })
 
-  const filteredBooks = useMemo(
-    () =>
-      visibleBooks
-        ?.filter((book) => {
-          const searchRegex = new RegExp(
-            search.replace(REGEXP_SPECIAL_CHAR, `\\$&`) || "",
-            "i",
-          )
+  const filteredBooks = useMemo(() => {
+    const searchRegex = new RegExp(
+      search.replace(REGEXP_SPECIAL_CHAR, `\\$&`) || "",
+      "i",
+    )
 
-          const metadata = book.metadata?.length
-            ? book.metadata
-            : [getMetadataFromBook(book)]
+    return visibleBooks
+      ?.filter((book) => {
+        const metadata = book.metadata?.length
+          ? book.metadata
+          : [getMetadataFromBook(book)]
 
-          return metadata?.some((item) => {
-            const { title } = item
+        return metadata?.some((item) => {
+          const { title } = item
 
-            if (!title) return false
+          if (!title) return false
 
-            const indexOfFirstMatch =
-              title?.toString()?.search(searchRegex) || 0
+          const indexOfFirstMatch = title?.toString()?.search(searchRegex) || 0
 
-            return indexOfFirstMatch >= 0
-          })
+          return indexOfFirstMatch >= 0
         })
-        .sort((a, b) =>
-          sortByTitleComparator(
-            getMetadataFromBook(a).title?.toString() ?? "",
-            getMetadataFromBook(b).title?.toString() ?? "",
-          ),
-        )
-        .map((item) => item._id),
-    [search, visibleBooks],
-  )
+      })
+      .map((book) => ({
+        book,
+        title: getMetadataFromBook(book).title?.toString() ?? "",
+      }))
+      .sort((a, b) => sortByTitleComparator(a.title, b.title))
+      .map(({ book }) => book._id)
+  }, [search, visibleBooks])
 
   return { data: filteredBooks }
 }

--- a/apps/web/src/search/useCollectionsForSearch.ts
+++ b/apps/web/src/search/useCollectionsForSearch.ts
@@ -15,34 +15,24 @@ export const useCollectionsForSearch = (search: string) => {
     isNotInterested: notInterestedContents,
   })
 
-  const filteredList = useMemo(
-    () =>
-      data
-        ?.filter((item) => {
-          const name = getCollectionComputedMetadata(item).title ?? ""
+  const filteredList = useMemo(() => {
+    const searchRegex = new RegExp(
+      search.replace(REGEXP_SPECIAL_CHAR, `\\$&`),
+      "i",
+    )
 
-          const searchRegexWithoutSpecialCharacters = search.replace(
-            REGEXP_SPECIAL_CHAR,
-            `\\$&`,
-          )
-
-          const searchRegex = new RegExp(
-            searchRegexWithoutSpecialCharacters,
-            "i",
-          )
-
-          const indexOfFirstMatch = name?.search(searchRegex) || 0
-          return indexOfFirstMatch >= 0
-        })
-        .sort((a, b) =>
-          sortByTitleComparator(
-            getCollectionComputedMetadata(a).title || "",
-            getCollectionComputedMetadata(b).title || "",
-          ),
-        )
-        .map((item) => item._id),
-    [data, search],
-  )
+    return data
+      ?.map((item) => ({
+        item,
+        title: getCollectionComputedMetadata(item).title ?? "",
+      }))
+      .filter(({ title }) => {
+        const indexOfFirstMatch = title?.search(searchRegex) || 0
+        return indexOfFirstMatch >= 0
+      })
+      .sort((a, b) => sortByTitleComparator(a.title || "", b.title || ""))
+      .map(({ item }) => item._id)
+  }, [data, search])
 
   return { data: filteredList }
 }


### PR DESCRIPTION
## Target

Book & collection **list search/sort** (`apps/web/src/search/*`, `apps/web/src/books/helpers.ts`). This is the app's largest collection (a user's whole library) run through its hottest path: the search hooks re-filter and re-sort the entire book/collection set on **every keystroke**, and the library screen re-sorts the whole library on every sort/filter change. User-visible symptom: input lag / dropped frames while typing in search and when reordering large libraries.

## Mechanism

Two forms of redundant work multiplied by library size (`n`):

1. **Derived metadata recomputed inside the sort comparator.** `sortBooksBy` ("alpha"), `useBooksForSearch`, and `useCollectionsForSearch` all called `getMetadataFromBook` / `getCollectionComputedMetadata` (expensive: directive-regex extraction, source-priority ordering, `toSorted`, a reducing object-spread merge, `Date` construction) *inside* their comparators — so each was invoked **~2·n·log n** times per sort instead of once per item.
2. **Search `RegExp` recompiled per item.** Both search hooks built `new RegExp(...)` (and `useCollectionsForSearch` also ran `search.replace(...)`) *inside the `.filter` callback* — **n** compilations per keystroke where **1** suffices.

Fix: decorate-sort-undecorate — compute each item's title key once (**n** calls instead of ~2·n·log n), sort on the cached key, then map back to ids; and hoist the regex compilation out of the filter (one compile per search). Comparator inputs and match results are byte-identical, so ordering and filtering behavior are unchanged.

## Measured impact

Micro-benchmark against the **real** `getMetadataFromBook`, alpha sort, 1000 books, 20 runs (removed before commit):

```
old: 1179.4ms, 187920 getMetadataFromBook calls
new:  151.4ms,  20000 getMetadataFromBook calls
speedup: 7.79x, call reduction: 9.4x
identical ordering: true
```

At n=1000 the metadata-derivation call count drops **9.4×** (matching the ~2·log₂n factor) and wall-clock sort is **~7.8× faster**. The regex hoist independently turns O(n) compilations per keystroke into O(1). Impact scales with library size.

## Gates

- `npm run lint` (biome) — exit 0, no new findings on touched files.
- `npm run build` (`tsc -b && vite build` for `@oboku/web`) — passes.
- `npm run test` (web) — the only failing files (`HttpClientApi.web.test.ts`, `httpClientApi.sw.test.ts`) fail **identically on a clean `develop` checkout** (pre-existing auth-refresh/DPoP timing failures, unrelated subsystem). This change adds **zero** new failures.

## Backlog (found, not taken)

- `getMetadataFromBook` / `getCollectionComputedMetadata` are recomputed independently by many list-item components on render; a shared memoized derivation (keyed on the book/collection doc identity) would cut repeated work across the whole rendered list, not just sort.
- `useLibraryBooks` recomputes `useBooksDownloadState` (a full reduce over every book) whenever the download signal changes, even when no visible row's state changed.
- The `"activity"` sort branch in `sortBooksBy` calls `new Date(...).getTime()` inside the comparator — same decorate-once opportunity as "alpha" (smaller per-unit cost, left out to keep this PR to one mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnAgfVDZuoRGa4ozBMVTgM)_