### PR TITLE
fix(deps): bump rxdb to 17.4.0 to patch high-severity ws DoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -416,6 +416,22 @@
         }
       }
     },
+    "apps/web/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "apps/web/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -438,6 +454,145 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "apps/web/node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "apps/web/node_modules/js-base64": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.0.tgz",
+      "integrity": "sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==",
+      "license": "BSD-3-Clause"
+    },
+    "apps/web/node_modules/mingo": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-7.2.2.tgz",
+      "integrity": "sha512-ll8DV+C5RnV2zF3Jwendxhgqknofzp7KaDwmlpvqo4xrdMC5F7JTc2ToZOz//de84QymZTFY7LPHMViE8uNHhA==",
+      "license": "MIT"
+    },
+    "apps/web/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "apps/web/node_modules/rxdb": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/rxdb/-/rxdb-17.4.0.tgz",
+      "integrity": "sha512-P/I9XpeJ/XS5SpDNoO94Y2cZprDOUhdE29Z7WtpFV2sMY3dYiFPvKj1TVQ/t7MAi6Mh8vjWpUe5srsMA5nEBwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "7.29.7",
+        "@types/simple-peer": "9.11.9",
+        "@types/ws": "8.18.1",
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1",
+        "array-push-at-sort-position": "5.0.0",
+        "as-typed": "1.3.2",
+        "broadcast-channel": "7.3.0",
+        "crypto-js": "4.2.0",
+        "custom-idle-queue": "5.0.2",
+        "dexie": "4.4.2",
+        "event-reduce-js": "6.0.0",
+        "get-graphql-from-jsonschema": "8.1.0",
+        "graphql": "16.14.2",
+        "graphql-ws": "5.16.2",
+        "is-my-json-valid": "2.20.6",
+        "js-base64": "3.8.0",
+        "jsonschema-key-compression": "1.7.0",
+        "mingo": "7.2.2",
+        "oblivious-set": "2.0.0",
+        "reconnecting-websocket": "4.4.0",
+        "simple-peer": "9.11.1",
+        "ws": "8.21.0",
+        "z-schema": "12.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@angular/core": "*",
+        "@preact/signals-core": "*",
+        "firebase": "^12.10.0",
+        "mongodb": "^6.21.0 || ^7.0.0",
+        "nats": "^2.29.3",
+        "react": "*",
+        "rxjs": "^7.8.2",
+        "vue": "*"
+      },
+      "peerDependenciesMeta": {
+        "@angular/core": {
+          "optional": true
+        },
+        "@preact/signals-core": {
+          "optional": true
+        },
+        "firebase": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "nats": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/z-schema": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-12.3.1.tgz",
+      "integrity": "sha512-vSLA62BENIHrltcviPzxLyoPg+XxjKwS75w6PyN4gNVWFnobTIEYexLhL2086ulT7bELMH9zD07lSxcAgB6Gjw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1",
+        "safe-regex2": "^5.1.0",
+        "validator": "^13.15.26"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^14.0.3"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -3814,7 +3969,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3831,7 +3985,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3848,7 +4001,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3865,7 +4017,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3882,7 +4033,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3899,7 +4049,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3916,7 +4065,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3933,7 +4081,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3950,7 +4097,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3967,7 +4113,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3984,7 +4129,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4001,7 +4145,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4018,7 +4161,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4035,7 +4177,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4052,7 +4193,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4069,7 +4209,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4086,7 +4225,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4103,7 +4241,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4120,7 +4257,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4137,7 +4273,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4154,7 +4289,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4171,7 +4305,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4188,7 +4321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4205,7 +4337,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4222,7 +4353,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4239,7 +4369,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10957,7 +11086,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10974,7 +11102,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12698,7 +12825,7 @@
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
       "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12742,13 +12869,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12760,13 +12885,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12778,13 +12901,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12796,13 +12917,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12814,13 +12933,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12832,13 +12949,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12850,13 +12965,11 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12868,13 +12981,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12886,13 +12997,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12904,13 +13013,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12922,13 +13029,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12940,13 +13045,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12955,7 +13058,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
@@ -12971,7 +13074,7 @@
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
       "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -21777,7 +21880,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
       "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -23712,7 +23815,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -24158,7 +24260,7 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -24460,6 +24562,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
       "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -27355,12 +27458,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/js-cookie": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
@@ -27971,7 +28068,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -27992,7 +28088,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28013,7 +28108,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28034,7 +28128,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28055,7 +28148,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28076,7 +28168,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28097,7 +28188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28118,7 +28208,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28139,7 +28228,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28160,7 +28248,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28181,7 +28268,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -30191,12 +30277,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/mingo": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/mingo/-/mingo-7.2.1.tgz",
-      "integrity": "sha512-MEIQPOSJS2sVCueyQeE2rzgEeW3HpIIhizPbeuwD4v7+miVj7NI3ZVPqqw8t3YPIWCivpIaXA4KsoRI7koyNOA==",
-      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "10.2.3",
@@ -34232,7 +34312,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -34609,99 +34689,6 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/rxdb": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/rxdb/-/rxdb-17.3.0.tgz",
-      "integrity": "sha512-8Pt7RWnibHVr4Ze213zqnCCGC+T2mNW1hRVQqr8widLAmyPmVVO/+nNgzWhd7tDFCqp899v55Le1w+4AF2I4+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "7.29.2",
-        "@types/simple-peer": "9.11.9",
-        "@types/ws": "8.18.1",
-        "ajv": "8.20.0",
-        "ajv-formats": "3.0.1",
-        "array-push-at-sort-position": "5.0.0",
-        "as-typed": "1.3.2",
-        "broadcast-channel": "7.3.0",
-        "crypto-js": "4.2.0",
-        "custom-idle-queue": "5.0.2",
-        "dexie": "4.4.2",
-        "event-reduce-js": "6.0.0",
-        "get-graphql-from-jsonschema": "8.1.0",
-        "graphql": "16.14.0",
-        "graphql-ws": "5.16.2",
-        "is-my-json-valid": "2.20.6",
-        "js-base64": "3.7.8",
-        "jsonschema-key-compression": "1.7.0",
-        "mingo": "7.2.1",
-        "oblivious-set": "2.0.0",
-        "reconnecting-websocket": "4.4.0",
-        "simple-peer": "9.11.1",
-        "ws": "8.20.1",
-        "z-schema": "12.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@angular/core": "*",
-        "@preact/signals-core": "*",
-        "firebase": "^12.10.0",
-        "mongodb": "^6.21.0 || ^7.0.0",
-        "nats": "^2.29.3",
-        "react": "*",
-        "rxjs": "^7.8.2",
-        "vue": "*"
-      },
-      "peerDependenciesMeta": {
-        "@angular/core": {
-          "optional": true
-        },
-        "@preact/signals-core": {
-          "optional": true
-        },
-        "firebase": {
-          "optional": true
-        },
-        "mongodb": {
-          "optional": true
-        },
-        "nats": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rxdb/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/rxdb/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/rxjs": {
@@ -36320,7 +36307,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-5.0.1.tgz",
       "integrity": "sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -37373,7 +37360,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -38770,7 +38757,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38782,7 +38768,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38793,7 +38778,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38804,7 +38788,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
       "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38836,7 +38819,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38853,7 +38835,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38870,7 +38851,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38887,7 +38867,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38904,7 +38883,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38921,7 +38899,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38938,7 +38915,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38955,7 +38931,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38972,7 +38947,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38989,7 +38963,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -39006,7 +38979,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -39025,7 +38997,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -39042,7 +39013,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -39056,7 +39026,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -40201,6 +40170,7 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -40351,7 +40321,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -40475,35 +40445,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/z-schema": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-12.2.0.tgz",
-      "integrity": "sha512-nl7fMiD2pwsrrkqKMByIdTDaM2hBGeA/phn+Aj3z+sSax4pRVB/m1VaiYTgZlFbGTj70yGIr86D+aLJMXo0Jtw==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1",
-        "safe-regex2": "^5.1.0",
-        "validator": "^13.15.26"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^14.0.3"
-      }
-    },
-    "node_modules/z-schema/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/zod": {


### PR DESCRIPTION
## The update

| | |
|---|---|
| **Package** | `rxdb` (dependency of `@oboku/web`) |
| **Change** | `17.3.0` → `17.4.0` |
| **Type** | Minor (within existing `^17.1.0` range — lockfile-only change) |
| **Motivation** | Security (high) |
| **Advisory** | [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) — `ws`: Memory-exhaustion DoS from tiny fragments/data chunks |

rxdb 17.3.0 pinned `ws@8.20.1` (in the vulnerable `8.0.0 – 8.20.1` range). rxdb 17.4.0 pins `ws@8.21.0`, which is patched, so bumping rxdb resolves the advisory on the rxdb dependency path. The manifest range in `apps/web/package.json` is deliberately left at `^17.1.0`; only `package-lock.json` changes.

**Changelog highlights (17.4.0):** `awaitDocumentPushed()` replication helper, replication-conflict observable, `$in`-query index-range planning, and a DocumentCache out-of-order-event fix. No breaking changes.

**Gates:** baseline recorded on a clean `develop` checkout (Node 25, matching CI) — `lint`, `build`, `test` all green. With the update applied, all three remain green (no new failures).

---

## Still-open security advisories (not addressed here — one dependency per PR)

`npm audit` went from **52 → 51** vulnerabilities. Remaining highlights, by severity:

**High**
- **`next` 16.1.6 → 16.2.10** (`apps/landing`) — minor bump fixing a large batch of advisories (HTTP request smuggling, Server Actions/HMR CSRF bypass, App-Router XSS, SSRF via WS upgrades, middleware/proxy bypass, cache poisoning, multiple DoS). **`next` is exact-pinned**, so bumping it requires a human decision to move the pin (paired with `eslint-config-next`).
- **`nodemailer` 8.0.11 → 9.0.3** (`apps/api`) — raw-message option bypasses `disableFileAccess`/`disableUrlAccess` → arbitrary file read + SSRF. Requires a **major** bump (outside `^8`); needs changelog review + code changes.
- **`@nestjs/platform-express` 11.1.27 → 11.1.28** (`apps/api`) — pulls `multer@2.2.0`, fixing two DoS advisories (deeply-nested field names; incomplete cleanup of aborted uploads). In-range, but should move with the rest of the `@nestjs/*` 11.1.28 family.
- **`ws` via `jsdom`** (`apps/admin`, test-only) — same advisory as above, but on the `jsdom@27` path (`ws@8.20.1`). Only fixable by updating `jsdom` (major, 27 → 29) or adding a `ws` override.
- **`vercel` CLI tree** (root devDep) — cluster of transitive highs (`undici`, `path-to-regexp`, `tar`, `minimatch`). `npm audit`'s only offered fix is a **major downgrade** to `vercel@50.41.0`, which is undesirable; better to wait for an upstream forward-fix.

**Moderate**
- `@swc/cli` 0.7.10 → 0.8.1 (major) — `file-type`/`bin-wrapper` ReDoS/decompression-bomb chain (`apps/api`).
- `aws-sdk` v2 (via `aws-lambda`, `apps/api`) — region-validation + `uuid` bounds; v2 is EOL, path forward is v3 / `aws-lambda@1.0.6` (major).
- `lerna` (root) — `js-yaml` + `tar` DoS; only offered fix is a major downgrade to `lerna@6.6.2` (undesirable).

---

## Pending queue — in-range, non-security (candidates for future runs)

Patch/minor updates available within existing ranges (grouped):

- **@prose-reader/** family 1.314.0 → 1.318.0 (archive-parser, cbz, core, shared, streamer, all enhancers, react-reader)
- **@mui/** 9.1.x → 9.2.0 (material, icons-material, utils, lab beta.5 → beta.6); **@mui/x-tree-view** 9.6.0 → 9.10.0
- **@nestjs/** 11.1.27 → 11.1.28 (common, core, platform-express, testing), @nestjs/typeorm 11.0.2 → 11.0.3, @nestjs/cli 11.0.23 → 11.0.24
- **@sentry/** 10.60.0 → 10.66.0 (nestjs, profiling-node, react)
- **@tanstack/** react-query(+persist) 5.101.1 → 5.101.2, react-router 1.170.16 → 1.170.18, react-virtual 3.14.3 → 3.14.6, router-plugin 1.168.18 → 1.168.20
- **@mantine/** 9.4.0 → 9.4.1 (core, dates, form, hooks, notifications)
- **reactjrx** 1.140.0 → 1.141.2, **firebase** 12.15.0 → 12.16.0, **dexie** 4.4.2 → 4.4.4, **@zip.js/zip.js** 2.8.26 → 2.8.31
- **dropbox** 10.34.0 → 10.37.1, **google-auth-library** 10.5.0 → 10.9.0, **nano** 11.0.5 → 11.0.6
- **vite** 8.1.0 → 8.1.5, **vitest** 4.1.9 → 4.1.10, **@biomejs/biome** 2.5.1 → 2.5.4, **@microsoft/api-extractor** 7.58.9 → 7.58.11, **unplugin-dts** 1.0.2 → 1.0.3, **prettier** 3.8.4 → 3.9.5
- **@azure/msal-browser** 5.14.0 → 5.17.1, **ag-grid-community/react** 36.0.0 → 36.0.1, **react-hook-form** 7.80.0 → 7.81.0, **react-icons** 5.6.0 → 5.7.0, **react-virtuoso** 4.18.7 → 4.18.11, **fuse.js** 7.4.2 → 7.5.0, **postcss** 8.5.15 → 8.5.19, **@types/react** 19.2.14 → 19.2.17, **@types/supertest** 7.2.0 → 7.2.1, **@aws-sdk/** client-s3/ssm 3.1075.0 → 3.1089.0
- Held back by exact pins: **react/react-dom** 19.2.4 → 19.2.7 (pinned), **next** 16.1.6 → 16.2.10 (pinned; see security section)

---

## Deferred majors (not applied — non-security major bumps need a human)

- **typescript** 5.9.3 → 7.0.2 — new TS major; likely type-checking breakage across the monorepo.
- **@types/node** 25.9.5 → 26.1.1 — Node 26 typings while project pins Node 25.
- **react-router** 7.18.1 → 8.2.0 — routing API breaking changes (`apps/web`).
- **typeorm** 0.3.31 → 1.1.0 — ORM 1.0; breaking schema/API changes (`apps/api`).
- **jose** 5.10.0 → 6.2.3 — ESM-only / API changes in the JWT lib (api + web). *(Also has a moderate advisory range, but 5.10.0 is the top of `^5`.)*
- **jsdom** 27 → 29 — test-env major (`apps/admin`); would also clear the `ws` advisory above.
- **pdfjs-dist** 5.7 → 6.1 — PDF.js API changes (web reader).
- **react-dropzone** 15 → 17 — API changes (`apps/web`).
- **eslint** 9 → 10 — flat-config/rule changes (`apps/landing`).
- **lint-staged** 16 → 17 — config/behavior changes (root).
- **rollup-plugin-node-externals** 8 → 9 — build-plugin API (root).
- **googleapis** 171 → 173 — generated-client changes (`apps/api`).
- **sharp** 0.34 → 0.35 — libvips bump (`apps/api`).
- **vercel** 54 → 56 — deploy CLI major (root).
- **nodemailer** 8 → 9, **@swc/cli** 0.7 → 0.8, **aws-lambda**/**aws-sdk** v3 — see security section (major + security).

---

## Needs manual attention

None — the applied update broke no gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019xL4cgYzrM9gP4FGZRNkuV)_