### PR TITLE
fix(api): extract day of month and 1-based month from published dates

### DIFF
--- a/apps/api/src/lib/metadata/extractDateComponents.spec.ts
+++ b/apps/api/src/lib/metadata/extractDateComponents.spec.ts
@@ -1,0 +1,43 @@
+import { extractDateComponents } from "./extractDateComponents"
+
+describe("extractDateComponents", () => {
+  it("extracts day of month and 1-based month from a full ISO date", () => {
+    expect(extractDateComponents("2020-05-15")).toEqual({
+      year: 2020,
+      month: 5,
+      day: 15,
+    })
+  })
+
+  it("extracts components regardless of the weekday", () => {
+    expect(extractDateComponents("2023-11-07")).toEqual({
+      year: 2023,
+      month: 11,
+      day: 7,
+    })
+  })
+
+  it("extracts only the year from a year-only string", () => {
+    expect(extractDateComponents("1999")).toEqual({
+      year: 1999,
+      month: undefined,
+      day: undefined,
+    })
+  })
+
+  it("returns no components for undefined input", () => {
+    expect(extractDateComponents(undefined)).toEqual({
+      year: undefined,
+      month: undefined,
+      day: undefined,
+    })
+  })
+
+  it("returns no components for an unparseable string", () => {
+    expect(extractDateComponents("not a date")).toEqual({
+      year: undefined,
+      month: undefined,
+      day: undefined,
+    })
+  })
+})

--- a/apps/api/src/lib/metadata/extractDateComponents.ts
+++ b/apps/api/src/lib/metadata/extractDateComponents.ts
@@ -11,9 +11,9 @@ export function extractDateComponents(dateStr: string | undefined = "") {
   } else if (!Number.isNaN(Date.parse(dateStr))) {
     const date = new Date(dateStr)
 
-    day = date.getDay()
-    month = date.getMonth()
-    year = date.getFullYear()
+    day = date.getUTCDate()
+    month = date.getUTCMonth() + 1
+    year = date.getUTCFullYear()
   }
 
   return { year, month, day }


### PR DESCRIPTION
## The bug

`extractDateComponents` (`apps/api/src/lib/metadata/extractDateComponents.ts`) is used by `parseGoogleMetadata` to turn a Google Books `publishedDate` into `{ year, month, day }`. It used:

- `date.getDay()` — the day of the **week** (0–6) — where the day of the **month** was intended, and
- `date.getMonth()` — **0-based** — while the only consumer of this shape (`displayableDate` in `apps/web/src/books/metadata/index.ts`, which renders `new Date(`${year} ${month} ${day}`)`) interprets `month` as **1-based**.

## How to observe it

Any book whose Google metadata has a full published date shows a wrong date in the web app. Concrete trace through the real code:

- `extractDateComponents("2020-05-15")` → `{ year: 2020, month: 4, day: 5 }` (May 15 is a Friday → `getDay()` = 5; `getMonth()` = 4)
- the web app then renders `new Date("2020 4 5").toDateString()` → **"Sun Apr 05 2020"** instead of May 15, 2020.

## The fix

Use `getUTCDate()`, `getUTCMonth() + 1`, `getUTCFullYear()`. UTC getters because Google Books dates are date-only ISO strings, which `Date.parse` treats as UTC midnight — local getters would shift the day in timezones west of UTC.

## Verification

- New regression test `apps/api/src/lib/metadata/extractDateComponents.spec.ts`: fails on the previous code (`"2023-11-07"` → `{ month: 10, day: 2 }`), passes after the fix (`{ month: 11, day: 7 }`).
- Full API jest suite: 20/20 suites, 127/127 tests pass.
- `biome check` and `nest build` pass. Pre-existing web test failures on `develop` (15 tests in the two HTTP-client test files) are untouched by this diff.

## Other findings (not addressed in this PR)

- **Adjacent directives are mis-parsed** (`packages/shared/src/directives.ts:43-45`): `extractDirectivesFromName("My Book [oboku~isbn~123][oboku~series]")` returns `isbn: "123[oboku~series]"` and never sets `series`, because the `(\[oboku~[^\]]*\])+` match collapses adjacent directives into one token and the `replace` calls are not global. `removeDirectiveFromString` in the same file handles the adjacent form correctly, so the two functions disagree on the input shape. Verified by executing the real code.
- **In-flight download progress resets to 0 whenever the download list changes** (`apps/web/src/download/flow/PluginDownloadFlowHost.tsx:27` + `DownloadFlowRequestItem.tsx:142-196`): the host passes a new inline `onSettled` closure on every render, `settle`/`onError` recompute from it, and the `prepareRemoteDownload` effect — whose deps include them — re-runs, unconditionally setting `downloadProgress: 0` for the in-flight book and re-resolving its link. Queueing or finishing any other download visibly snaps every active download's progress bar back to 0%. Verified by tracing the dependency chain in the real code.
- **API jest never runs `*.test.ts` files**: `apps/api` jest `testRegex` is `.*\.spec\.ts$`, so `apps/api/src/lib/metadata/refineTitle.test.ts` is silently skipped by `npm run test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6GuRdinfw3bbV1JyB2GS6