### PR TITLE
perf: compute book title sort key once when sorting the library alphabetically

### DIFF
--- a/apps/web/src/books/helpers.ts
+++ b/apps/web/src/books/helpers.ts
@@ -187,12 +187,14 @@ export const sortBooksBy = (
       })
     }
     case "alpha": {
-      return [...books].sort((a, b) =>
-        sortByTitleComparator(
-          getMetadataFromBook(a).title?.toString() ?? "",
-          getMetadataFromBook(b).title?.toString() ?? "",
-        ),
-      )
+      const booksWithSortTitle = books.map((book) => ({
+        book,
+        title: getMetadataFromBook(book).title?.toString() ?? "",
+      }))
+
+      booksWithSortTitle.sort((a, b) => sortByTitleComparator(a.title, b.title))
+
+      return booksWithSortTitle.map((entry) => entry.book)
     }
     default:
       return books


### PR DESCRIPTION
## Target

**Subsystem:** web library book sorting (`apps/web/src/books/helpers.ts` → `sortBooksBy`).

**User-visible symptom:** selecting the **alpha** (A–Z) sort on the library screen — or opening a large collection — runs an expensive, main-thread sort that scales super-linearly with library size. On large libraries this shows up as a jank/hitch when switching to alphabetical sorting and whenever the filtered list changes (the memo re-runs on any change to the filtered books).

`sortBooksBy` is invoked from `useBooksSortedBy` (the main library list via `useLibraryBooks`) and from `CollectionDetailsScreen`, always over the full book collection — the app's largest data set.

## Change

**Mechanism (one sentence):** the `alpha` branch called `getMetadataFromBook()` *inside* the sort comparator, so the expensive per-book metadata reduction ran twice on every comparison (~2·n·log n times); this precomputes each book's title key once (n calls) and sorts the precomputed strings — a Schwartzian transform.

`getMetadataFromBook` is not cheap per call: it does a regex directive extraction (`extractDirectivesFromName`), builds and `toSorted`s a priority list (with `indexOf` inside *its* comparator), runs a `reduce` with per-entry object merges and array spreads, constructs a `Date`, and runs a second regex (`removeDirectiveFromString`). Paying that twice per comparison is pure waste — the value depends only on the book, not on the pair being compared.

**Scale multiplier:** `getMetadataFromBook` invocations go from ~2·n·log n to exactly **n** per sort. The comparator itself still runs n·log n times, but now only over cheap precomputed strings via the shared `Intl.Collator`.

**Behavior:** identical. The sort key is byte-for-byte the same string that was previously computed inline; the input array is still not mutated (new arrays throughout). Verified equal ordering in the benchmark below across n = 200 / 1000 / 3000.

## Measured impact

Benchmark using the real `getMetadataFromBook` logic against the built `@oboku/shared` collator, 3 representative metadata sources per book, 20 iterations averaged (Node v22):

| library size | before | after | speedup | `getMetadataFromBook` calls (before → after) |
|---|---|---|---|---|
| 200 | 11.2 ms | 1.2 ms | 9.2× | 2,528 → 200 |
| 1,000 | 82.2 ms | 7.4 ms | 11.1× | 17,232 → 1,000 |
| 3,000 | 297.6 ms | 25.6 ms | 11.6× | 60,644 → 3,000 |

`identical=true` (same ordering) at every size.

## Gates

`npm ci` → biome `check` on the changed file, `npm run build:web`, and the shared `sorting.test.ts` all pass. The web `test` run has **12 pre-existing failures** in `src/http/HttpClientApi.web.test.ts` + 3 in `httpClientApi.sw.test.ts` (auth-cookie-lock / Web Locks in the sandbox env); I confirmed these fail identically on a clean `origin/develop` checkout without this change. No new failures introduced, and this change touches no code near them.

## Backlog (other perf opportunities found, not taken here)

- **`useLibraryBooks` filter is unmemoized** (`apps/web/src/library/books/useLibraryBooks.ts`): `unsortedBooks.filter(...)` runs over the whole library on every render before the memoized sort; could be wrapped in `useMemo` keyed on the filter inputs.
- **`getMetadataFromBook` has no memoization at the source** (`apps/web/src/books/metadata/index.ts`): `useMetadataFromBook` memoizes per component, but list renderers and sorts recompute it repeatedly for the same book. A per-book cache keyed on `(metadata, metadataSourcePriority)` identity would help the alpha sort further and every list row.
- **Search sorting** (`apps/web/src/search/useBooksForSearch.ts`, `useCollectionsForSearch.ts`): same `getMetadataFromBook`/title-in-comparator pattern; candidates for the same treatment if they sort large result sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJozu15aeVytV6W3qBoQMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJozu15aeVytV6W3qBoQMf)_