### PR TITLE
chore(deps): bump @nestjs/platform-express to 11.1.28 (fixes multer DoS)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,7 +26,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/jwt": "^11.0.0",
-    "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/platform-express": "^11.1.28",
     "@nestjs/schedule": "^6.0.0",
     "@nestjs/typeorm": "^11.0.0",
     "@oboku/archive-metadata": "^0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/event-emitter": "^3.0.1",
         "@nestjs/jwt": "^11.0.0",
-        "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/platform-express": "^11.1.28",
         "@nestjs/schedule": "^6.0.0",
         "@nestjs/typeorm": "^11.0.0",
         "@oboku/archive-metadata": "^0.1.0",
@@ -3828,6 +3828,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3844,6 +3845,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3860,6 +3862,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3876,6 +3879,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3892,6 +3896,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3908,6 +3913,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3924,6 +3930,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3940,6 +3947,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3956,6 +3964,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3972,6 +3981,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3988,6 +3998,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4004,6 +4015,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4020,6 +4032,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4036,6 +4049,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4052,6 +4066,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4068,6 +4083,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4084,6 +4100,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4100,6 +4117,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4116,6 +4134,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4132,6 +4151,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4148,6 +4168,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4164,6 +4185,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4180,6 +4202,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4196,6 +4219,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4212,6 +4236,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4228,6 +4253,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8776,14 +8802,14 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.27",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.27.tgz",
-      "integrity": "sha512-0ZFhz6H6EdGh4xQVbUNwjoAwBuz73P7FvUAl67h9CTdMqQlJDaQYJApBv8pKfVZ1fGjMCbl0m9DcC6pXaZPWSQ==",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
+      "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
-        "multer": "2.1.1",
+        "multer": "2.2.0",
         "path-to-regexp": "8.4.2",
         "tslib": "2.8.1"
       },
@@ -10955,6 +10981,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10971,6 +10998,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12694,7 +12722,7 @@
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
       "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12738,11 +12766,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12754,11 +12784,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12770,11 +12802,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12786,11 +12820,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12802,11 +12838,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12818,11 +12856,13 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12834,11 +12874,13 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12850,11 +12892,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12866,11 +12910,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12882,11 +12928,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12898,11 +12946,13 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12914,11 +12964,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12927,7 +12979,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
@@ -12943,7 +12995,7 @@
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
       "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -21749,7 +21801,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
       "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -23684,6 +23736,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -24129,7 +24182,7 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -27942,6 +27995,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -27962,6 +28016,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -27982,6 +28037,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28002,6 +28058,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28022,6 +28079,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28042,6 +28100,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28062,6 +28121,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28082,6 +28142,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28102,6 +28163,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28122,6 +28184,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -28142,6 +28205,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -30428,9 +30492,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -34192,7 +34256,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -36280,7 +36344,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-5.0.1.tgz",
       "integrity": "sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -37333,7 +37397,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -38730,6 +38794,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38741,6 +38806,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38751,6 +38817,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38761,6 +38828,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
       "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38792,6 +38860,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38808,6 +38877,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38824,6 +38894,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38840,6 +38911,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38856,6 +38928,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38872,6 +38945,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38888,6 +38962,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38904,6 +38979,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38920,6 +38996,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38936,6 +39013,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38952,6 +39030,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -38970,6 +39049,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38986,6 +39066,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38999,6 +39080,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -40293,7 +40375,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
## The update

| Package | From | To | Type |
| --- | --- | --- | --- |
| `@nestjs/platform-express` (apps/api) | 11.1.27 | 11.1.28 | **patch** |
| ↳ `multer` (transitive, only consumer is platform-express) | 2.1.1 | 2.2.0 | — |

**Security-motivated.** `multer` 2.1.1 is affected by two denial-of-service advisories on the API's file-upload path; `@nestjs/platform-express` 11.1.28 bumps its `multer` dependency to the patched 2.2.0:

- **GHSA-72gw-mp4g-v24j** (high) — DoS via deeply nested field names
- **GHSA-3p4h-7m6x-2hcm** (moderate) — DoS via incomplete cleanup of aborted uploads

`multer` is pulled in **only** by `@nestjs/platform-express`, so this single patch bump fully clears both advisories — no `@nestjs` family coupling was required (`platform-express` 11.1.28 peer-depends on `@nestjs/common`/`@nestjs/core` `^11.0.0`, satisfied by the installed 11.1.27).

### Diff scope
Only `@nestjs/platform-express` and `multer` change version. The mandated `npm dedupe` was run and confirmed this update introduces **no new duplication**. The repo's lockfile carries pre-existing dedup debt (a tree-wide `npm dedupe` rewrites ~680 lines on clean `develop`, unrelated to this change) — that cleanup was deliberately left out to keep this security fix reviewable as a single unit.

### Gates (Node 25 per `.github/workflows/check.yml`; run here on Node 22)
| Gate | Baseline (`develop`) | With change |
| --- | --- | --- |
| `npm run lint` (biome) | ✅ pass | ✅ pass |
| `npm run build` (7 projects) | ✅ pass | ✅ pass |
| `npm run test` | ⚠️ 15 pre-existing failures | ⚠️ same 15, no new |

The 15 test failures are **pre-existing on `develop`**, all in `apps/web/src/http/HttpClientApi.web.test.ts` (12) and `apps/web/src/http/httpClientApi.sw.test.ts` (3) — auth/http-client tests unrelated to this dependency. `@oboku/api` (the touched package) tests pass. No new failures introduced.

---

## Pending queue (found this run, not addressed here — one dependency per PR)

### Remaining security advisories, by severity
Most high/critical advisories are **transitive via dev-only tooling** — the `vercel` devDependency (the entire `@vercel/*` cluster) and `nx`/`lerna`. They cannot be fixed at the leaves; they clear when the parent tool is upgraded (see deferred majors).

- **critical:** `tar` (≤7.5.18) — transitive via `vercel`/`lerna`/`nx` dev tooling
- **high (direct deps):**
  - `next` (landing) 16.1.6 — latest stable **16.2.10 is still within the advisory range**; no fixed release available yet, so deferred.
  - `nodemailer` (api) 8.0.11 — fix requires **major 8→9** (see deferred majors).
  - `rxdb` (web) 17.3.0 — fixed by **minor 17.4.0** (ws memory-exhaustion DoS); good candidate for the next PR.
  - `vercel` (devDep) 54.x — fix requires **major 54→56**; would clear the whole `@vercel/*` + `tar` cluster at once.
- **high (transitive):** `axios`, `brace-expansion`, `js-yaml`, `minimatch`, `nx`, `path-to-regexp`, `undici`, `ws` (remaining copy via `jsdom`), `@vercel/*`
- **moderate (direct):** `@swc/cli` 0.7.10, `lerna`
- **moderate (transitive):** `ajv`, `aws-sdk`, `file-type`, `postcss`, `protobufjs`, `smol-toml`, `srvx`, `uuid`, `@xhmikosr/*`, `@vercel/*`
- **low:** `@tootallnate/once`, `aws-lambda`

### Non-security patch updates (30) — safe, most-behind first
`@biomejs/biome` 2.5.1→2.5.5, `@nestjs/common`/`core`/`testing` 11.1.27→11.1.28, `@nestjs/typeorm` 11.0.2→11.0.3, `@nestjs/cli` 11.0.23→11.0.24, `@swc/core` 1.15.43→1.15.46, `@tanstack/react-query`(+persist) 5.101.1→5.101.3, `@tanstack/react-router` 1.170.16→1.170.18, `@tanstack/react-virtual` 3.14.3→3.14.7, `@tanstack/router-plugin` 1.168.18→1.168.23, `@mantine/*` 9.4.0→9.4.2, `@chakra-ui/react` 3.36.0→3.36.1, `@microsoft/api-extractor` 7.58.9→7.58.12, `@types/supertest` 7.2.0→7.2.1, `@zip.js/zip.js` 2.8.26→2.8.33, `ag-grid-community`/`react` 36.0.0→36.0.1, `dexie` 4.4.2→4.4.4, `nano` 11.0.5→11.0.6, `postcss` 8.5.15→8.5.21, `react-virtuoso` 4.18.7→4.18.11, `unplugin-dts` 1.0.2→1.0.3, `vite` 8.1.0→8.1.5, `vitest` 4.1.9→4.1.10.

### Non-security minor updates (24)
`@aws-sdk/client-s3`/`ssm` 3.1075→3.1091, `@azure/msal-browser` 5.14.0→5.17.1, `@fontsource/roboto` 5.2.10→5.3.0, `@mui/material`/`icons-material`/`utils` 9.1.x→9.2.0, `@mui/x-tree-view` 9.6.0→9.10.0, `@sentry/*` 10.60.0→10.67.0, `@swc/cli` 0.7.10→0.8.1, `dropbox` 10.34.0→10.37.1, `eslint-config-next` 16.1.6→16.2.10, `firebase` 12.15.0→12.16.0, `fuse.js` 7.4.2→7.5.0, `google-auth-library` 10.5.0→10.9.0, `next` 16.1.6→16.2.10, `prettier` 3.8.4→3.9.6, `react-hook-form` 7.80.0→7.82.0, `react-icons` 5.6.0→5.7.0, `reactjrx` 1.140.0→1.141.3, `rxdb` 17.3.0→17.4.0 *(also security)*, `sharp` 0.34.5→0.35.3.

### Deferred majors (need manual scheduling — breaking changes)
- `vercel` 54.15.1 → **56.4.1** — major CLI/build-utils overhaul; clears the entire `@vercel/*` + `tar` advisory cluster.
- `nodemailer` 8.0.11 → **9.0.3** — v9 drops old Node support and tightens the message API (raw-option file/URL access); security-relevant.
- `typescript` 5.9.3 → **7.0.2** — new major line; type-checking/emit behavior changes.
- `eslint` 9.39.4 → **10.7.0** — flat-config-only, Node baseline bump.
- `react-router` 7.18.0 → **8.2.0** — routing API changes.
- `typeorm` 0.3.30 → **1.1.0** — first stable major; API/migration changes.
- `pdfjs-dist` 5.7.284 → **6.1.200** — worker/API changes.
- `react-dropzone` 15.0.0 → **19.1.1** — several majors behind; API changes.
- `jose` 5.9.6 → **6.2.3** — ESM/API changes.
- `googleapis` 171.4.0 → **173.0.0** — generated-client major.
- `jsdom` 27.4.0 → **29.1.1** — also carries the remaining vulnerable `ws` copy.
- `lint-staged` 17.1.0, `@types/node` 26.1.1 — dev tooling majors.

### Needs manual attention
None — the chosen update passes all gates with no new failures. No update was skipped for breaking a gate this run.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKoPAepDc2xhSFFDhHTHe5)_