### PR TITLE
fix(shared): match reader file extensions case-insensitively

### DIFF
--- a/packages/shared/src/contentType.test.ts
+++ b/packages/shared/src/contentType.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { isFileSupported } from "./contentType"
+
+describe("isFileSupported", () => {
+  it("should accept supported extensions regardless of case", () => {
+    expect(isFileSupported({ name: "MyBook.EPUB" })).toBe(true)
+    expect(isFileSupported({ name: "comic.CBZ" })).toBe(true)
+    expect(isFileSupported({ name: "document.Pdf" })).toBe(true)
+  })
+
+  it("should accept supported lowercase extensions", () => {
+    expect(isFileSupported({ name: "MyBook.epub" })).toBe(true)
+    expect(isFileSupported({ name: "comic.cbz" })).toBe(true)
+    expect(isFileSupported({ name: "archive.zip" })).toBe(true)
+  })
+
+  it("should accept supported mime types when the name is not recognized", () => {
+    expect(
+      isFileSupported({ name: "no-extension", mimeType: "application/pdf" }),
+    ).toBe(true)
+  })
+
+  it("should reject unsupported files", () => {
+    expect(isFileSupported({ name: "movie.mkv" })).toBe(false)
+    expect(isFileSupported({ name: "movie.MKV" })).toBe(false)
+    expect(isFileSupported({ name: "no-extension" })).toBe(false)
+    expect(isFileSupported({})).toBe(false)
+  })
+})

--- a/packages/shared/src/contentType.ts
+++ b/packages/shared/src/contentType.ts
@@ -48,7 +48,7 @@ export const isFileSupported = ({
   name?: string | null
   mimeType?: string | null
 }) => {
-  const extension = `.${getUrlExtension(name || "")}`
+  const extension = `.${getUrlExtension(name || "").toLowerCase()}`
 
   return (
     READER_ACCEPTED_EXTENSIONS.includes(extension) ||


### PR DESCRIPTION
## The bug

`isFileSupported` (`packages/shared/src/contentType.ts`) builds the extension from the raw file name and compares it against the all-lowercase `READER_ACCEPTED_EXTENSIONS` list. Any file with an uppercase or mixed-case extension is reported as unsupported:

- `isFileSupported({ name: "MyBook.EPUB" })` → `false` (verified by executing the real code; `"MyBook.epub"` → `true`)

## How to observe it

`isFileSupported` is the gate for which files become books:

- `apps/api/src/plugins/synology-drive/client.ts:92` and `apps/api/src/plugins/webdav/operations.ts:48` filter sync items with it (name only, no mime type available), so `Book.EPUB` / `comic.CBZ` on a NAS or WebDAV share is **silently skipped during sync** and never appears in the library.
- `apps/web/src/common/FileTreeView/LazyTreeView.tsx:195`, `apps/web/src/plugins/webdav/upload/FileBrowseStep.tsx:25`, and `apps/web/src/plugins/synology-drive/browsing/tree.ts:16` grey out / hide those files in the pickers.

Case-insensitivity is the established contract elsewhere: the sibling `isPotentialZipFile` in the same file lowercases the name first, and the archive reader's own `getExtension` lowercases too.

## The fix

Lowercase the extracted extension in `isFileSupported` before comparing. `getUrlExtension` itself is left untouched (its casing is preserved for other consumers).

## Verification

- New regression test `packages/shared/src/contentType.test.ts`: `MyBook.EPUB` / `comic.CBZ` / `document.Pdf` fail on the previous code and pass after the fix; lowercase, mime-type, and unsupported-file cases covered.
- `npm run lint`, `npm run build` (all 7 projects), shared suite 102/102 pass.
- `npm run test` at repo root: only pre-existing failures remain — the same 15 tests in `apps/web/src/http/HttpClientApi.web.test.ts` + `httpClientApi.sw.test.ts` fail identically on a clean `develop` checkout (re-verified with this change stashed).

## Other findings (not addressed in this PR)

Confirmed by tracing the real code paths; listed so they aren't lost:

- **`bulkDelete` omits `_rev`, so dangling-link deletion silently never deletes** (`apps/api/src/lib/couch/bulkDelete.ts`): it posts `{_id, _deleted: true}` without `_rev` to `_bulk_docs`; CouchDB answers each doc with a `conflict` error (nano's `bulk` doesn't throw on per-doc errors), so `deleteDanglingLinks` records the link as deleted in the sync report while the doc survives. Dangling links accumulate and are "re-deleted" on every sync. The caller has `_rev` in hand (`Helpers["find"]` returns it) — the fix is to forward it.
- **`useCollections`' `isNotInterested: "only"` branch intersects the wrong array** (`apps/web/src/collections/useCollections.ts:152`): it uses `bookIds` (the query param, `undefined` for the search screen caller) instead of the `notInterestedBookIds` computed just above — and `intersection(collection.books, undefined)` degenerates to the full book list. Setting the search filter "Show not interested contents: Only" therefore shows **every non-empty collection** instead of only collections with a not-interested book.
- **Empty Google metadata guard is always false** (`apps/api/src/lib/metadata/google/getGoogleBookMetadata.ts:98`): `if (!Object.keys(parsedMetadata)) return undefined` — an array is always truthy (missing `.length`), so a no-result lookup still emits a field-less `{ type: "googleBookApi" }` source entry onto the book.
- **`createThrottler` never clears its `setInterval`** (`apps/api/src/lib/utils.ts:97`): each dropbox/google/one-drive sync spawns a 50 ms interval that lives for the whole process lifetime — a slow timer/CPU leak on a long-running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqCq7ako5cdiYdvpJAKgKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqCq7ako5cdiYdvpJAKgKJ)_