### PR TITLE
refactor(web): consolidate incremental book mutation pipeline

### DIFF
--- a/apps/web/src/books/incrementalBookMutation.ts
+++ b/apps/web/src/books/incrementalBookMutation.ts
@@ -1,0 +1,21 @@
+import { getLatestDatabase } from "../rxdb/RxDbProvider"
+import { from, mergeMap, of } from "rxjs"
+import type { RxDocument } from "rxdb"
+import type { BookDocType } from "@oboku/shared"
+
+export const incrementalBookMutation = <Result>(
+  doc: RxDocument<BookDocType> | string,
+  applyIncremental: (item: RxDocument<BookDocType>) => Promise<Result>,
+) =>
+  getLatestDatabase().pipe(
+    mergeMap((db) =>
+      typeof doc === "string"
+        ? from(db.book.findOne({ selector: { _id: doc } }).exec())
+        : of(doc),
+    ),
+    mergeMap((item) => {
+      if (!item) return of(null)
+
+      return from(applyIncremental(item))
+    }),
+  )

--- a/apps/web/src/books/useIncrementalBookModify.ts
+++ b/apps/web/src/books/useIncrementalBookModify.ts
@@ -1,8 +1,7 @@
-import { getLatestDatabase } from "../rxdb/RxDbProvider"
-import { from, mergeMap, of } from "rxjs"
 import type { ModifyFunction, RxDocument } from "rxdb"
 import type { BookDocType } from "@oboku/shared"
 import { useMutation$ } from "reactjrx"
+import { incrementalBookMutation } from "./incrementalBookMutation"
 
 export const useIncrementalBookModify = () =>
   useMutation$({
@@ -13,16 +12,7 @@ export const useIncrementalBookModify = () =>
       doc: RxDocument<BookDocType> | string
       mutationFn: ModifyFunction<BookDocType>
     }) =>
-      getLatestDatabase().pipe(
-        mergeMap((db) =>
-          typeof doc === "string"
-            ? from(db.book.findOne({ selector: { _id: doc } }).exec())
-            : of(doc),
-        ),
-        mergeMap((item) => {
-          if (!item) return of(null)
-
-          return from(item.incrementalModify(mutationFn))
-        }),
+      incrementalBookMutation(doc, (item) =>
+        item.incrementalModify(mutationFn),
       ),
   })

--- a/apps/web/src/books/useIncrementalBookPatch.ts
+++ b/apps/web/src/books/useIncrementalBookPatch.ts
@@ -1,8 +1,7 @@
-import { getLatestDatabase } from "../rxdb/RxDbProvider"
-import { from, mergeMap, of } from "rxjs"
 import type { RxDocument } from "rxdb"
 import type { BookDocType } from "@oboku/shared"
 import { useMutation$ } from "reactjrx"
+import { incrementalBookMutation } from "./incrementalBookMutation"
 
 export const useIncrementalBookPatch = () =>
   useMutation$({
@@ -12,17 +11,5 @@ export const useIncrementalBookPatch = () =>
     }: {
       doc: RxDocument<BookDocType> | string
       patch: Partial<BookDocType>
-    }) =>
-      getLatestDatabase().pipe(
-        mergeMap((db) =>
-          typeof doc === "string"
-            ? from(db.book.findOne({ selector: { _id: doc } }).exec())
-            : of(doc),
-        ),
-        mergeMap((item) => {
-          if (!item) return of(null)
-
-          return from(item.incrementalPatch(patch))
-        }),
-      ),
+    }) => incrementalBookMutation(doc, (item) => item.incrementalPatch(patch)),
   })

--- a/apps/web/src/books/useIncrementalBookUpdate.ts
+++ b/apps/web/src/books/useIncrementalBookUpdate.ts
@@ -1,8 +1,7 @@
-import { getLatestDatabase } from "../rxdb/RxDbProvider"
-import { from, mergeMap, of } from "rxjs"
 import type { RxDocument, UpdateQuery } from "rxdb"
 import type { BookDocType } from "@oboku/shared"
 import { useMutation$ } from "reactjrx"
+import { incrementalBookMutation } from "./incrementalBookMutation"
 
 export const useIncrementalBookUpdate = () =>
   useMutation$({
@@ -13,16 +12,5 @@ export const useIncrementalBookUpdate = () =>
       doc: RxDocument<BookDocType> | string
       updateObj: UpdateQuery<BookDocType>
     }) =>
-      getLatestDatabase().pipe(
-        mergeMap((db) =>
-          typeof doc === "string"
-            ? from(db.book.findOne({ selector: { _id: doc } }).exec())
-            : of(doc),
-        ),
-        mergeMap((item) => {
-          if (!item) return of(null)
-
-          return from(item.incrementalUpdate(updateObj))
-        }),
-      ),
+      incrementalBookMutation(doc, (item) => item.incrementalUpdate(updateObj)),
   })


### PR DESCRIPTION
## Consolidation: incremental book mutation pipeline

**What was duplicated**

The three incremental book mutation hooks each reimplemented the exact same document-resolution + null-guard pipeline, differing only in the final rxdb operation:

- `apps/web/src/books/useIncrementalBookModify.ts` → `item.incrementalModify(mutationFn)`
- `apps/web/src/books/useIncrementalBookPatch.ts` → `item.incrementalPatch(patch)`
- `apps/web/src/books/useIncrementalBookUpdate.ts` → `item.incrementalUpdate(updateObj)`

The shared block, copy-pasted in all three:

```ts
getLatestDatabase().pipe(
  mergeMap((db) =>
    typeof doc === "string"
      ? from(db.book.findOne({ selector: { _id: doc } }).exec())
      : of(doc),
  ),
  mergeMap((item) => {
    if (!item) return of(null)
    return from(/* the differing operation */)
  }),
)
```

**What it became**

A single `apps/web/src/books/incrementalBookMutation.ts` helper that owns the resolve-doc + null-guard pipeline and takes the differing operation as a callback. Each hook keeps its own public API (same name, same argument shape, same return) and now delegates to the helper.

The varying behavior is passed as a function, not a flag/mode parameter — the three hooks stay distinct concepts at their boundary while sharing the one piece that was genuinely identical.

**Why these are truly the same concept**

The doc-resolution (`string | RxDocument` → `RxDocument | null`) and the missing-document guard are one behavior with one place to fix; only the incremental operation differs, and that is exactly what the callback captures. No error message, return shape, ordering, or query key changed.

**Net LOC**: +28 / −42 (net −14).

**Verification**
- `tsc -b` (web): passes.
- `biome check` (web/src/books): clean.
- `vitest run` (web): 184 passed / 37 failed — identical to the `develop` baseline; the 37 failures are pre-existing and environment-related (`navigator.locks` unavailable in the test runtime), unaffected by this change.

---

### Other candidates found (left for future runs)
- `apps/web/src/plugins/tokenValidity.ts` + its test are a verbatim copy of `apps/web/src/plugins/common/tokenValidity.ts`; only the `common/` copy has real importers (dropbox / google / one-drive). The root pair looks like a dead duplicate — deletable, but that reads as dead-code removal rather than consolidation, so it was kept out of this PR's story.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjDUJXpyhzCwpJJ73YcGdn)_