### PR TITLE
perf: compute book title sort key once per book in alpha sort

### DIFF
--- a/apps/web/src/books/helpers.ts
+++ b/apps/web/src/books/helpers.ts
@@ -187,12 +187,13 @@ export const sortBooksBy = (
       })
     }
     case "alpha": {
-      return [...books].sort((a, b) =>
-        sortByTitleComparator(
-          getMetadataFromBook(a).title?.toString() ?? "",
-          getMetadataFromBook(b).title?.toString() ?? "",
-        ),
-      )
+      return books
+        .map((book) => ({
+          book,
+          title: getMetadataFromBook(book).title?.toString() ?? "",
+        }))
+        .sort((a, b) => sortByTitleComparator(a.title, b.title))
+        .map(({ book }) => book)
     }
     default:
       return books


### PR DESCRIPTION
## Target

**Subsystem:** library book listing (`apps/web/src/books/helpers.ts` → `sortBooksBy`).

**User-visible symptom:** when the library is sorted alphabetically (`sorting: "alpha"`), the main library screen re-runs this sort on the *entire* book collection every time filters, download state, reading state, or tag selection change (it feeds `useLibraryBooks` / `useBooksSortedBy`). For a large library this is main-thread work that delays the grid re-render after each interaction.

## The change

`sortBooksBy`'s `alpha` branch called `getMetadataFromBook(a)` and `getMetadataFromBook(b)` **inside** the sort comparator. `getMetadataFromBook` is not cheap — per call it does a `find`, directive extraction, `getOrderedBookMetadataSources`, a `toReversed`, a `toSorted` (with `indexOf` in its comparator), and a `reduce` that shallow-copies objects and builds a merged metadata record.

A comparison-based sort invokes its comparator ~`n·log₂(n)` times, so the old code ran that expensive merge **~2·n·log₂(n)** times per sort.

**Mechanism:** decorate-sort-undecorate — compute each book's title **once** (`n` calls), sort on the precomputed strings, then unwrap. This turns the `getMetadataFromBook` cost from **O(n·log n) → O(n)**. The comparator (`sortByTitleComparator`) and the resulting order are unchanged; the input array is still not mutated.

## Measured impact

Micro-benchmark on realistic book docs (two metadata entries each), run under the app's vitest/jsdom setup with the real `getMetadataFromBook`:

| N (books) | `getMetadataFromBook` calls (old → new) | sort wall time (old → new) |
|-----------|------------------------------------------|-----------------------------|
| 2000      | 38,730 → 2,000 (**19.4× fewer**)         | 157.4 ms → 12.9 ms (**~12×**) |

Order verified identical to the previous implementation (`order identical: true`). Scales with library size and sort frequency; the benchmark file was throwaway and is not included in the diff.

## Gates

- `npm run build` (web, `tsc -b && vite build`): ✅ passes.
- `npm run lint` (biome, changed file): ✅ clean.
- `npm run test` (vitest): the 15 failures in `src/http/HttpClientApi.web.test.ts` and `src/http/httpClientApi.sw.test.ts` are **pre-existing on `develop`** (reproduced with the change stashed) and unrelated to this subsystem; no new failures introduced.

## Backlog (other perf opportunities found, not taken here to keep scope to one subsystem)

- `apps/web/src/search/useBooksForSearch.ts`: the same `getMetadataFromBook`-inside-comparator pattern in its `.sort(...)`, **and** a `new RegExp(...)` constructed inside the `.filter(...)` callback (rebuilt once per book instead of once per search) — both hoistable.
- `getMetadataFromBook` itself (`apps/web/src/books/metadata/index.ts`) allocates several intermediate arrays and does per-item object spreads on every call; a lighter title-only path could cut the per-book cost further for sort/search key extraction.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dkihQVZGC8NhYJzQcdoav)_