### PR TITLE
fix(web): derive go-back availability from the router history index

### DIFF
--- a/apps/web/src/navigation/AppBrowserRouter.tsx
+++ b/apps/web/src/navigation/AppBrowserRouter.tsx
@@ -1,11 +1,4 @@
-import {
-  BrowserRouter,
-  Routes,
-  Route,
-  Navigate,
-  Outlet,
-  useLocation,
-} from "react-router"
+import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router"
 import { HomeScreen } from "../pages/HomeScreen"
 import { LoginScreen } from "../pages/LoginScreen"
 import { ReaderScreen } from "../reader/ReaderScreen"
@@ -30,7 +23,7 @@ import { BookTagsScreen } from "../pages/books/$id/tags/BookTagsScreen"
 import { BookCollectionsScreen } from "../pages/books/$id/collections/BookCollectionsScreen"
 import { BookMetadataSourceScreen } from "../pages/books/$id/metadata/$source/BookMetadataSourceScreen"
 import { BookOptimizeScreen } from "../pages/books/$id/optimize/BookOptimizeScreen"
-import { memo, useEffect, useRef, type ReactNode } from "react"
+import type { ReactNode } from "react"
 import { useMediaQuery, useTheme } from "@mui/material"
 import { SearchScreenExpanded } from "../search/SearchScreenExpanded"
 import { useActiveProfile } from "../profiles"
@@ -241,7 +234,6 @@ export const AppBrowserRouter = ({ children }: { children: ReactNode }) => {
         )}
       </Routes>
       {children}
-      <TrackHistoryCanGoBack />
     </ModalHistoryProvider>
   )
 
@@ -256,33 +248,3 @@ export const AppBrowserRouter = ({ children }: { children: ReactNode }) => {
     </BrowserRouter>
   )
 }
-
-const TrackHistoryCanGoBack = memo(() => {
-  const { pathname, state } = useLocation()
-  const isFirstChange = useRef(true)
-
-  useEffect(() => {
-    return () => {
-      // concurrent bug ?
-      // we have to reset the ref for next mount, no idea why
-      isFirstChange.current = true
-    }
-  }, [])
-
-  useEffect(() => {
-    void pathname
-
-    if (!isFirstChange.current && !state?.__obokuFallbackBack) {
-      window.history.replaceState(
-        {
-          ...window.history.state,
-          __obokuCanGoBack: true,
-        },
-        ``,
-      )
-    }
-    isFirstChange.current = false
-  }, [pathname, state])
-
-  return null
-})

--- a/apps/web/src/navigation/useSafeGoBack.test.tsx
+++ b/apps/web/src/navigation/useSafeGoBack.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from "@testing-library/react"
+import { BrowserRouter, useLocation, useNavigate } from "react-router"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { ROUTES } from "./routes"
+import { useSafeGoBack } from "./useSafeGoBack"
+
+/**
+ * `useSafeGoBack` reasons about the real `window.history` stack, so these tests
+ * drive a `BrowserRouter` (a `MemoryRouter` never touches `window.history`).
+ * jsdom keeps one history stack per file, so each test starts by wiping the
+ * current entry's state, which makes the router re-seed it at index 0 — the
+ * same situation as opening a deep link in a fresh tab.
+ */
+
+const BOOK_OPTIMIZE_PATH = "/books/book-1/optimize"
+
+let latestGoBack: (defaultTo?: string) => void
+let latestNavigate: ReturnType<typeof useNavigate>
+let currentLocation: ReturnType<typeof useLocation>
+
+const Probe = () => {
+  currentLocation = useLocation()
+  latestNavigate = useNavigate()
+  latestGoBack = useSafeGoBack().goBack
+
+  return null
+}
+
+const renderAt = (url: string) => {
+  window.history.replaceState(null, "", url)
+
+  render(
+    <BrowserRouter>
+      <Probe />
+    </BrowserRouter>,
+  )
+}
+
+const currentUrl = () =>
+  `${currentLocation.pathname}${currentLocation.search}${currentLocation.hash}`
+
+beforeEach(() => {
+  window.history.replaceState(null, "", "/")
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("useSafeGoBack", () => {
+  describe("with no entry to pop (deep link opened directly)", () => {
+    it("falls back to home", async () => {
+      renderAt(`${BOOK_OPTIMIZE_PATH}?tab=content`)
+
+      act(() => latestGoBack())
+
+      await waitFor(() => expect(currentUrl()).toBe(ROUTES.HOME))
+    })
+
+    it("falls back to the provided default", async () => {
+      renderAt(`${BOOK_OPTIMIZE_PATH}?tab=content`)
+
+      act(() => latestGoBack("/books/book-1"))
+
+      await waitFor(() => expect(currentUrl()).toBe("/books/book-1"))
+    })
+
+    it("replaces the entry instead of pushing one", async () => {
+      renderAt(`${BOOK_OPTIMIZE_PATH}?tab=content`)
+      const lengthBeforeFallback = window.history.length
+
+      act(() => latestGoBack())
+
+      await waitFor(() => expect(currentUrl()).toBe(ROUTES.HOME))
+      expect(window.history.length).toBe(lengthBeforeFallback)
+    })
+  })
+
+  describe("with a pushed entry", () => {
+    it("pops back to it", async () => {
+      renderAt("/books/book-1")
+
+      act(() => latestNavigate(`${BOOK_OPTIMIZE_PATH}?tab=content`))
+      await waitFor(() =>
+        expect(currentUrl()).toBe(`${BOOK_OPTIMIZE_PATH}?tab=content`),
+      )
+
+      act(() => latestGoBack())
+
+      await waitFor(() => expect(currentUrl()).toBe("/books/book-1"))
+    })
+
+    it("still pops back to it after a replace-only navigation", async () => {
+      // Regression: switching tab replaces the entry with `setSearchParams(…,
+      // { replace: true })`. react-router rebuilds the whole history state on
+      // replace, which used to wipe the flag this hook relied on, so back
+      // wrongly fell through to home.
+      renderAt("/books/book-1")
+
+      act(() => latestNavigate(`${BOOK_OPTIMIZE_PATH}?tab=content`))
+      await waitFor(() =>
+        expect(currentUrl()).toBe(`${BOOK_OPTIMIZE_PATH}?tab=content`),
+      )
+
+      act(() =>
+        latestNavigate(`${BOOK_OPTIMIZE_PATH}?tab=metadata`, { replace: true }),
+      )
+      await waitFor(() =>
+        expect(currentUrl()).toBe(`${BOOK_OPTIMIZE_PATH}?tab=metadata`),
+      )
+
+      act(() => latestGoBack())
+
+      await waitFor(() => expect(currentUrl()).toBe("/books/book-1"))
+    })
+
+    it("ignores the provided default", async () => {
+      renderAt("/books/book-1")
+
+      act(() => latestNavigate(`${BOOK_OPTIMIZE_PATH}?tab=content`))
+      await waitFor(() =>
+        expect(currentUrl()).toBe(`${BOOK_OPTIMIZE_PATH}?tab=content`),
+      )
+
+      act(() => latestGoBack(ROUTES.PROFILE))
+
+      await waitFor(() => expect(currentUrl()).toBe("/books/book-1"))
+    })
+  })
+})

--- a/apps/web/src/navigation/useSafeGoBack.ts
+++ b/apps/web/src/navigation/useSafeGoBack.ts
@@ -2,19 +2,25 @@ import { useCallback, useMemo } from "react"
 import { useLocation, useNavigate } from "react-router"
 import { ROUTES } from "./routes"
 
+/**
+ * react-router stores the history entry position under `idx` and rebuilds the
+ * whole history state object on every push/replace, so custom keys cannot be
+ * stamped alongside it. `idx > 0` means this app pushed an entry we can pop.
+ */
+const hasPoppableHistoryEntry = () => {
+  const entryIndex: unknown = window.history.state?.idx
+
+  return typeof entryIndex === "number" && entryIndex > 0
+}
+
 export const useSafeGoBack = () => {
   const navigate = useNavigate()
   const { pathname } = useLocation()
 
   const goBack = useCallback(
     (defaultTo?: string) => {
-      if (!window.history.state.__obokuCanGoBack && pathname !== ROUTES.HOME) {
-        navigate(defaultTo ?? ROUTES.HOME, {
-          replace: true, // prevent infinite loop of fallback
-          state: {
-            __obokuFallbackBack: true,
-          },
-        })
+      if (!hasPoppableHistoryEntry() && pathname !== ROUTES.HOME) {
+        navigate(defaultTo ?? ROUTES.HOME, { replace: true })
       } else {
         navigate(-1)
       }


### PR DESCRIPTION
## Problem

Opening `/books/:id/optimize?tab=content`, switching to the Metadata tab, then pressing the back arrow lands on **home** instead of the previous screen.

Two things conspired:

1. The tab switch calls `setSearchParams(next, { replace: true })`. react-router's `replace` builds a **brand-new** history state object (`{usr, key, idx, masked}`) rather than merging — so the custom `__obokuCanGoBack` flag that `useSafeGoBack` relied on was silently dropped.
2. `TrackHistoryCanGoBack` only re-stamped the flag on `[pathname, state]` changes, and a tab switch changes only `search`.

`goBack` then took the fallback branch — `navigate(ROUTES.HOME, { replace: true })` — which not only went home but *overwrote* the optimize entry.

Adding `search` to the tracker's deps would have made it worse: on a cold deep-link load (index 0), a tab click would mark the entry as go-back-able and `navigate(-1)` would walk out of the app entirely.

## Fix

react-router already tracks the entry position per history entry under `history.state.idx` — `0` on a fresh load, incremented on push, and **preserved** across replace. `useSafeGoBack` now reads that instead, which lets the custom flag, the `__obokuFallbackBack` marker, and the whole `TrackHistoryCanGoBack` component go away (−32 lines net).

### Trade-off worth reviewing

`idx` is a react-router implementation detail: it appears nowhere in the public `.d.ts`, and the exported `History` interface has no index accessor or `canGoBack`. There is no public API for "can I go back" (`useNavigationType` only reports how you arrived), so the previous custom tracking was reasonable in intent — the problem was storing state in a slot react-router owns and rebuilds.

The new `useSafeGoBack.test.tsx` pins the assumption, so a react-router upgrade that changes the state shape fails the suite rather than silently sending users home.

## Tests

New `useSafeGoBack.test.tsx` (6 tests) drives a real `BrowserRouter` — `MemoryRouter` never touches `window.history`, so it cannot exercise this:

- no poppable entry (cold deep link) → falls back to home / to `defaultTo`, and replaces rather than pushes
- pushed entry → pops back to it, and ignores `defaultTo`
- **regression:** pushed entry → replace-only navigation → back still pops correctly

Full web suite: 43 files / 247 tests pass. Typecheck and biome clean.

## Verification note

I could not click through the real optimize screen end-to-end — the local dev server redirects to `/login` and I did not sign in. Verification is the unit tests plus the confirmed react-router source behaviour; a manual click-through is worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)