### PR TITLE
feat(web): let users protect storage from browser eviction

### DIFF
--- a/apps/web/src/notifications/inbox/LocalNotificationCard.tsx
+++ b/apps/web/src/notifications/inbox/LocalNotificationCard.tsx
@@ -1,5 +1,4 @@
 import { memo } from "react"
-import { LoginRounded } from "@mui/icons-material"
 import { Alert, AlertTitle, Button, Stack } from "@mui/material"
 import { Link, useLocation } from "react-router"
 import type { LocalNotification } from "./useLocalNotifications"
@@ -32,7 +31,7 @@ export const LocalNotificationCard = memo(function LocalNotificationCard({
             state={{ from: location.pathname } satisfies FromLocationState}
             size="small"
             variant="contained"
-            startIcon={<LoginRounded />}
+            startIcon={<notification.action.icon />}
           >
             {notification.action.label}
           </Button>

--- a/apps/web/src/notifications/inbox/useLocalNotifications.ts
+++ b/apps/web/src/notifications/inbox/useLocalNotifications.ts
@@ -1,7 +1,10 @@
 import { useMemo } from "react"
+import type { SvgIconComponent } from "@mui/icons-material"
+import { LoginRounded, StorageRounded } from "@mui/icons-material"
 import type { NotificationSeverity } from "@oboku/shared"
 import { useActiveProfile } from "../../profiles"
 import { ROUTES } from "../../navigation/routes"
+import { useIsStoragePersisted } from "../../storage/useIsStoragePersisted"
 
 export type LocalNotification = {
   id: string
@@ -11,11 +14,13 @@ export type LocalNotification = {
   action?: {
     label: string
     to: string
+    icon: SvgIconComponent
   }
 }
 
 export const useLocalNotifications = (): LocalNotification[] => {
   const needsRelogin = useActiveProfile().data?.needsRelogin ?? false
+  const { data: isStoragePersisted } = useIsStoragePersisted()
 
   return useMemo(() => {
     const notifications: LocalNotification[] = []
@@ -29,10 +34,25 @@ export const useLocalNotifications = (): LocalNotification[] => {
         action: {
           label: "Sign in again",
           to: ROUTES.SESSION_EXPIRED,
+          icon: LoginRounded,
+        },
+      })
+    }
+
+    if (isStoragePersisted === false) {
+      notifications.push({
+        id: "storage_not_persisted",
+        severity: "warning",
+        title: "Storage not protected",
+        body: "The browser may delete your library and uploaded books to reclaim space.",
+        action: {
+          label: "Manage storage",
+          to: `${ROUTES.PROFILE}/manage-storage`,
+          icon: StorageRounded,
         },
       })
     }
 
     return notifications
-  }, [needsRelogin])
+  }, [needsRelogin, isStoragePersisted])
 }

--- a/apps/web/src/pages/profile/manage-storage/ManageStorageScreen.tsx
+++ b/apps/web/src/pages/profile/manage-storage/ManageStorageScreen.tsx
@@ -32,6 +32,7 @@ import { useRemoveCoversInCache } from "../../../covers/useRemoveCoversInCache"
 import { useDownloadedBooks } from "../../../download/useDownloadedBooks"
 import { useBooks } from "../../../books/states"
 import { useRemoveAllDownloads } from "../../../settings/useRemoveAllDownloads"
+import { StoragePersistenceListItem } from "./StoragePersistenceListItem"
 
 const bookListStyle = { width: "100%" }
 
@@ -124,6 +125,7 @@ export const ManageStorageScreen = () => {
             }
           />
         </ListItem>
+        <StoragePersistenceListItem />
         <ListItemButton onClick={() => removeCoversInCache()}>
           <ListItemIcon>
             <ImageRounded />

--- a/apps/web/src/pages/profile/manage-storage/StoragePersistenceListItem.test.tsx
+++ b/apps/web/src/pages/profile/manage-storage/StoragePersistenceListItem.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { links } from "@oboku/shared"
+import { StoragePersistenceListItem } from "./StoragePersistenceListItem"
+
+const stubStorage = ({
+  persisted,
+  persist,
+}: {
+  persisted: () => Promise<boolean>
+  persist: () => Promise<boolean>
+}) => {
+  Object.defineProperty(navigator, "storage", {
+    configurable: true,
+    value: { persisted, persist },
+  })
+}
+
+const renderListItem = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+
+  return render(<StoragePersistenceListItem />, {
+    wrapper: function withQueryClient({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      )
+    },
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("StoragePersistenceListItem", () => {
+  it("reports protected storage without offering an action", async () => {
+    stubStorage({
+      persisted: async () => true,
+      persist: async () => true,
+    })
+
+    renderListItem()
+
+    expect(await screen.findByText("Storage is protected")).toBeDefined()
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("offers to request protection when storage is evictable", async () => {
+    stubStorage({
+      persisted: async () => false,
+      persist: async () => true,
+    })
+
+    renderListItem()
+
+    expect(
+      await screen.findByText("Protect storage from deletion"),
+    ).toBeDefined()
+    expect(screen.getByRole("button")).toBeDefined()
+  })
+
+  it("switches to protected once the browser grants the request", async () => {
+    let isPersisted = false
+    const persist = vi.fn(async function grantPersistence() {
+      isPersisted = true
+
+      return true
+    })
+    stubStorage({ persisted: async () => isPersisted, persist })
+
+    renderListItem()
+    fireEvent.click(await screen.findByRole("button"))
+
+    expect(await screen.findByText("Storage is protected")).toBeDefined()
+    expect(persist).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([true, false])(
+    "always offers the documentation link (persisted: %s)",
+    async (persisted) => {
+      stubStorage({
+        persisted: async () => persisted,
+        persist: async () => persisted,
+      })
+
+      renderListItem()
+
+      const readMore = await screen.findByRole("link", { name: "Read more" })
+
+      expect(readMore.getAttribute("href")).toBe(links.documentationStorage)
+      expect(readMore.getAttribute("target")).toBe("_blank")
+    },
+  )
+
+  it("explains the refusal when the browser declines", async () => {
+    stubStorage({
+      persisted: async () => false,
+      persist: async () => false,
+    })
+
+    renderListItem()
+    fireEvent.click(await screen.findByRole("button"))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Refused by the browser. Installing oboku as an app usually helps.",
+        ),
+      ).toBeDefined()
+    })
+  })
+})

--- a/apps/web/src/pages/profile/manage-storage/StoragePersistenceListItem.tsx
+++ b/apps/web/src/pages/profile/manage-storage/StoragePersistenceListItem.tsx
@@ -1,0 +1,80 @@
+import { GppGoodRounded, GppMaybeRounded } from "@mui/icons-material"
+import {
+  Link,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material"
+import { links } from "@oboku/shared"
+import { useIsStoragePersisted } from "../../../storage/useIsStoragePersisted"
+import { useRequestStoragePersistence } from "../../../storage/useRequestStoragePersistence"
+
+const PROTECTED_DESCRIPTION =
+  "Protected from automatic deletion by the browser."
+const UNPROTECTED_DESCRIPTION =
+  "The browser may delete your library and uploaded books to reclaim space. Tap to protect."
+const REFUSED_DESCRIPTION =
+  "Refused by the browser. Installing oboku as an app usually helps."
+
+const withReadMore = (description: string) => (
+  <>
+    {`${description} `}
+    <Link
+      href={links.documentationStorage}
+      target="_blank"
+      rel="noopener"
+      onClick={function keepRowActionFromFiring(event) {
+        event.stopPropagation()
+      }}
+    >
+      Read more
+    </Link>
+  </>
+)
+
+export const StoragePersistenceListItem = () => {
+  const { data: isPersisted } = useIsStoragePersisted()
+  const {
+    mutate: requestStoragePersistence,
+    isPending: isRequestingPersistence,
+    data: wasRequestGranted,
+  } = useRequestStoragePersistence()
+
+  if (isPersisted === undefined) return null
+
+  if (isPersisted) {
+    return (
+      <ListItem>
+        <ListItemIcon>
+          <GppGoodRounded color="success" />
+        </ListItemIcon>
+        <ListItemText
+          primary="Storage is protected"
+          secondary={withReadMore(PROTECTED_DESCRIPTION)}
+        />
+      </ListItem>
+    )
+  }
+
+  return (
+    <ListItemButton
+      disabled={isRequestingPersistence}
+      onClick={function requestPersistence() {
+        requestStoragePersistence()
+      }}
+    >
+      <ListItemIcon>
+        <GppMaybeRounded color="error" />
+      </ListItemIcon>
+      <ListItemText
+        primary="Protect storage from deletion"
+        secondary={withReadMore(
+          wasRequestGranted === false
+            ? REFUSED_DESCRIPTION
+            : UNPROTECTED_DESCRIPTION,
+        )}
+      />
+    </ListItemButton>
+  )
+}

--- a/apps/web/src/storage/useIsStoragePersisted.ts
+++ b/apps/web/src/storage/useIsStoragePersisted.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query"
+
+export const STORAGE_PERSISTENCE_QUERY_KEY = ["storage/persistence"]
+
+export const useIsStoragePersisted = () =>
+  useQuery({
+    queryKey: STORAGE_PERSISTENCE_QUERY_KEY,
+    networkMode: "always",
+    queryFn: () => navigator.storage.persisted(),
+  })

--- a/apps/web/src/storage/useRequestStoragePersistence.ts
+++ b/apps/web/src/storage/useRequestStoragePersistence.ts
@@ -1,0 +1,23 @@
+import {
+  type DefaultError,
+  useMutation,
+  type UseMutationOptions,
+  useQueryClient,
+} from "@tanstack/react-query"
+import { STORAGE_PERSISTENCE_QUERY_KEY } from "./useIsStoragePersisted"
+
+export const useRequestStoragePersistence = (
+  options?: Pick<UseMutationOptions<boolean, DefaultError, void>, "meta">,
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: () => navigator.storage.persist(),
+    onSuccess: function refreshPersistedState() {
+      void queryClient.invalidateQueries({
+        queryKey: STORAGE_PERSISTENCE_QUERY_KEY,
+      })
+    },
+  })
+}

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -38,6 +38,7 @@
 * [Books](guides/books.md)
 * [Data Sources](guides/datasources.md)
 * [Reader](guides/reader.md)
+* [Storage protection](guides/storage.md)
 * [Supported Contents](guides/supported-contents.md)
 
 ## Sync Providers

--- a/gitbook/guides/storage.md
+++ b/gitbook/guides/storage.md
@@ -1,0 +1,62 @@
+# Storage protection
+
+oboku keeps a lot on your device: your library, your reading progress, the covers it has cached and every book you downloaded for offline reading. By default browsers treat all of that as *best-effort* storage, which means they are allowed to delete it without asking you whenever they need to reclaim disk space.
+
+Protecting your storage tells the browser it may not do that.
+
+## Why it matters
+
+Most of what oboku stores is also on the server, so if it is deleted it comes back the next time you sign in and synchronize. Losing it is annoying rather than fatal.
+
+Two things do not come back:
+
+* **Books you uploaded directly from your device.** oboku is the only place those files exist — there is no datasource to fetch them from again, so they are lost for good.
+* **Anything you changed while offline** that had not synchronized yet.
+
+Everything else — downloaded books from Google Drive, Dropbox, Synology, your own server — can be downloaded again, but you may be re-fetching several gigabytes over a connection you were not planning to use.
+
+{% hint style="warning" %}
+If your library is mostly made of books you uploaded yourself, treat storage protection as required rather than optional.
+{% endhint %}
+
+## Checking your status
+
+Go to **Profile → Manage storage**. The storage protection entry tells you where you stand:
+
+* A **green** shield means your storage is protected and the browser will not delete it on its own.
+* A **red** shield means the browser is currently allowed to delete oboku's data.
+
+## How to protect it
+
+Tap the entry when it is red and oboku will ask the browser for protection. What happens next depends on the browser, and this is the part that surprises people:
+
+* **Firefox** asks you directly. Accept the prompt and you are done.
+* **Chrome, Edge and most Chromium browsers** never ask you. They decide on their own, based on how important the site looks to them — whether you installed it, how much you use it, whether you bookmarked it, whether you allowed notifications. If they decide no, nothing visible happens and the shield stays red.
+
+### Install oboku as an app
+
+This is the single most effective thing you can do. An installed app is treated as important by every browser, and it is the only lever you fully control.
+
+* **Desktop Chrome / Edge** — open the install icon in the address bar, or the browser menu, and choose to install oboku.
+* **iOS / iPadOS Safari** — Share → *Add to Home Screen*.
+* **Android Chrome** — menu → *Add to Home screen* / *Install app*.
+
+Once installed, open oboku from its own icon and tap the entry again.
+
+{% hint style="info" %}
+Chrome does not document its exact criteria and does not always grant protection even when a site looks important, so the request can be refused more than once. It costs nothing to try again later — a refusal is never permanent, and nothing gets stuck.
+{% endhint %}
+
+## What protection does not cover
+
+Protecting your storage stops the browser from deleting oboku's data *on its own*. It does not stop:
+
+* you clearing site data or browsing data yourself,
+* uninstalling the app or deleting your browser profile,
+* the operating system wiping the browser.
+
+It also does not give oboku more space. Your quota is unchanged; only the deletion policy is.
+
+{% hint style="info" %}
+Protection is per browser and per device. Enabling it on your laptop does nothing for your tablet — you need to do it once on each device you read on.
+{% endhint %}

--- a/packages/shared/src/design.ts
+++ b/packages/shared/src/design.ts
@@ -10,6 +10,7 @@ export const links = {
   documentation: `https://docs.oboku.me`,
   documentationConnectors: `https://docs.oboku.me/guides/connectors`,
   documentationSecrets: `https://docs.oboku.me/secrets`,
+  documentationStorage: `https://docs.oboku.me/guides/storage`,
   app: `https://app.oboku.me`,
   site: `https://oboku.me`,
   linkedin: `https://www.linkedin.com/in/maxime-bret`,


### PR DESCRIPTION
## Why

Origin storage is **best-effort** by default, so the browser is free to evict oboku's entire bucket under disk pressure — the RxDB library, the Dexie `downloads` table and the covers cache all go together, since eviction is per-origin and all-or-nothing.

Most of that re-syncs from CouchDB on the next sign-in. Two things don't: **books uploaded straight from a device** (`PLUGIN_FILE_TYPE` stores the file locally with no datasource to re-fetch from) and any local change that hadn't replicated yet.

Nothing in the app ever called `navigator.storage.persist()`. Verified against production: `persisted()` returns `false` and the permission sits at `prompt`, so no user is currently protected.

## What

- **`storage/useIsStoragePersisted`** — query over `navigator.storage.persisted()`
- **`storage/useRequestStoragePersistence`** — mutation over `persist()`, invalidating the query on success
- **Manage storage row** — green shield when protected, red when evictable and tappable to request it, plus a refusal state and a "Read more" link
- **Inbox notification** while storage is evictable, linking to that screen
- **`gitbook/guides/storage.md`** — what it is, why it matters, how to fix it

## Notes for review

**The inbox notification cannot be dismissed, on purpose.** Chrome refuses `persist()` for most users in a plain tab, so the warning is permanent for them. That's deliberate: installing the app both satisfies Chrome's heuristics and clears the warning, so the nag and the fix are the same action. Revisit if users complain.

**`LocalNotificationCard` hardcoded `LoginRounded`**, which only worked while `session_expired` was the only local notification. The icon now comes from the notification's action; `session_expired` keeps its login icon, so nothing changes visually.

**No fallback for missing API.** `persist()`/`persisted()` are Baseline since Dec 2021 (Safari 15.2+), so there's no capability guard, per the repo's browser-support stance.

## Verification

`tsc` clean across web, shared and api. 46 files / 264 tests in web, 98 in shared. Biome clean.

**Not verified visually** — `/profile/manage-storage` and the inbox both need a signed-in session, so the two UIs are covered by tests and typecheck only. Worth a look before merge. Note that Chrome hard-denies on `localhost` (notifications are blocked there too), so the *granted* state is easiest to exercise in Firefox, which prompts and honours the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)