### PR TITLE
perf: compute search title once and hoist search regex in book search

### DIFF
--- a/apps/web/src/search/useBooksForSearch.ts
+++ b/apps/web/src/search/useBooksForSearch.ts
@@ -15,39 +15,35 @@ export const useBooksForSearch = (search: string) => {
     isNotInterested: notInterestedContents,
   })
 
-  const filteredBooks = useMemo(
-    () =>
-      visibleBooks
-        ?.filter((book) => {
-          const searchRegex = new RegExp(
-            search.replace(REGEXP_SPECIAL_CHAR, `\\$&`) || "",
-            "i",
-          )
+  const filteredBooks = useMemo(() => {
+    const searchRegex = new RegExp(
+      search.replace(REGEXP_SPECIAL_CHAR, `\\$&`) || "",
+      "i",
+    )
 
-          const metadata = book.metadata?.length
-            ? book.metadata
-            : [getMetadataFromBook(book)]
+    return (visibleBooks ?? [])
+      .filter((book) => {
+        const metadata = book.metadata?.length
+          ? book.metadata
+          : [getMetadataFromBook(book)]
 
-          return metadata?.some((item) => {
-            const { title } = item
+        return metadata?.some((item) => {
+          const { title } = item
 
-            if (!title) return false
+          if (!title) return false
 
-            const indexOfFirstMatch =
-              title?.toString()?.search(searchRegex) || 0
+          const indexOfFirstMatch = title?.toString()?.search(searchRegex) || 0
 
-            return indexOfFirstMatch >= 0
-          })
+          return indexOfFirstMatch >= 0
         })
-        .sort((a, b) =>
-          sortByTitleComparator(
-            getMetadataFromBook(a).title?.toString() ?? "",
-            getMetadataFromBook(b).title?.toString() ?? "",
-          ),
-        )
-        .map((item) => item._id),
-    [search, visibleBooks],
-  )
+      })
+      .map((book) => ({
+        book,
+        title: getMetadataFromBook(book).title?.toString() ?? "",
+      }))
+      .sort((a, b) => sortByTitleComparator(a.title, b.title))
+      .map(({ book }) => book._id)
+  }, [search, visibleBooks])
 
   return { data: filteredBooks }
 }


### PR DESCRIPTION
## Target

**Subsystem:** book/collection search (`apps/web/src/search/useBooksForSearch.ts`).

**User-visible symptom:** the search results memo recomputes on every keystroke over the *entire* library. On a large library this makes typing in search feel laggy, because each character re-runs the whole filter+sort pass with redundant per-book work.

This is the same class of hotspot that #510 fixed for the library alpha sort — `getMetadataFromBook` called inside a sort comparator — but the search path still carried it, plus an extra per-book regex compile.

## Changes (same subsystem)

Both are pure hoists/decorate-sort-undecorate; output and ordering are byte-for-byte identical (verified — see below).

1. **Hoist the search `RegExp` out of the `.filter` callback.** The regex depends only on `search`, which is constant for the whole pass, yet it was recompiled once per book. Mechanism: move it to a single compilation per memo run. Multiplier: **N books × every keystroke** → 1 compile per keystroke instead of N. (`String.prototype.search` ignores `lastIndex`/global flag, so reuse is safe.)

2. **Precompute each book's title once for the sort.** The comparator called the expensive `getMetadataFromBook` **twice per comparison** (~`2·n·log n` metadata merges — the merge does directive-regex extraction, priority `toSorted`, and reduce-with-spreads). Decorate-sort-undecorate computes the title once per book (`n` calls), turning `O(n·log n)` metadata merges into `O(n)`.

## Impact

Micro-benchmark with the real `getMetadataFromBook` at a realistic **3000-book** library (mean over 20×5 searches, outputs asserted identical to the old implementation across 5 different queries):

| | per search (per keystroke) |
|---|---|
| before | **149.3 ms** |
| after | **15.5 ms** |
| speedup | **~9.6×** |

The dominant win is the sort-comparator metadata merges (`O(n·log n)` → `O(n)`); the regex hoist removes `N-1` redundant compiles per keystroke on top.

Behavior note: previously the memo returned `undefined` while the underlying books query was loading; it now returns `[]`. Both consumers (`SearchScreenExpanded.tsx`, `pages/SearchScreen.tsx`) already destructure with `data: books = []`, so this is unobservable.

## Verification

- Equivalence: the benchmark asserts old vs new produce identical id lists across 5 queries before timing; no mismatch.
- Gates on a clean checkout (baseline) vs. this change: `pnpm lint` clean, `tsc -b` clean, `vitest run` unchanged (same 15 pre-existing `src/http/*` auth-refresh failures on both — unrelated to this change, untouched).

## Backlog (found, not taken this run)

- `useCollectionsForSearch.ts` calls `getCollectionComputedMetadata` **twice per comparison** in its sort — same decorate-sort-undecorate fix applies (smaller collection counts, so lower multiplier).
- `useLibraryBooks.ts` filter uses `filteredTags.includes(b)` inside a `.some` per book; fine for a few selected tags, but worth a `Set` if tag filters ever grow.
- `getMetadataFromBook` itself is the expensive unit repeatedly hit across list/search/detail paths; a per-book memo/cache keyed on `(metadata, metadataSourcePriority)` would benefit every caller at once.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTpoRzFz6L5YQ1MXtHE2Vf)_