### PR TITLE
refactor(api): consolidate synology-drive link session resolution

### DIFF
--- a/apps/api/src/plugins/synology-drive/index.ts
+++ b/apps/api/src/plugins/synology-drive/index.ts
@@ -1,5 +1,11 @@
-import { isCollectionOfType, PLUGIN_SYNOLOGY_DRIVE_TYPE } from "@oboku/shared"
+import {
+  isCollectionOfType,
+  type LinkWithCredentials,
+  PLUGIN_SYNOLOGY_DRIVE_TYPE,
+  type ProviderApiCredentials,
+} from "@oboku/shared"
 import { Logger } from "@nestjs/common"
+import type createNano from "nano"
 import {
   type DataSourcePlugin,
   MODIFIED_AT_UNSUPPORTED,
@@ -15,6 +21,37 @@ import {
 import { getDataSourceData } from "../helpers"
 
 const logger = new Logger("SynologyDrivePlugin")
+
+const openSynologyDriveSessionForLink = async ({
+  link,
+  providerCredentials,
+  db,
+}: {
+  link: LinkWithCredentials<"synology-drive">
+  providerCredentials: ProviderApiCredentials<"synology-drive">
+  db?: createNano.DocumentScope<unknown>
+}) => {
+  const connectorId = link.data?.connectorId
+  if (!connectorId || !providerCredentials || !db) {
+    throw new Error(
+      "Synology Drive credentials (password) and connector are required",
+    )
+  }
+  const connector = await getConnectorById(db, connectorId, "synology-drive")
+  if (!connector) {
+    throw new Error("Synology Drive connector not found")
+  }
+  const session = await getSynologyDriveSession({
+    connector: {
+      allowSelfSigned: connector.allowSelfSigned,
+      url: connector.url,
+      username: connector.username,
+    },
+    providerCredentials,
+  })
+
+  return { session, fileId: link.data.fileId }
+}
 
 export const dataSource: DataSourcePlugin<"synology-drive"> = {
   type: PLUGIN_SYNOLOGY_DRIVE_TYPE,
@@ -108,25 +145,11 @@ export const dataSource: DataSourcePlugin<"synology-drive"> = {
     }
   },
   getFileMetadata: async ({ link, providerCredentials, db }) => {
-    const connectorId = link.data?.connectorId
-    if (!connectorId || !providerCredentials || !db) {
-      throw new Error(
-        "Synology Drive credentials (password) and connector are required",
-      )
-    }
-    const connector = await getConnectorById(db, connectorId, "synology-drive")
-    if (!connector) {
-      throw new Error("Synology Drive connector not found")
-    }
-    const session = await getSynologyDriveSession({
-      connector: {
-        allowSelfSigned: connector.allowSelfSigned,
-        url: connector.url,
-        username: connector.username,
-      },
+    const { session, fileId } = await openSynologyDriveSessionForLink({
+      link,
       providerCredentials,
+      db,
     })
-    const { fileId } = link.data
     const metadata = await getSynologyDriveItemMetadata({
       fileId,
       session,
@@ -143,25 +166,11 @@ export const dataSource: DataSourcePlugin<"synology-drive"> = {
     }
   },
   getFolderMetadata: async ({ link, providerCredentials, db }) => {
-    const connectorId = link.data?.connectorId
-    if (!connectorId || !providerCredentials || !db) {
-      throw new Error(
-        "Synology Drive credentials (password) and connector are required",
-      )
-    }
-    const connector = await getConnectorById(db, connectorId, "synology-drive")
-    if (!connector) {
-      throw new Error("Synology Drive connector not found")
-    }
-    const session = await getSynologyDriveSession({
-      connector: {
-        allowSelfSigned: connector.allowSelfSigned,
-        url: connector.url,
-        username: connector.username,
-      },
+    const { session, fileId } = await openSynologyDriveSessionForLink({
+      link,
       providerCredentials,
+      db,
     })
-    const { fileId } = link.data
     const metadata = await getSynologyDriveItemMetadata({
       fileId,
       session,
@@ -173,25 +182,11 @@ export const dataSource: DataSourcePlugin<"synology-drive"> = {
     }
   },
   download: async (link, providerCredentials, db) => {
-    const connectorId = link.data?.connectorId
-    if (!connectorId || !providerCredentials || !db) {
-      throw new Error(
-        "Synology Drive credentials (password) and connector are required",
-      )
-    }
-    const connector = await getConnectorById(db, connectorId, "synology-drive")
-    if (!connector) {
-      throw new Error("Synology Drive connector not found")
-    }
-    const session = await getSynologyDriveSession({
-      connector: {
-        allowSelfSigned: connector.allowSelfSigned,
-        url: connector.url,
-        username: connector.username,
-      },
+    const { session, fileId } = await openSynologyDriveSessionForLink({
+      link,
       providerCredentials,
+      db,
     })
-    const { fileId } = link.data
 
     return downloadSynologyDriveStream({
       fileId,


### PR DESCRIPTION
## What was duplicated

In `apps/api/src/plugins/synology-drive/index.ts`, three methods of the `synology-drive` data source plugin — `getFileMetadata`, `getFolderMetadata`, and `download` — each opened with a byte-for-byte identical ~18-line preamble:

1. read `link.data?.connectorId`
2. throw `"Synology Drive credentials (password) and connector are required"` when connectorId / providerCredentials / db are missing
3. load the connector via `getConnectorById`, throw `"Synology Drive connector not found"` if absent
4. open a session with `getSynologyDriveSession({ connector: { allowSelfSigned, url, username }, providerCredentials })`
5. destructure `{ fileId }` from `link.data`

This was flagged by `jscpd` as the largest intra-file duplication in the package (123 / 98-token clones between the three blocks).

## What it became

A single module-level helper `openSynologyDriveSessionForLink({ link, providerCredentials, db })` that performs the validation + session setup and returns `{ session, fileId }`. The three methods now call it and keep only their method-specific logic (metadata mapping / stream download).

The helper's `link` parameter is typed `LinkWithCredentials<"synology-drive">` (which is `Pick<LinkDocTypeForProvider<T>, "type" | "data">`), so `download`'s richer `LinkDocTypeForProvider<"synology-drive">` argument is assignable without any cast.

## Why these are truly the same concept

All three call sites need exactly one thing before doing their work: an authenticated Synology Drive session for the link's connector, plus the link's `fileId`. The preamble is not incidentally similar — it is the same "resolve a session for this link" operation, with identical validation and identical error messages. `sync` is intentionally left untouched: it resolves its connector from the datasource (not a link), validates differently, and logs progress, so it is a different concept.

## Net LOC

`1 file changed, 47 insertions(+), 52 deletions(-)` — net −5 lines, eliminating ~36 lines of duplicated logic (two redundant copies of the 18-line preamble); the added lines are the extracted helper's explicit parameter types.

## Behavior preservation

Pure mechanical extraction — same validation order, same error messages, same session construction, same return values. No public API, return-shape, ordering, or logging changes.

## Gates

Run against a clean `develop` baseline (Node 22 locally; CI pins 25):

- `tsc -p apps/api/tsconfig.build.json --noEmit` — 0 errors, matches baseline
- `biome check` on the changed file — clean
- `apps/api` jest suite — 19/19 suites, 122/122 tests pass

## Other candidates considered and skipped

Recorded for future runs of this sweep — each was rejected as not a behavior-preserving duplicate:

- `migrateResourceIdToData` in `apps/api/.../migration.service.ts` vs `apps/web/src/rxdb/collections/utils.ts` — share the switch body but have **divergent contracts**: the api version returns `null` for `file`/unknown types (load-bearing at its `if (!newData) continue` call site) while the web version returns the base object and its test suite asserts that. Unifying would require a mode flag.
- Web plugin `UpsertFile` (dropbox vs one-drive) and `FileBrowseStep` (server vs webdav) — the shared parts are per-plugin scaffolding whose auth/upload internals evolve independently; the webdav/server file-browse step is already partly consolidated by the maintainer.
- `BookDanglingCollections` vs `BookDanglingLinks` — differ only in user-facing copy (content, kept separate per repo guidance).
- `useRepair.ts` (web) has three near-identical rxjs "remove dangling references" pipes — a viable follow-up consolidation, deferred to keep this PR a single coherent story.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SiouS4DW4vVoe9wfNAN761)_