### PR TITLE
fix(docker): copy scripts into the install stage

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -10,6 +10,7 @@ FROM node-pnpm AS base
 WORKDIR /usr/src/app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml lerna.json nx.json ./
 COPY patches ./patches
+COPY scripts ./scripts
 COPY packages ./packages
 COPY config ./config
 COPY apps/api/package.json ./apps/api/package.json


### PR DESCRIPTION
## Problem

All four image builds on `develop` are failing at `dockerfile:19` (`RUN pnpm install --frozen-lockfile`):

```
Error: Cannot find module '/usr/src/app/scripts/check-dexie-version.mjs'
    at Function._load (node:internal/modules/cjs/loader:1192:37)
  code: 'MODULE_NOT_FOUND',
  requireStack: []
```

#524 added a root `postinstall` hook (`node scripts/check-dexie-version.mjs`) without updating the Dockerfile. The `base` stage deliberately copies only the workspace manifests plus `patches`, `packages`, and `config` — never `scripts/` — so `pnpm install` reached the postinstall hook with no file to run.

Because every app stage builds on `base`, api / web / admin / couchdb all failed identically, and the amd64 and arm64 legs cancelled each other. The non-Docker jobs (`check.yml`, the Vercel deploy) were unaffected since they run from a full `actions/checkout` tree, which is why this only showed up in the image builds.

## Fix

One line added to the `base` stage:

```dockerfile
COPY patches ./patches
COPY scripts ./scripts
COPY packages ./packages
```

The `api`, `web-build`, and `admin-build` stages all do `COPY --from=base /usr/src/app .`, so they inherit `scripts/` and need no change. This is the only Dockerfile in the repo that runs `pnpm install`.

## Verification

The guard now actually executes inside the image, where `apps/web/node_modules` is populated — so the relevant risk was trading one build failure for another. Against the lockfile it passes: `rxdb@17.4.0` resolves `dexie: 4.4.2` (`pnpm-lock.yaml:24213`) and `apps/web/package.json` pins `"dexie": "4.4.2"`, so the two agree and the check exits 0. The `../dexie` sibling lookup also holds under pnpm's layout, since `dexie` is a direct dependency of `rxdb` in the same `.pnpm` directory.

No Docker daemon was available in the working environment, so the failure mode itself was reproduced by running the postinstall command from a directory without the script — the stack trace matches the CI log line for line (`Module._load` → `wrapModuleLoad` → `executeUserEntryPoint` → `run_main_module:33:47`, `requireStack: []`). The green image builds on this PR are the real confirmation.

## Note on the approach

Fixing the Dockerfile was chosen over making the postinstall tolerate its own absence, so the duplicate-Dexie guard stays enforced during image builds — that being where a drifting `dexie` pin would otherwise ship silently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S828yJM3UYrYT8CoGsdtxu)_