### PR TITLE
chore: remove strict dead code (unused exports)

### DIFF
--- a/apps/api/src/lib/couch/dbHelpers.ts
+++ b/apps/api/src/lib/couch/dbHelpers.ts
@@ -1,11 +1,10 @@
-import createNano, { type MangoResponse, type RequestError } from "nano"
+import createNano, { type RequestError } from "nano"
 import {
   type SafeMangoQuery,
   type InsertAbleBookDocType,
   ReadingStateState,
   type DocType,
   type ModelOf,
-  type DataSourceDocType,
   type SettingsDocType,
   isShallowEqual,
 } from "@oboku/shared"
@@ -141,16 +140,6 @@ export const insert = async <
   if (!doc.ok) throw new Error("Unable to create document")
 
   return doc
-}
-
-export const findAllDataSources = async (
-  db: createNano.DocumentScope<unknown>,
-) => {
-  return db.find({
-    selector: {
-      rx_model: "datasource",
-    },
-  }) as Promise<MangoResponse<DataSourceDocType>>
 }
 
 /** Fetches the singleton settings document. Returns null if missing or on error. */

--- a/apps/api/src/lib/google/googleBooksApi.ts
+++ b/apps/api/src/lib/google/googleBooksApi.ts
@@ -109,25 +109,3 @@ export const findByVolumeId = async (
 
   throw new Error(`An error occurred during findByISBN`)
 }
-
-export const findSeriesByTitle = async (
-  name: string,
-  apiKey: string,
-  config: AppConfigService,
-) => {
-  const response = await performWithBackoff({
-    asyncFunction: () =>
-      axios.get<GoogleBooksApiVolumesResponseData>(
-        `${config.config.getOrThrow("GOOGLE_BOOK_API_URL", { infer: true })}/volumes?q=intitle:${name}&key=${apiKey}`,
-      ),
-    retry: isRetryableGoogleBooksError,
-  })
-
-  if (response.status === 200) {
-    // Logger.info(`google findByName response`, response.data)
-
-    return response.data
-  }
-
-  throw new Error(`An error occurred during findByISBN`)
-}

--- a/apps/api/src/lib/utils.ts
+++ b/apps/api/src/lib/utils.ts
@@ -129,13 +129,6 @@ export const onBeforeError =
       ),
     )
 
-export const switchMapMergeOuter = <T, R>(
-  project: (value: T) => Observable<R>,
-) =>
-  switchMap((outer: T) =>
-    project(outer).pipe(map((inner) => ({ ...outer, ...inner }))),
-  )
-
 export const switchMapCombineOuter = <T, R>(
   project: (value: T) => Observable<R>,
 ) =>

--- a/apps/web/src/collections/dbHelpers.ts
+++ b/apps/web/src/collections/dbHelpers.ts
@@ -9,12 +9,6 @@ export const getCollectionById = (database: Database, id: string) => {
   )
 }
 
-export const getCollections = async (database: Database) => {
-  const result = await database.collections.obokucollection.find({}).exec()
-
-  return result
-}
-
 export const observeEmptyCollection = ({
   db,
   id,

--- a/apps/web/src/reader/states.ts
+++ b/apps/web/src/reader/states.ts
@@ -1,5 +1,4 @@
-import { filter, switchMap } from "rxjs"
-import { isDefined, signal, useQuery$, useSignalValue } from "reactjrx"
+import { signal, useSignalValue } from "reactjrx"
 import type { createAppReader } from "./useCreateReader"
 
 type ReaderInstance = ReturnType<typeof createAppReader>
@@ -12,23 +11,9 @@ export const useReader = () => {
   return useSignalValue(readerSignal)
 }
 
-export const reader$ = readerSignal.pipe(filter(isDefined))
-
 export const isMenuShownStateSignal = signal({
   key: "isMenuShownState",
   default: false,
 })
 
 // =======> Please do not forget to add atom to the reset part !
-
-export const usePagination = () =>
-  useQuery$({
-    queryKey: ["pagination"],
-    networkMode: "always",
-    queryFn: () => {
-      return readerSignal.pipe(
-        filter(isDefined),
-        switchMap((reader) => reader.pagination.state$),
-      )
-    },
-  })

--- a/apps/web/src/tags/helpers.ts
+++ b/apps/web/src/tags/helpers.ts
@@ -8,7 +8,6 @@ import {
   RXDB_QUERY_KEY_PREFIX,
 } from "../queries/queryClient"
 import { getLatestDatabase, latestDatabase$ } from "../rxdb/RxDbProvider"
-import type { Database } from "../rxdb"
 import type { DeepReadonlyObject, MangoQuery } from "rxdb"
 import { useMutation, type UseQueryOptions } from "@tanstack/react-query"
 
@@ -57,31 +56,6 @@ const protectedTags$ = tags$.pipe(
   map((tag) => tag.filter(({ isProtected }) => isProtected)),
 )
 
-/**
- * @deprecated move to observable
- */
-export const getProtectedTags = async (db: Database) => {
-  const result = await db.tag.find({}).exec()
-
-  return result.filter(({ isProtected }) => isProtected).map(({ _id }) => _id)
-}
-
-/**
- * @deprecated move to observable
- */
-export const getTagsByIds = async (db: Database) => {
-  const result = await db.tag.find({}).exec()
-
-  return result.reduce(
-    (acc, tag) => {
-      acc[tag._id] = tag
-
-      return acc
-    },
-    {} as Record<string, TagsDocType>,
-  )
-}
-
 export const useTag = <TData = DeepReadonlyObject<TagsDocType> | null>(
   id?: string,
   options: Omit<
@@ -121,25 +95,6 @@ export const useTags = ({
         map((items) => items.map((item) => item.toJSON())),
       ),
     ...options,
-  })
-
-export const useTagsByIds = () =>
-  useQuery$({
-    ...createRxdbQueryDefaultOptions(),
-    queryKey: [RXDB_QUERY_KEY_PREFIX, "tagsById"],
-    queryFn: () =>
-      tags$.pipe(
-        map((tags) =>
-          tags.reduce(
-            (acc, tag) => {
-              acc[tag._id] = tag
-
-              return acc
-            },
-            {} as Record<string, DeepReadonlyObject<TagsDocType>>,
-          ),
-        ),
-      ),
   })
 
 export const useTagIds = () =>


### PR DESCRIPTION
Automated dead-code sweep. Removes exports flagged by `knip` and confirmed by a repo-wide grep to be **strict dead code** — each symbol appears only at its own declaration, with no static import, dynamic `import()`, string/URL, worker, config, or test reference anywhere in the repo.

### Removed (evidence: grep for the symbol name across `apps/`, `packages/`, `config/`, `scripts/`, `gitbook/` returned only its own declaration line)

| File | Symbol | Notes |
|------|--------|-------|
| `apps/web/src/tags/helpers.ts` | `getProtectedTags` | `@deprecated`, never called |
| `apps/web/src/tags/helpers.ts` | `getTagsByIds` | `@deprecated`, never called |
| `apps/web/src/tags/helpers.ts` | `useTagsByIds` | hook never used |
| `apps/web/src/reader/states.ts` | `reader$` | never imported |
| `apps/web/src/reader/states.ts` | `usePagination` | hook never used |
| `apps/web/src/collections/dbHelpers.ts` | `getCollections` | never imported |
| `apps/api/src/lib/utils.ts` | `switchMapMergeOuter` | never used (sibling `switchMapCombineOuter` is used) |
| `apps/api/src/lib/google/googleBooksApi.ts` | `findSeriesByTitle` | never called (`GoogleBooksApiVolumesResponseData` stays, still used elsewhere) |
| `apps/api/src/lib/couch/dbHelpers.ts` | `findAllDataSources` | never called |

Also dropped the now-orphaned type/operator imports these symbols were the sole users of: `Database` (tags/helpers), `MangoResponse` + `DataSourceDocType` (couch/dbHelpers), and `filter`/`switchMap`/`isDefined`/`useQuery$` (reader/states).

### Deliberately left in (knip flagged, but not strict dead code)
- `createUser` (couch/dbHelpers) and `getDataSourcePlugin` (dataSources/helpers) — unused *export* but referenced internally within their own file.
- `getConnectorIdsWithSameServer`, `WithAdminUser`/`AdminUser`, and the `plugins/types.ts` type surface — documented/speculative API surface (e.g. JSDoc claiming cross-provider use, NestJS param decorator), kept per the sweep's "when in doubt, leave it in" rule.
- All knip-flagged "unused files" — every one is actually referenced via vite config, `new Worker(new URL())`, an HTML auth-callback, `public/` runtime assets, or `App.tsx`. False positives; untouched.
- Dependency changes — none. No whole feature/file was removed, so no manifest dependency became unreferenced.

### Gates
- `biome check .` (lint) — passes.
- `apps/web` `tsc -b` — passes.
- `apps/api` `nest build` — passes (after building the `@oboku/*` workspace libs, as CI does).
- No test file references any removed symbol.

net: **+2 / −108 lines** across 6 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Xb8Rr8xPgnjmexMzNbZBW

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xb8Rr8xPgnjmexMzNbZBW)_