### PR TITLE
perf(web): linearize covers cache cleanup passes

### DIFF
--- a/apps/web/src/covers/helpers.shared.ts
+++ b/apps/web/src/covers/helpers.shared.ts
@@ -21,21 +21,3 @@ export const getMetadataFromRequest = (request: Request) => {
     coverTimeCached,
   }
 }
-
-export const hasAnotherMoreRecentCoverForThisRequest = (
-  request: Request,
-  requests: readonly Request[],
-) => {
-  const { coverId, coverTimeCached } = getMetadataFromRequest(request)
-
-  return requests.find((key) => {
-    const { coverId: itemCoverId, coverTimeCached: existingCoverTimeCached } =
-      getMetadataFromRequest(key)
-
-    return (
-      key.url !== request.url &&
-      itemCoverId === coverId &&
-      existingCoverTimeCached > coverTimeCached
-    )
-  })
-}

--- a/apps/web/src/covers/registerCoversCacheCleanup.sw.ts
+++ b/apps/web/src/covers/registerCoversCacheCleanup.sw.ts
@@ -7,11 +7,7 @@ import {
   lastValueFrom,
 } from "rxjs"
 import { createSwDatabase } from "../rxdb/db.sw"
-import {
-  getMetadataFromRequest,
-  hasAnotherMoreRecentCoverForThisRequest,
-  SW_COVERS_CACHE_KEY,
-} from "./helpers.shared"
+import { getMetadataFromRequest, SW_COVERS_CACHE_KEY } from "./helpers.shared"
 import { Logger } from "../debug/logger.shared"
 import { coalesce } from "../workers/coalesce"
 
@@ -48,14 +44,14 @@ const runCleanup = async (profile: string | undefined): Promise<unknown> => {
                     return clearAllCovers()
                   }
 
+                  const idsInDb = new Set<string>()
+                  for (const { _id } of bookDocs) idsInDb.add(_id)
+                  for (const { _id } of collectionDocs) idsInDb.add(_id)
+
                   const cacheKeysNotInDb = cacheKeys.filter((key) => {
                     const { coverId } = getMetadataFromRequest(key)
 
-                    const coverFoundInDb =
-                      bookDocs.some(({ _id }) => _id === coverId) ||
-                      collectionDocs.some(({ _id }) => _id === coverId)
-
-                    return !coverFoundInDb
+                    return !idsInDb.has(coverId)
                   })
 
                   if (cacheKeysNotInDb.length) {
@@ -86,9 +82,27 @@ const runCleanup = async (profile: string | undefined): Promise<unknown> => {
     switchMap((cache) =>
       from(cache.keys()).pipe(
         switchMap((keys) => {
-          const keysToRemoveDueToNewerVersion = keys.filter((item) =>
-            hasAnotherMoreRecentCoverForThisRequest(item, keys),
-          )
+          const latestTimeByCoverId = new Map<string, number>()
+          const keyMetadata = keys.map((request) => {
+            const { coverId, coverTimeCached } = getMetadataFromRequest(request)
+            const latestCoverTime = latestTimeByCoverId.get(coverId)
+
+            if (
+              latestCoverTime === undefined ||
+              coverTimeCached > latestCoverTime
+            ) {
+              latestTimeByCoverId.set(coverId, coverTimeCached)
+            }
+
+            return { request, coverId, coverTimeCached }
+          })
+
+          const keysToRemoveDueToNewerVersion = keyMetadata
+            .filter(
+              ({ coverId, coverTimeCached }) =>
+                coverTimeCached < (latestTimeByCoverId.get(coverId) ?? 0),
+            )
+            .map(({ request }) => request)
 
           return from(
             Promise.all(


### PR DESCRIPTION
## Target

**Subsystem:** the service-worker covers cache cleanup (`apps/web/src/covers/registerCoversCacheCleanup.sw.ts`).

**User-visible symptom:** this cleanup runs on the service-worker thread every 10 minutes and again on startup (`ServiceWorkerBackgroundTasks` → `SwTask.CoversCacheCleanup`). The service worker is the same thread that serves every cover fetch for the library, so a slow cleanup pass contends with cover loading. The work was super-linear in the number of cached covers, which grows with library size × how many times each book's metadata (and therefore its cover hash/url) has been refreshed.

## Changes

Two passes over the cover cache keys, both made linear. Each request's headers are now parsed once instead of repeatedly, and both passes were verified to produce **byte-for-byte identical removal sets** (see benchmark parity checks below) — behavior is unchanged, only speed.

| Change | Mechanism | Scale multiplier |
| --- | --- | --- |
| Obsolete-cover detection (`cacheKeysNotInDb`) | Replaced per-key `bookDocs.some(...) \|\| collectionDocs.some(...)` membership test with a single `Set` of book+collection ids. | `O(cacheKeys × (books + collections))` → `O(cacheKeys + books + collections)`. |
| Outdated-version detection (`keysToRemoveDueToNewerVersion`) | Replaced the pairwise `keys.filter(k => hasAnotherMoreRecentCoverForThisRequest(k, keys))` (which re-parsed headers on every comparison) with a single "max `coverTimeCached` per `coverId`" map, then a linear filter. | `O(cacheKeys²)` → `O(cacheKeys)`. |

The now-unused `hasAnotherMoreRecentCoverForThisRequest` helper (its only caller) is removed from `helpers.shared.ts`.

### Semantics preserved

The old outdated-version rule removed a key iff another key with the **same `coverId`**, a **different url**, and a **strictly greater `coverTimeCached`** existed. Since a Cache entry is keyed by url, a strictly-greater time necessarily belongs to a different url, so "remove iff the key's time is below the max time for its `coverId`" is exactly equivalent — including the tie-at-max case (ties are kept under both).

## Measured impact

Pure-logic benchmark (`node`, faithful `Request`-header emulation) at a realistic heavy-library scale — 1000 books × 2 cached cover versions + 200 orphan covers = 2200 cache entries, 100 collections:

```
outdated-pass identical output: true (removes 1000)
not-in-db-pass identical output: true (removes 200)

outdated pass  OLD (O(n^2)): 106.42 ms
outdated pass  NEW (O(n))  :   0.307 ms   (~350x)
not-in-db pass OLD (O(n*m)):   5.58 ms
not-in-db pass NEW (O(n+m)):   0.176 ms   (~30x)
```

The quadratic pass dominates and degrades further as the cache grows (seconds at larger caches); the new passes stay flat. This removes a recurring multi-hundred-millisecond stall from the cover-serving thread for large libraries.

## Gates

- `biome check .` — clean (only pre-existing warnings in unrelated files).
- `tsc -b` (apps/web) — passes.
- `vite build` (apps/web) — passes; `service-worker.js` emitted.
- `vitest run` (apps/web) — 204 passed / 37 failed, **identical to the baseline on `develop`** (the 37 failures are pre-existing, environment-related — `navigator.locks` undefined and one-drive/http mocks — none touch covers). No new failures introduced.

## Backlog (other perf opportunities found, not taken)

- `sortBooksBy` "activity" branch (`apps/web/src/books/helpers.ts`) allocates a `new Date(...)` twice per comparison — `O(n log n)` Date allocations. The "alpha" branch already precomputes its sort key; "activity" could do the same (precompute epoch ms once per book). Lower priority — bounded by library size, not by a periodic multiplier.
- `useLibraryBooks` filter (`apps/web/src/library/books/useLibraryBooks.ts`) does `filteredTags.includes(b)` inside `book.tags.some(...)` inside a `.filter` over all books; fine while `filteredTags` is tiny but could be a `Set` if tag filters ever grow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNbzoWKvYxCqMT7PLKPTHQ)_