### PR TITLE
fix(api): attach all missing tags to a book when some are already present

### DIFF
--- a/apps/api/src/lib/couch/dbHelpers.spec.ts
+++ b/apps/api/src/lib/couch/dbHelpers.spec.ts
@@ -1,0 +1,88 @@
+import type createNano from "nano"
+import { addTagsToBookIfNotExist } from "./dbHelpers"
+
+type StoredDoc = {
+  _id: string
+  _rev: string
+  rx_model: "book" | "tag"
+  tags?: string[]
+  books?: string[]
+}
+
+const createFakeDb = (docs: StoredDoc[]) => {
+  const store = new Map(docs.map((doc) => [doc._id, doc]))
+  const inserted: StoredDoc[] = []
+
+  const fakeDb = {
+    get: async (id: string) => {
+      const doc = store.get(id)
+      if (!doc) throw new Error(`missing doc ${id}`)
+      return { ...doc }
+    },
+    insert: async (doc: StoredDoc) => {
+      inserted.push(doc)
+      store.set(doc._id, doc)
+      return { ok: true, id: doc._id, rev: `${doc._rev}-next` }
+    },
+    // Only get/insert are exercised by atomicUpdate; nano's full
+    // DocumentScope surface is irrelevant to these tests.
+  } as unknown as createNano.DocumentScope<unknown>
+
+  return { fakeDb, inserted, store }
+}
+
+describe("addTagsToBookIfNotExist", () => {
+  it("adds the missing tags when the book already has one of them", async () => {
+    const { fakeDb, inserted, store } = createFakeDb([
+      { _id: "book-1", _rev: "1", rx_model: "book", tags: ["tag-existing"] },
+      {
+        _id: "tag-existing",
+        _rev: "1",
+        rx_model: "tag",
+        books: ["book-1"],
+      },
+      { _id: "tag-new", _rev: "1", rx_model: "tag", books: [] },
+    ])
+
+    await addTagsToBookIfNotExist(fakeDb, "book-1", ["tag-existing", "tag-new"])
+
+    expect(store.get("book-1")?.tags).toEqual(["tag-existing", "tag-new"])
+    expect(store.get("tag-new")?.books).toEqual(["book-1"])
+    expect(inserted.filter((doc) => doc._id === "tag-existing")).toHaveLength(0)
+  })
+
+  it("does not write the book when it already has every tag", async () => {
+    const { fakeDb, inserted } = createFakeDb([
+      {
+        _id: "book-1",
+        _rev: "1",
+        rx_model: "book",
+        tags: ["tag-a", "tag-b"],
+      },
+      { _id: "tag-a", _rev: "1", rx_model: "tag", books: ["book-1"] },
+      { _id: "tag-b", _rev: "1", rx_model: "tag", books: ["book-1"] },
+    ])
+
+    const [bookUpdate] = await addTagsToBookIfNotExist(fakeDb, "book-1", [
+      "tag-a",
+      "tag-b",
+    ])
+
+    expect(bookUpdate).toBeNull()
+    expect(inserted).toHaveLength(0)
+  })
+
+  it("adds every tag to a book that has none of them", async () => {
+    const { fakeDb, store } = createFakeDb([
+      { _id: "book-1", _rev: "1", rx_model: "book", tags: [] },
+      { _id: "tag-a", _rev: "1", rx_model: "tag", books: [] },
+      { _id: "tag-b", _rev: "1", rx_model: "tag", books: [] },
+    ])
+
+    await addTagsToBookIfNotExist(fakeDb, "book-1", ["tag-a", "tag-b"])
+
+    expect(store.get("book-1")?.tags).toEqual(["tag-a", "tag-b"])
+    expect(store.get("tag-a")?.books).toEqual(["book-1"])
+    expect(store.get("tag-b")?.books).toEqual(["book-1"])
+  })
+})

--- a/apps/api/src/lib/couch/dbHelpers.ts
+++ b/apps/api/src/lib/couch/dbHelpers.ts
@@ -219,7 +219,7 @@ export const addTagsToBookIfNotExist = async (
 
   const [bookUpdate, tagUpdate] = await Promise.all([
     atomicUpdate(db, "book", bookId, (old) => {
-      const tags = old.tags.find((tag) => tagIds.includes(tag))
+      const tags = tagIds.every((tagId) => old.tags.includes(tagId))
         ? old.tags
         : [...old.tags.filter((tag) => !tagIds.includes(tag)), ...tagIds]
 


### PR DESCRIPTION
## The bug

`addTagsToBookIfNotExist` (`apps/api/src/lib/couch/dbHelpers.ts`) skipped the **book-side** write whenever *any one* of the requested tag ids was already on the book:

```ts
const tags = old.tags.find((tag) => tagIds.includes(tag)) // "any overlap?"
  ? old.tags                                              // → keep everything as-is
  : [...old.tags.filter((tag) => !tagIds.includes(tag)), ...tagIds]
```

Meanwhile the **tag-side** write in the same function has a correct per-item check and still goes through, so the two halves of the bidirectional book↔tag link diverge.

### How to observe it

Sync a datasource whose items carry tags `[T1, T2]` against a book that already has `T1` (e.g. the user added `T2` to the datasource after the first sync, or the book picked up `T1` from a folder directive earlier):

1. Book side: `old.tags.find(...)` finds `T1` → returns `old.tags` unchanged. Since `atomicUpdate` compares with `isShallowEqual` and the array reference is identical, **no write is issued at all**.
2. Tag side: `T2.books` gains the book id → written.

Result: `T2.books` lists the book forever, but `book.tags` never receives `T2`. This never self-heals — `updateTagsForBook`'s `someNewTagsDoesNotExistYet` stays true on every subsequent sync and the same no-op repeats.

Beyond the inconsistency, this has a privacy impact: `isBookProtected` reads `book.tags`, so when the never-attached tag is a protected one (`isProtected: true`), the book is treated as unprotected and `retrieveMetadataAndSaveCover` ships its title/ISBN to external metadata providers — exactly what the protected-tag gate is documented to prevent. `isCollectionProtected` is bypassed the same way.

## Root cause

The bail-out condition tested "does the book already have *at least one* of these tags" instead of "does the book already have *all* of these tags".

## The fix

```ts
const tags = tagIds.every((tagId) => old.tags.includes(tagId))
  ? old.tags
  : [...old.tags.filter((tag) => !tagIds.includes(tag)), ...tagIds]
```

One line: bail out (keeping the same array reference so `atomicUpdate` skips the write) only when every requested tag is already present; otherwise merge. The tag-side logic is untouched.

## Verification

- New regression test `apps/api/src/lib/couch/dbHelpers.spec.ts` drives `addTagsToBookIfNotExist` against a fake nano scope. Before the fix, the key case fails exactly as traced (book keeps `["tag-existing"]`, while `tag-new.books` gains the book); after the fix all three cases pass:
  - adds the missing tags when the book already has one of them (the regression)
  - does not write the book when it already has every tag (no-op preserved)
  - adds every tag to a book that has none of them
- `pnpm lint` ✅ and `pnpm build` ✅
- `pnpm test`: the api jest suite passes; the only failures are the pre-existing `@oboku/web` vitest failures (`navigator.locks` undefined in the test environment, present on a clean `develop` checkout before this change — baseline 37 failures, now a strict subset of 15 after a full build).

## Other findings (not addressed in this PR)

Confirmed with concrete traces during this hunt, left for follow-ups:

- **`bulkDelete` omits `_rev`** (`apps/api/src/lib/couch/bulkDelete.ts`): CouchDB `_bulk_docs` returns per-doc `conflict` errors inside a 201 response, so dangling-link deletion silently no-ops — `deleteDanglingLinks` reports links as deleted while they survive forever.
- **Book stuck in `metadataUpdateStatus: "fetching"`** (`apps/api/src/books/books-metadata.service.ts`): the "unable to find link" throw sits *outside* the try/catch that resets the status, so a book whose first link is missing keeps a permanent "fetching" badge and the UI disables retry.
- **Manage-storage flags protected books' downloads as "extra files"** (`apps/web/src/pages/profile/manage-storage/ManageStorageScreen.tsx`): the extra-downloads diff uses the lock-filtered `useBooks()` query instead of `partitionDownloadedBooks(db)`, so with the library locked, downloads of protected books are offered for deletion (unrecoverable for `file`-plugin books).
- **`useFixableLinks` reports every link as dangling while books are still loading** (`apps/web/src/problems/useFixableLinks.ts`): `unsafeBooks?.reduce(...) ?? []` collapses "not loaded" into "no links used"; the repair action would `bulkRemove` every link document.
- **Adjacent filename directives are mis-parsed** (`packages/shared/src/directives.ts`): `"[oboku~tags~a][oboku~ignore]"` (no space) parses to the garbage tag `a[oboku~ignore]` and drops `ignore`, because the `(...)+` match is stripped with non-global replaces; `removeDirectiveFromString` handles the same input correctly. Uppercase `[OBOKU~...]` is matched (`i` flag) but never parsed (case-sensitive strip).
- **`toSynologyDriveModifiedAt("")` fabricates the Unix epoch** (`packages/synology/src/client.ts`): `Number("")` is `0`, so blank provider values become `1970-01-01T00:00:00.000Z`, violating the `modifiedAt` contract in `packages/shared/src/metadata/index.ts` ("real timestamp or omit") that guards re-download caching.
- **Cover endpoint hardcodes `Content-Type: image/webp`** (`apps/api/src/covers/covers.controller.ts`): `?format=image/jpeg` encodes JPEG bytes but advertises webp, and the mislabelled response is cached for a year.
- **`formatBytes` emits `1000.0 KB`** (`packages/shared/src/utils/formatBytes.ts`): the unit bucket is chosen on the unrounded value, so e.g. `999999` renders as `1000.0 KB` instead of `1.0 MB`.
- **`is()` drops the NaN case of `Object.is`** (`packages/shared/src/utils/objects.ts`): `isShallowEqual({a: NaN}, {a: NaN})` is `false`, making NaN-valued docs re-emit/re-write on every comparison pass.
- **`repairCollectionBooks` treats the `limit: 999` truncation as dangling** (`apps/api/src/lib/sync/collections/repairCollectionBooks.ts`): collections with >999 books get real members written out, then re-added next sync, oscillating membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eTuTgDgdGpcxjxsCc7Bsp

---
_Generated by [Claude Code](https://claude.ai/code/session_014eTuTgDgdGpcxjxsCc7Bsp)_