### PR TITLE
ci: stop semantic-release from commenting on released PRs

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -30,6 +30,12 @@ export default {
         message: "chore: release v${nextRelease.version}",
       },
     ],
-    "@semantic-release/github",
+    [
+      "@semantic-release/github",
+      {
+        successComment: false,
+        releasedLabels: false,
+      },
+    ],
   ],
 }


### PR DESCRIPTION
Follow-up to #531. The `@semantic-release/github` plugin's default `successComment` posts "This PR is included in version X" on every PR whose commits are part of a release, and `releasedLabels` adds a `released` label to each. The first release (`v1.2.0`) analyzed everything since `v1.1.0`, so it swept through months of merged PRs in one run.

Both behaviors are now disabled. Future releases would only have touched the handful of PRs in their own range, but the notifications add nothing — the release page already lists the commits.

The `failComment` default is kept: if a release run fails, semantic-release opens a single "The automated release is failing" issue, which is useful signal for a background job.

Note this takes effect on the next develop → master merge, since master runs the release with the config it carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X91x1vJ1CJ45Gwk9WmrFaa

---
_Generated by [Claude Code](https://claude.ai/code/session_01X91x1vJ1CJ45Gwk9WmrFaa)_