### PR TITLE
perf(web): scope download-state subscriptions to what each consumer reads

### DIFF
--- a/apps/web/src/download/states.ts
+++ b/apps/web/src/download/states.ts
@@ -1,7 +1,6 @@
-import type { BookDocType } from "@oboku/shared"
-import { useMemo } from "react"
+import { isShallowEqual } from "@oboku/shared"
+import { useCallback } from "react"
 import { signal, useSignalValue } from "reactjrx"
-import type { DeepReadonlyObject } from "rxdb"
 
 export enum DownloadState {
   None = "none",
@@ -9,17 +8,17 @@ export enum DownloadState {
   Downloading = "downloading",
 }
 
-export const booksDownloadStateSignal = signal<
-  Record<
-    string,
-    | {
-        downloadState?: DownloadState
-        downloadProgress?: number
-        size?: number
-      }
-    | undefined
-  >
->({
+export type BooksDownloadState = Record<
+  string,
+  | {
+      downloadState?: DownloadState
+      downloadProgress?: number
+      size?: number
+    }
+  | undefined
+>
+
+export const booksDownloadStateSignal = signal<BooksDownloadState>({
   key: "bookDownloadsState",
   default: {},
 })
@@ -29,15 +28,7 @@ const mapBookDownloadState = ({
   bookDownloadState,
 }: {
   bookId: string
-  bookDownloadState: Record<
-    string,
-    | {
-        downloadState?: DownloadState
-        downloadProgress?: number
-        size?: number
-      }
-    | undefined
-  >
+  bookDownloadState: BooksDownloadState
 }) => {
   return {
     downloadState: DownloadState.None,
@@ -57,31 +48,15 @@ export const getBookDownloadsState = ({ bookId }: { bookId: string }) => {
 }
 
 export const useBookDownloadState = (bookId?: string | null) => {
-  const bookDownloadState = useSignalValue(booksDownloadStateSignal)
+  const selectBookDownloadState = useCallback(
+    (bookDownloadState: BooksDownloadState) =>
+      bookId ? mapBookDownloadState({ bookId, bookDownloadState }) : undefined,
+    [bookId],
+  )
 
-  if (!bookId) return undefined
-
-  return mapBookDownloadState({ bookId, bookDownloadState })
-}
-
-export const useBooksDownloadState = (
-  bookIds: DeepReadonlyObject<BookDocType>[] = [],
-) => {
-  const bookDownloadState = useSignalValue(booksDownloadStateSignal)
-
-  return useMemo(
-    () =>
-      bookIds.reduce(
-        (acc, book) => {
-          acc[book._id] = mapBookDownloadState({
-            bookId: book._id,
-            bookDownloadState,
-          })
-
-          return acc
-        },
-        {} as Record<string, ReturnType<typeof mapBookDownloadState>>,
-      ),
-    [bookDownloadState, bookIds],
+  return useSignalValue(
+    booksDownloadStateSignal,
+    selectBookDownloadState,
+    isShallowEqual,
   )
 }

--- a/apps/web/src/download/states.ts
+++ b/apps/web/src/download/states.ts
@@ -49,8 +49,11 @@ export const getBookDownloadsState = ({ bookId }: { bookId: string }) => {
 
 export const useBookDownloadState = (bookId?: string | null) => {
   const selectBookDownloadState = useCallback(
-    (bookDownloadState: BooksDownloadState) =>
-      bookId ? mapBookDownloadState({ bookId, bookDownloadState }) : undefined,
+    function selectBookDownloadState(bookDownloadState: BooksDownloadState) {
+      return bookId
+        ? mapBookDownloadState({ bookId, bookDownloadState })
+        : undefined
+    },
     [bookId],
   )
 

--- a/apps/web/src/library/books/useLibraryBooks.ts
+++ b/apps/web/src/library/books/useLibraryBooks.ts
@@ -1,49 +1,79 @@
-import { useRef } from "react"
-import { useBooksSortedBy } from "../../books/helpers"
+import { isShallowEqual } from "@oboku/shared"
+import { useMemo, useRef } from "react"
+import { sortBooksBy } from "../../books/helpers"
 import { useBooks } from "../../books/states"
-import { DownloadState, useBooksDownloadState } from "../../download/states"
+import {
+  type BooksDownloadState,
+  DownloadState,
+  booksDownloadStateSignal,
+} from "../../download/states"
 import { useSignalValue } from "reactjrx"
 import { libraryStateSignal } from "./states"
+
+const selectDownloadedBookIds = (bookDownloadState: BooksDownloadState) =>
+  Object.keys(bookDownloadState).filter(
+    (bookId) =>
+      bookDownloadState[bookId]?.downloadState === DownloadState.Downloaded,
+  )
 
 export const useLibraryBooks = () => {
   const results = useRef<string[]>([])
   const library = useSignalValue(libraryStateSignal)
-  const filteredTags = library.tags
   const { data: unsortedBooks } = useBooks()
-  const booksDownloadState = useBooksDownloadState(unsortedBooks)
+  const downloadedBookIds = useSignalValue(
+    booksDownloadStateSignal,
+    selectDownloadedBookIds,
+    isShallowEqual,
+  )
+  const {
+    downloadState,
+    isNotInterested,
+    readingStates,
+    sorting,
+    tags: filteredTags,
+  } = library
+  const downloadedBookIdsFilter =
+    downloadState === DownloadState.Downloaded ? downloadedBookIds : undefined
 
-  const filteredBooks = unsortedBooks?.filter((book) => {
-    if (
-      library.downloadState === DownloadState.Downloaded &&
-      booksDownloadState[book._id]?.downloadState !== DownloadState.Downloaded
-    ) {
-      return false
-    }
+  const bookIds = useMemo(() => {
+    const downloadedBookIdSet =
+      downloadedBookIdsFilter && new Set(downloadedBookIdsFilter)
 
-    if (
-      filteredTags?.length &&
-      !book?.tags?.some((b) => filteredTags.includes(b))
-    ) {
-      return false
-    }
+    const filteredBooks = (unsortedBooks ?? []).filter((book) => {
+      if (downloadedBookIdSet && !downloadedBookIdSet.has(book._id)) {
+        return false
+      }
 
-    if (
-      library.readingStates.length &&
-      !library.readingStates.includes(book.readingStateCurrentState)
-    ) {
-      return false
-    }
+      if (
+        filteredTags?.length &&
+        !book?.tags?.some((tagId) => filteredTags.includes(tagId))
+      ) {
+        return false
+      }
 
-    if (library.isNotInterested !== "only" && book.isNotInterested) return false
+      if (
+        readingStates.length &&
+        !readingStates.includes(book.readingStateCurrentState)
+      ) {
+        return false
+      }
 
-    if (library.isNotInterested === "only" && !book.isNotInterested)
-      return false
+      if (isNotInterested !== "only" && book.isNotInterested) return false
 
-    return true
-  })
+      if (isNotInterested === "only" && !book.isNotInterested) return false
 
-  const sortedList = useBooksSortedBy(filteredBooks, library.sorting)
-  const bookIds = sortedList.map((item) => item._id)
+      return true
+    })
+
+    return sortBooksBy(filteredBooks, sorting).map((book) => book._id)
+  }, [
+    downloadedBookIdsFilter,
+    filteredTags,
+    isNotInterested,
+    readingStates,
+    sorting,
+    unsortedBooks,
+  ])
 
   if (bookIds.length !== results.current.length) {
     results.current = bookIds

--- a/apps/web/src/library/books/useLibraryBooks.ts
+++ b/apps/web/src/library/books/useLibraryBooks.ts
@@ -35,45 +35,50 @@ export const useLibraryBooks = () => {
   const downloadedBookIdsFilter =
     downloadState === DownloadState.Downloaded ? downloadedBookIds : undefined
 
-  const bookIds = useMemo(() => {
-    const downloadedBookIdSet =
-      downloadedBookIdsFilter && new Set(downloadedBookIdsFilter)
+  const bookIds = useMemo(
+    function computeVisibleBookIds() {
+      const downloadedBookIdSet =
+        downloadedBookIdsFilter && new Set(downloadedBookIdsFilter)
 
-    const filteredBooks = (unsortedBooks ?? []).filter((book) => {
-      if (downloadedBookIdSet && !downloadedBookIdSet.has(book._id)) {
-        return false
-      }
+      const filteredBooks = (unsortedBooks ?? []).filter(
+        function matchesLibraryFilters(book) {
+          if (downloadedBookIdSet && !downloadedBookIdSet.has(book._id)) {
+            return false
+          }
 
-      if (
-        filteredTags?.length &&
-        !book?.tags?.some((tagId) => filteredTags.includes(tagId))
-      ) {
-        return false
-      }
+          if (
+            filteredTags?.length &&
+            !book?.tags?.some((tagId) => filteredTags.includes(tagId))
+          ) {
+            return false
+          }
 
-      if (
-        readingStates.length &&
-        !readingStates.includes(book.readingStateCurrentState)
-      ) {
-        return false
-      }
+          if (
+            readingStates.length &&
+            !readingStates.includes(book.readingStateCurrentState)
+          ) {
+            return false
+          }
 
-      if (isNotInterested !== "only" && book.isNotInterested) return false
+          if (isNotInterested !== "only" && book.isNotInterested) return false
 
-      if (isNotInterested === "only" && !book.isNotInterested) return false
+          if (isNotInterested === "only" && !book.isNotInterested) return false
 
-      return true
-    })
+          return true
+        },
+      )
 
-    return sortBooksBy(filteredBooks, sorting).map((book) => book._id)
-  }, [
-    downloadedBookIdsFilter,
-    filteredTags,
-    isNotInterested,
-    readingStates,
-    sorting,
-    unsortedBooks,
-  ])
+      return sortBooksBy(filteredBooks, sorting).map((book) => book._id)
+    },
+    [
+      downloadedBookIdsFilter,
+      filteredTags,
+      isNotInterested,
+      readingStates,
+      sorting,
+      unsortedBooks,
+    ],
+  )
 
   if (bookIds.length !== results.current.length) {
     results.current = bookIds


### PR DESCRIPTION
## The target

The **book download-state subsystem** (`booksDownloadStateSignal`) and its consumers in the library book list.

`DownloadFlowRequestItem` writes progress into `booksDownloadStateSignal` from `xhr.onprogress` (`httpClient.web.ts:120`), i.e. once per network chunk — many times per second while a book downloads. Every write replaces the whole record (`{...prev, [bookId]: {...}}`).

Every consumer subscribed to the *entire* signal with no selector, so each progress tick re-rendered:

- `useLibraryBooks` → mounted app-wide via `PreloadQueries` (`App.tsx:102`) **and** again in `LibraryBooksScreen`,
- every visible book card (`BookCoverCard`, `BookListItemHorizontal` → `useBookDownloadState`),

and re-ran the library's full filter → sort → map pipeline twice per tick. On top of that, `useBooksSortedBy`'s `useMemo` could never hit, because `filteredBooks` was rebuilt with a fresh array identity on every render — so the sort re-ran on *any* re-render of the screen, including selection toggles.

User-visible symptom: the library list janks and interactions lag while a book is downloading, and it gets worse the larger the library.

## Changes

**1. `useBookDownloadState` selects one book's entry** (`download/states.ts`)

Mechanism: the hook subscribed to the whole signal, so a progress tick for book A re-rendered every mounted consumer bound to books B…Z. It now passes a per-book selector plus `isShallowEqual` to `useSignalValue` (the pattern already used by `useLocalSettings`), so `useSyncExternalStore` bails out unless *that* book's own state changed.

Scale multiplier: one subscribed component per rendered list item — roughly 20–40 in a virtualized grid — times the progress-tick rate. Each of those is an MUI `Card`/`Cover` subtree with emotion `sx` props. Render cost isn't measurable in this environment; the mechanism is that all but one of those re-renders were reacting to state they don't read.

**2. `useLibraryBooks` selects the downloaded ids and memoizes the pipeline** (`library/books/useLibraryBooks.ts`)

Mechanism: the hook consumed the whole download map only to answer "is this book downloaded?", and rebuilt filter + sort + map on every render. It now selects the list of downloaded book ids (stable across progress ticks under `isShallowEqual`, since progress updates change `downloadProgress`, not `downloadState`) and wraps the pipeline in a `useMemo` keyed on the filters that actually drive it. The download projection only enters the dependency list when the "Downloaded" filter is active.

Scale multiplier: the whole library, twice per tick (`PreloadQueries` + `LibraryBooksScreen`).

**3. Removed `useBooksDownloadState`** (`download/states.ts`)

It allocated one mapped object per book in the library on every tick, and `useLibraryBooks` was its only consumer.

## Measured impact

Pure-function benchmark of the filter + sort + map pipeline, run under the project's vitest (jsdom), synthetic books with two metadata sources each, 200 passes after warmup. This is the work now skipped on renders where no filter or sort input changed:

| books | `date` | `activity` | `alpha` |
|---|---|---|---|
| 500 | 0.023 ms | 0.065 ms | 0.449 ms |
| 2000 | 0.139 ms | 0.559 ms | 1.911 ms |

`alpha` dominates because it runs `getMetadataFromBook` per book (priority `toSorted` + per-entry `mergeObjects`). At 2000 books on `alpha` that's ~3.8 ms of pure JS per progress tick across the two mounted call sites — before any React work — on a desktop-class machine; several times that on a phone.

Download-state projection per tick, same setup:

| books | old `useBooksDownloadState` map | new `selectDownloadedBookIds` |
|---|---|---|
| 500 | 0.091 ms | 0.005 ms |
| 2000 | 0.440 ms | 0.012 ms |

The re-render savings (items 1 and 2) are React/DOM-bound and can't be measured in this headless environment; they rest on the mechanism above.

No behavior change: the filter predicate, sort order, and the returned id list are identical. The `Set` lookup replaces a record lookup over the same data, and the previous mapped record defaulted absent books to `DownloadState.None`, which the `Downloaded` set excludes the same way.

## Gates

Run on this branch's base and again after the change:

- `pnpm run lint` — clean (3 pre-existing warnings, 7 infos)
- `pnpm run build` — passes
- `pnpm run test` — 46 files passed, 2 failed. The 15 failures are in `src/http/HttpClientApi.web.test.ts` and `src/http/httpClientApi.sw.test.ts` (auth refresh / DPoP) and reproduce identically on a clean checkout of `develop`. No new failures.

## Backlog

Other performance opportunities found but not taken:

- `useDownloadedBooks` (`download/useDownloadedBooks.ts`) has the same whole-signal subscription and filters all books per tick, but only `ManageStorageScreen` mounts it — small multiplier, left alone to keep this PR to one subsystem.
- `getMetadataFromBook` (`books/metadata/index.ts`) is the hot spot inside the `alpha` sort: it spreads and re-sorts the metadata list per call, with `priorityLowestFirst.indexOf(...)` *inside* the `toSorted` comparator, plus `mergeObjects` allocating per entry. A precomputed priority `Map` and a cheaper merge would speed up every alpha sort and every `useMetadataFromBook` call site.
- `booksDownloadStateSignal` writes are unthrottled at `xhr.onprogress` rate. Throttling the `downloadProgress` write (the only field that changes mid-download) to ~animation frame rate would cut the remaining per-tick React work for the one item that legitimately re-renders — but that changes the progress-bar update cadence, so it's a product call, not an invisible perf fix.
- `useLibraryBooks`'s tag filter does `filteredTags.includes(tagId)` inside a `some` over each book's tags. Currently negligible (tag filters are a handful of ids), but it would become O(n·m) if tag filtering ever grows.


---
_Generated by [Claude Code](https://claude.ai/code/session_015DGbc3LQehJZECXi7BK55a)_