### PR TITLE
chore(deps): bump nodemailer to 9.0.4 to fix SSRF/file-read advisory (major)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -52,7 +52,7 @@
     "nano": "^11.0.6",
     "node-domexception": "^2.0.2",
     "node-unrar-js": "^2.0.2",
-    "nodemailer": "^8.0.11",
+    "nodemailer": "^9.0.4",
     "pg": "^8.22.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,8 +272,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       nodemailer:
-        specifier: ^8.0.11
-        version: 8.0.11
+        specifier: ^9.0.4
+        version: 9.0.4
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -813,10 +813,16 @@ packages:
   '@aws-sdk/core@3.977.1':
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/core@3.977.4':
     resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.61':
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}
@@ -10227,8 +10233,8 @@ packages:
     resolution: {integrity: sha512-hLNmoJzqaKJnod8yiTVGe9hnlNRHotUi0CreSv/8HtfRi/3JnRC8DvsmKfeGGguRjTEulhZK6zXX5PXoVuDZ2w==}
     engines: {node: '>=10.0.0'}
 
-  nodemailer@8.0.11:
-    resolution: {integrity: sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==}
+  nodemailer@9.0.4:
+    resolution: {integrity: sha512-LmJNRVRtfSCULxcZpy0Cpg4WWenlUZ9+zbmTO+S7v9wD6XreYLjXRFtDjtV/4F0HT5p1GyZfA0Ux/myxHb18CQ==}
     engines: {node: '>=6.0.0'}
 
   nopt@8.1.0:
@@ -24675,7 +24681,7 @@ snapshots:
 
   node-unrar-js@2.0.2: {}
 
-  nodemailer@8.0.11: {}
+  nodemailer@9.0.4: {}
 
   nopt@8.1.0:
     dependencies:


### PR DESCRIPTION
## The update

| | |
|---|---|
| **Package** | `nodemailer` (`apps/api`) |
| **Version** | `^8.0.11` → `^9.0.4` |
| **Type** | **major** (8 → 9) |
| **Motivation** | Security — high severity |
| **Advisory** | [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f) |

**Advisory:** the message-level `raw` option bypassed `disableFileAccess` / `disableUrlAccess`, enabling arbitrary file read and full-response SSRF in the delivered message. Vulnerable `<=9.0.0`, patched `>=9.0.1`.

**Breaking changes in v9 & how they're handled:** the only breaking change is that HTTPS requests made while **fetching remote content** (attachment `href`/`path` URLs, OAuth2 token endpoints, HTTP/HTTPS proxy `CONNECT`) now validate the server's TLS certificate by default. `apps/api/src/email/EmailService.ts` uses none of those paths — it sends inline `text`/`html` over a configured SMTP transport via `createTransport` / `sendMail` / `verify` / `close` — so **no code changes are required**. Later 9.0.x releases are hardening/mime fixes (STARTTLS handling, SMTP socket lifecycle, base64 MIME-word surrogate handling).

`@types/nodemailer` stays at `^8.0.1` (its current latest; no v9 type line is published, and the API surface used is unchanged), so no companion bump.

**Gates** (Node 25, per CI `check.yml`): baseline on a clean `develop` checkout was green, and with the bump applied `pnpm run lint`, `pnpm run build`, and `pnpm run test` (122 tests) all pass with no new failures.

---

## Pending queue

Everything else `pnpm outdated -r` reported this run, so this PR doubles as a status report. One dependency per PR, so these are for subsequent runs.

### Security-relevant (from `pnpm audit -r`: 1 critical · 24 high · 21 moderate · 6 low)

Most advisories are **transitive under dev-only tooling** (`vercel`, `lerna`, `next`, `semantic-release`) and can't be fixed by bumping a single direct dependency:

- **`tar` — critical** ([GHSA-23hp-3jrh-7fpw](https://github.com/advisories/GHSA-23hp-3jrh-7fpw), decompression/parse DoS) plus several high tar advisories. Only reachable via `lerna > tar` and `vercel > @vercel/fun > tar` — resolving it needs **lerna 10 (major)** *and* **vercel 58 (major)**, or a pinned `tar` override; deferred as it isn't a single-dep update.
- **`react-router` — high** ([GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2), RSC-mode CSRF bypass), direct in `apps/web`, `7.18.1` → **8.3.0 (major)**. Advisory affects RSC mode only; `apps/web` is a Vite SPA and does not use RSC, so real-world exposure is negligible — hence nodemailer (a genuinely exercised production path) was prioritized.
- **`postcss` (high), `path-to-regexp` (high), `undici` (high+low), `minimatch`/`brace-expansion`/`js-yaml`/`fast-uri` (high) etc.** — all transitive via `next` (landing), `vercel`, and `lerna`. Bumping **`next` 16.2.12 → 16.3.0 (minor)** is expected to clear the landing-app `postcss`/`path-to-regexp` chains.
- **`sharp` — high** (inherited libvips advisories) — note a prior sharp bump already landed (#540); remaining paths are transitive.

### Non-security majors (each its own future PR)

`@types/node` 25→26 · `@types/uuid` 10→11 *(deprecated — consider `uuid`'s own types)* · `eslint` 9→10 *(landing)* · `google-auth-library` 10→11 · `googleapis` 171→174 · `jose` 5→6 · `jsdom` 27→30 · `lerna` 9→10 · `lint-staged` 16→17 · `pdfjs-dist` 5→6 · `react-dropzone` 15→20 · `react-router` 7→8 *(security, above)* · `rollup-plugin-node-externals` 8→9 · `typescript` 5.9→7.0 · `typeorm` 0.3→1.1 · `vercel` 54→58

### Minor / patch

`@mantine/*` 9.4.2→9.5.1 *(family)* · `@prose-reader/*` 1.334.0→1.343.0 *(family; pinned via `minimumReleaseAgeExclude`)* · `@sentry/*` 10.68→10.69 *(family)* · `@aws-sdk/client-s3` & `client-ssm` →3.1102.0 · `next` 16.2.12→16.3.0 · `vite` 8.1.5→8.2.0 · `axios` 1.18.1→1.19.0 · `dropbox` 10.38→10.41 · `firebase` 12.16→12.17 · `react-hook-form` 7.83→7.84 · `dexie` 4.4.2→4.4.4 *(guarded by `scripts/check-dexie-version.mjs`)* · `@azure/msal-browser` 5.17.1→5.17.3 · `@tanstack/react-virtual` 3.14.8→3.14.9 · `@swc/core` 1.15.46→1.15.47 · `@swc/cli` 0.7→0.8 · `@vitejs/plugin-react` 6.0.4→6.0.5 · `postcss` *(admin dev)* 8.5.23→8.5.25 · `reactjrx` 1.141.5→1.141.6 · `@types/react` & `@types/react-dom` · `eslint-config-next` 16.2→16.3 · `globals` 17.7→17.9

Also `node-domexception` (in `apps/api`) is flagged deprecated by the registry.

## Needs manual attention

None this run — the chosen update landed green with no reverts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvazYviR5jcJnX68bcBMSg)_