### PR TITLE
Confirm local book updates

### DIFF
--- a/apps/web/src/books/optimize/BookOptimizeProvider.tsx
+++ b/apps/web/src/books/optimize/BookOptimizeProvider.tsx
@@ -11,8 +11,10 @@ import { useForm, type Control } from "react-hook-form"
 import type { BookDocType, LinkDocType } from "@oboku/shared"
 import type { DeepReadonlyObject } from "rxdb"
 import type { Observable } from "rxjs"
+import { Logger } from "../../debug/logger.shared"
 import { notify } from "../../notifications/toasts"
 import type { FileInspection } from "./useFileInspection"
+import { confirmApplyLocalUpdate } from "./apply/confirmApplyLocalUpdate"
 import { useApplyLocalOptimizations } from "./apply/useApplyLocalOptimizations"
 import { useUploadToDataSource } from "./actions/useUploadToDataSource"
 import { useRevertLocalChanges } from "./actions/useRevertLocalChanges"
@@ -30,7 +32,7 @@ type BookOptimizeContextValue = {
   isUploading: boolean
   canApplyLocally: boolean
   canUpload: boolean
-  applyLocally: () => void
+  applyLocally: () => Promise<void>
   uploadToDataSource: () => Promise<void>
   revertLocalChanges: () => Promise<void>
   canRevert: boolean
@@ -113,31 +115,42 @@ export function BookOptimizeProvider({
   // (unable to apply and unable to upload).
   const canApplyLocally = isValid && isDirty && !isBusy
 
-  const applyLocally = useCallback(() => {
-    if (!canApplyLocally) return
+  const applyLocally = useCallback(
+    async function confirmAndApplyLocally() {
+      if (!canApplyLocally) return
 
-    applyLocalOptimizations(
-      { bookId, actions: buildUpdateActions(getValues(), inspection) },
-      {
-        onSuccess: () => {
-          reset(getValues())
-          notify({
-            title: "Book optimized",
-            description:
-              "Changes were saved to the downloaded file on this device.",
-            severity: "success",
-          })
+      const actions = buildUpdateActions(getValues(), inspection)
+
+      Logger.info("[bookOptimize] local update actions", { bookId, actions })
+
+      const isConfirmed = await confirmApplyLocalUpdate(actions)
+
+      if (!isConfirmed) return
+
+      applyLocalOptimizations(
+        { bookId, actions },
+        {
+          onSuccess: () => {
+            reset(getValues())
+            notify({
+              title: "Book optimized",
+              description:
+                "Changes were saved to the downloaded file on this device.",
+              severity: "success",
+            })
+          },
         },
-      },
-    )
-  }, [
-    applyLocalOptimizations,
-    bookId,
-    canApplyLocally,
-    getValues,
-    inspection,
-    reset,
-  ])
+      )
+    },
+    [
+      applyLocalOptimizations,
+      bookId,
+      canApplyLocally,
+      getValues,
+      inspection,
+      reset,
+    ],
+  )
 
   const value = useMemo<BookOptimizeContextValue>(
     () => ({

--- a/apps/web/src/books/optimize/apply/buildUpdateActions.ts
+++ b/apps/web/src/books/optimize/apply/buildUpdateActions.ts
@@ -6,7 +6,7 @@ import {
   trimMetadataFixerFormValues,
 } from "../metadata/targets"
 import {
-  hasCompressionDimension,
+  hasImageCompressionOperation,
   parseDimension,
   type BookOptimizeFormValues,
 } from "../form"
@@ -31,7 +31,7 @@ const resolveMetadataPatchAction = (
 const resolveCompressImagesAction = (
   values: BookOptimizeFormValues,
 ): WebArchiveUpdateAction | undefined => {
-  if (!values.compressImages || !hasCompressionDimension(values))
+  if (!values.compressImages || !hasImageCompressionOperation(values))
     return undefined
 
   return {
@@ -39,6 +39,7 @@ const resolveCompressImagesAction = (
     config: {
       maxWidth: parseDimension(values.maxWidth),
       maxHeight: parseDimension(values.maxHeight),
+      outputMode: values.imageOutputMode,
     },
   }
 }

--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
@@ -48,7 +48,7 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
       },
       {
         kind: "compress-images",
-        config: { maxWidth: 1200, maxHeight: 1600 },
+        config: { maxWidth: 1200, maxHeight: 1600, outputMode: "webp" },
       },
     ]
     renderDialogProvider()
@@ -70,8 +70,10 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
     expect(screen.getByText("OPF package document")).not.toBeNull()
     expect(listItems[1]?.textContent).toContain("Resize eligible")
     expect(screen.getByText("1200 × 1600 px")).not.toBeNull()
-    expect(screen.getByText("JPG · JPEG · PNG · BMP")).not.toBeNull()
-    expect(listItems[2]?.textContent).toContain("Convert images to")
+    expect(screen.getAllByText("JPG · JPEG · PNG · BMP")).toHaveLength(2)
+    expect(listItems[2]?.textContent).toContain(
+      "Convert JPG · JPEG · PNG · BMP images to WebP",
+    )
     expect(screen.getByText("WebP")).not.toBeNull()
     expect(listItems[3]?.textContent).toBe(
       "Update references to converted images.",
@@ -96,7 +98,11 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
       },
       {
         kind: "compress-images",
-        config: { maxWidth: undefined, maxHeight: 1600 },
+        config: {
+          maxWidth: undefined,
+          maxHeight: 1600,
+          outputMode: "original",
+        },
       },
     ]
     renderDialogProvider()
@@ -111,6 +117,13 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
     expect(screen.getByText("ComicInfo.xml")).not.toBeNull()
     expect(listItems[1]?.textContent).toContain("to a maximum height of")
     expect(screen.getByText("1600 px")).not.toBeNull()
+    expect(screen.getByText("JPG · JPEG · PNG")).not.toBeNull()
+    expect(listItems[2]?.textContent).toContain(
+      "Keep each resized image in its original format",
+    )
+    expect(listItems[3]?.textContent).toContain(
+      "Leave all other image formats unchanged",
+    )
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
 

--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import type { WebArchiveUpdateAction } from "@oboku/archive-metadata/web"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { DialogProvider } from "../../../common/dialogs/DialogProvider"
+import { dialogSignal } from "../../../common/dialogs/state"
+import { confirmApplyLocalUpdate } from "./confirmApplyLocalUpdate"
+
+function renderDialogProvider() {
+  render(
+    <DialogProvider>
+      <div>Application content</div>
+    </DialogProvider>,
+  )
+}
+
+function openConfirmation(actions: WebArchiveUpdateAction[]): Promise<boolean> {
+  let confirmation: Promise<boolean> | undefined
+
+  act(function showApplyConfirmation() {
+    confirmation = confirmApplyLocalUpdate(actions)
+  })
+
+  if (!confirmation) {
+    throw new Error("Expected an apply confirmation")
+  }
+
+  return confirmation
+}
+
+describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
+  beforeEach(function resetDialogs() {
+    dialogSignal.setValue([])
+  })
+
+  afterEach(function cleanUpDialogs() {
+    cleanup()
+    dialogSignal.setValue([])
+  })
+
+  it("lists every update and the final file replacement", async function listUpdates() {
+    const actions: WebArchiveUpdateAction[] = [
+      {
+        kind: "patch-metadata",
+        patch: { isbn: "9781234567897" },
+        targets: { comicInfo: true, opf: true },
+      },
+      {
+        kind: "compress-images",
+        config: { maxWidth: 1200, maxHeight: 1600 },
+      },
+    ]
+    renderDialogProvider()
+
+    const confirmation = openConfirmation(actions)
+
+    expect(await screen.findByRole("dialog")).not.toBeNull()
+    expect(screen.getByText("Before updating the book...")).not.toBeNull()
+    expect(screen.getByRole("heading", { name: "Book updates" })).not.toBeNull()
+    expect(
+      screen.getByRole("heading", { name: "Downloaded file" }),
+    ).not.toBeNull()
+    const listItems = screen.getAllByRole("listitem")
+
+    expect(listItems).toHaveLength(5)
+    expect(listItems[0]?.textContent).toContain("Set the ISBN to")
+    expect(screen.getByText("9781234567897")).not.toBeNull()
+    expect(screen.getByText("ComicInfo.xml")).not.toBeNull()
+    expect(screen.getByText("OPF package document")).not.toBeNull()
+    expect(listItems[1]?.textContent).toContain("Resize eligible")
+    expect(screen.getByText("1200 × 1600 px")).not.toBeNull()
+    expect(screen.getByText("JPG · JPEG · PNG · BMP")).not.toBeNull()
+    expect(listItems[2]?.textContent).toContain("Convert images to")
+    expect(screen.getByText("WebP")).not.toBeNull()
+    expect(listItems[3]?.textContent).toBe(
+      "Update references to converted images.",
+    )
+    expect(
+      screen.getByText(
+        "Replace the downloaded file on this device with the result.",
+      ),
+    ).not.toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "Update book" }))
+
+    await expect(confirmation).resolves.toBe(true)
+  })
+
+  it("describes removing metadata and a single resize constraint", async function listRemovalAndResize() {
+    const actions: WebArchiveUpdateAction[] = [
+      {
+        kind: "patch-metadata",
+        patch: { isbn: undefined },
+        targets: { comicInfo: true },
+      },
+      {
+        kind: "compress-images",
+        config: { maxWidth: undefined, maxHeight: 1600 },
+      },
+    ]
+    renderDialogProvider()
+
+    const confirmation = openConfirmation(actions)
+
+    expect(await screen.findByRole("dialog")).not.toBeNull()
+    const listItems = screen.getAllByRole("listitem")
+
+    expect(listItems).toHaveLength(5)
+    expect(listItems[0]?.textContent).toContain("Remove the ISBN from")
+    expect(screen.getByText("ComicInfo.xml")).not.toBeNull()
+    expect(listItems[1]?.textContent).toContain("to a maximum height of")
+    expect(screen.getByText("1600 px")).not.toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+
+    await expect(confirmation).resolves.toBe(false)
+  })
+})

--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
@@ -1,0 +1,188 @@
+import {
+  CONVERTIBLE_IMAGE_FORMAT_NAMES,
+  type WebArchiveUpdateAction,
+} from "@oboku/archive-metadata/web"
+import { FiberManualRecord } from "@mui/icons-material"
+import {
+  Chip,
+  List,
+  ListItem,
+  ListItemIcon,
+  Stack,
+  Typography,
+  styled,
+} from "@mui/material"
+import { Fragment, type ReactNode } from "react"
+import { showConfirmDialog } from "../../../common/dialogs/presets"
+import { CONTAINER_LABELS } from "../metadata/targets"
+
+const BulletListItemIcon = styled(ListItemIcon)(({ theme }) => ({
+  minWidth: theme.spacing(3),
+  fontSize: theme.typography.pxToRem(7),
+}))
+
+const UpdateContentStack = styled(Stack)({
+  flex: 1,
+  minWidth: 0,
+})
+
+function KeyChip({ label }: { label: string }) {
+  return <Chip label={label} size="small" variant="outlined" />
+}
+
+function UpdateListItem({ children }: { children: ReactNode }) {
+  return (
+    <ListItem disableGutters alignItems="flex-start">
+      <BulletListItemIcon>
+        <FiberManualRecord fontSize="inherit" />
+      </BulletListItemIcon>
+      <UpdateContentStack>
+        <Typography component="div" variant="body2">
+          {children}
+        </Typography>
+      </UpdateContentStack>
+    </ListItem>
+  )
+}
+
+function MetadataTargetChips({ targets }: { targets: string[] }) {
+  return targets.map(function renderMetadataTarget(target, index) {
+    return (
+      <Fragment key={target}>
+        {index > 0 ? " and " : null}
+        <KeyChip label={target} />
+      </Fragment>
+    )
+  })
+}
+
+function MetadataUpdateItems({
+  action,
+}: {
+  action: Extract<WebArchiveUpdateAction, { kind: "patch-metadata" }>
+}) {
+  const targets: string[] = []
+
+  if (action.targets.comicInfo) targets.push(CONTAINER_LABELS.comicInfo)
+  if (action.targets.opf) targets.push(CONTAINER_LABELS.opf)
+
+  return action.patch.isbn === undefined ? (
+    <UpdateListItem>
+      Remove the ISBN from <MetadataTargetChips targets={targets} />.
+    </UpdateListItem>
+  ) : (
+    <UpdateListItem>
+      Set the ISBN to <KeyChip label={action.patch.isbn} /> in{" "}
+      <MetadataTargetChips targets={targets} />.
+    </UpdateListItem>
+  )
+}
+
+function ImageResizeUpdateItem({
+  maxWidth,
+  maxHeight,
+}: {
+  maxWidth: number | undefined
+  maxHeight: number | undefined
+}) {
+  const formats = CONVERTIBLE_IMAGE_FORMAT_NAMES.join(" · ")
+
+  if (maxWidth !== undefined && maxHeight !== undefined) {
+    return (
+      <UpdateListItem>
+        Resize eligible <KeyChip label={formats} /> images to fit within{" "}
+        <KeyChip label={`${maxWidth} × ${maxHeight} px`} />.
+      </UpdateListItem>
+    )
+  }
+
+  if (maxWidth !== undefined) {
+    return (
+      <UpdateListItem>
+        Resize eligible <KeyChip label={formats} /> images to a maximum width of{" "}
+        <KeyChip label={`${maxWidth} px`} />.
+      </UpdateListItem>
+    )
+  }
+
+  if (maxHeight !== undefined) {
+    return (
+      <UpdateListItem>
+        Resize eligible <KeyChip label={formats} /> images to a maximum height
+        of <KeyChip label={`${maxHeight} px`} />.
+      </UpdateListItem>
+    )
+  }
+
+  return null
+}
+
+function ImageCompressionUpdateItems({
+  action,
+}: {
+  action: Extract<WebArchiveUpdateAction, { kind: "compress-images" }>
+}) {
+  return (
+    <>
+      <ImageResizeUpdateItem {...action.config} />
+      <UpdateListItem>
+        Convert images to <KeyChip label="WebP" /> when the result is smaller.
+      </UpdateListItem>
+      <UpdateListItem>Update references to converted images.</UpdateListItem>
+    </>
+  )
+}
+
+function UpdateActionItems({ action }: { action: WebArchiveUpdateAction }) {
+  return action.kind === "patch-metadata" ? (
+    <MetadataUpdateItems action={action} />
+  ) : (
+    <ImageCompressionUpdateItems action={action} />
+  )
+}
+
+function ApplyUpdateMessage({
+  actions,
+}: {
+  actions: WebArchiveUpdateAction[]
+}) {
+  return (
+    <Stack spacing={2}>
+      <Typography variant="body2" color="text.secondary">
+        Review the updates that will be made before continuing.
+      </Typography>
+      {actions.length > 0 && (
+        <Stack spacing={0.5}>
+          <Typography component="h3" variant="subtitle2">
+            Book updates
+          </Typography>
+          <List dense disablePadding>
+            {actions.map(function renderUpdateAction(action) {
+              return <UpdateActionItems key={action.kind} action={action} />
+            })}
+          </List>
+        </Stack>
+      )}
+      <Stack spacing={0.5}>
+        <Typography component="h3" variant="subtitle2">
+          Downloaded file
+        </Typography>
+        <List dense disablePadding>
+          <UpdateListItem>
+            Replace the downloaded file on this device with the result.
+          </UpdateListItem>
+        </List>
+      </Stack>
+    </Stack>
+  )
+}
+
+export async function confirmApplyLocalUpdate(
+  actions: WebArchiveUpdateAction[],
+): Promise<boolean> {
+  return showConfirmDialog({
+    title: "Before updating the book...",
+    message: <ApplyUpdateMessage actions={actions} />,
+    actions: [{ title: "Update book" }],
+  })
+}

--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
@@ -1,5 +1,6 @@
 import {
   CONVERTIBLE_IMAGE_FORMAT_NAMES,
+  PRESERVABLE_IMAGE_FORMAT_NAMES,
   type WebArchiveUpdateAction,
 } from "@oboku/archive-metadata/web"
 import { FiberManualRecord } from "@mui/icons-material"
@@ -81,12 +82,12 @@ function MetadataUpdateItems({
 function ImageResizeUpdateItem({
   maxWidth,
   maxHeight,
+  formats,
 }: {
   maxWidth: number | undefined
   maxHeight: number | undefined
+  formats: string
 }) {
-  const formats = CONVERTIBLE_IMAGE_FORMAT_NAMES.join(" · ")
-
   if (maxWidth !== undefined && maxHeight !== undefined) {
     return (
       <UpdateListItem>
@@ -122,13 +123,36 @@ function ImageCompressionUpdateItems({
 }: {
   action: Extract<WebArchiveUpdateAction, { kind: "compress-images" }>
 }) {
+  const keepsOriginalFormat = action.config.outputMode === "original"
+  const formats = (
+    keepsOriginalFormat
+      ? PRESERVABLE_IMAGE_FORMAT_NAMES
+      : CONVERTIBLE_IMAGE_FORMAT_NAMES
+  ).join(" · ")
+
   return (
     <>
-      <ImageResizeUpdateItem {...action.config} />
-      <UpdateListItem>
-        Convert images to <KeyChip label="WebP" /> when the result is smaller.
-      </UpdateListItem>
-      <UpdateListItem>Update references to converted images.</UpdateListItem>
+      <ImageResizeUpdateItem {...action.config} formats={formats} />
+      {keepsOriginalFormat ? (
+        <>
+          <UpdateListItem>
+            Keep each resized image in its original format.
+          </UpdateListItem>
+          <UpdateListItem>
+            Leave all other image formats unchanged.
+          </UpdateListItem>
+        </>
+      ) : (
+        <>
+          <UpdateListItem>
+            Convert <KeyChip label={formats} /> images to{" "}
+            <KeyChip label="WebP" />.
+          </UpdateListItem>
+          <UpdateListItem>
+            Update references to converted images.
+          </UpdateListItem>
+        </>
+      )}
     </>
   )
 }

--- a/apps/web/src/books/optimize/content/ContentReport.tsx
+++ b/apps/web/src/books/optimize/content/ContentReport.tsx
@@ -1,12 +1,24 @@
 import { formatBytes } from "@oboku/shared"
+import { Chip, Divider, Stack, Typography, styled } from "@mui/material"
 import { useBookOptimize } from "../BookOptimizeProvider"
 import { Report, ReportRow } from "../Report"
+
+const FileFormatsSectionStack = styled(Stack)(({ theme }) => ({
+  gap: theme.spacing(0.75),
+}))
+
+const FileFormatChipsStack = styled(Stack)(({ theme }) => ({
+  flexDirection: "row",
+  flexWrap: "wrap",
+  gap: theme.spacing(0.5),
+}))
 
 export function ContentReport() {
   const { inspection } = useBookOptimize()
   const {
     fileSize,
     fileCount,
+    fileExtensions,
     imageCount,
     imageBytes,
     averageImageResolution,
@@ -34,6 +46,28 @@ export function ContentReport() {
           value={`${averageImageResolution.width} × ${averageImageResolution.height} px`}
         />
       )}
+      <Divider />
+      <FileFormatsSectionStack>
+        <Typography variant="body2" color="text.secondary">
+          File formats
+        </Typography>
+        <FileFormatChipsStack>
+          {fileExtensions.length > 0 ? (
+            fileExtensions.map(function renderFileExtension(extension) {
+              return (
+                <Chip
+                  key={extension}
+                  label={extension}
+                  size="small"
+                  variant="outlined"
+                />
+              )
+            })
+          ) : (
+            <Typography variant="body2">—</Typography>
+          )}
+        </FileFormatChipsStack>
+      </FileFormatsSectionStack>
     </Report>
   )
 }

--- a/apps/web/src/books/optimize/content/ImageCompressionOption.tsx
+++ b/apps/web/src/books/optimize/content/ImageCompressionOption.tsx
@@ -1,18 +1,29 @@
 import {
-  Alert,
   Checkbox,
+  FormControl,
   FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  Radio,
+  RadioGroup,
   Stack,
   Typography,
   styled,
 } from "@mui/material"
 import { useController } from "react-hook-form"
 import { ControlledTextField } from "../../../common/forms/ControlledTextField"
-import { hasCompressionDimension, type BookOptimizeFormValues } from "../form"
+import {
+  hasImageCompressionOperation,
+  type BookOptimizeFormValues,
+} from "../form"
 import { useBookOptimize } from "../BookOptimizeProvider"
-import { CONVERTIBLE_IMAGE_FORMAT_NAMES } from "@oboku/archive-metadata/web"
+import {
+  CONVERTIBLE_IMAGE_FORMAT_NAMES,
+  PRESERVABLE_IMAGE_FORMAT_NAMES,
+} from "@oboku/archive-metadata/web"
 
 const convertibleFormats = CONVERTIBLE_IMAGE_FORMAT_NAMES.join(", ")
+const preservableFormats = PRESERVABLE_IMAGE_FORMAT_NAMES.join(", ")
 
 const OptionStack = styled(Stack)(({ theme }) => ({
   border: `1px solid ${theme.palette.divider}`,
@@ -24,6 +35,15 @@ const OptionStack = styled(Stack)(({ theme }) => ({
 const DimensionsStack = styled(Stack)(({ theme }) => ({
   flexDirection: "row",
   gap: theme.spacing(1),
+}))
+
+const ResizeDimensionsFormHelperText = styled(FormHelperText)(({ theme }) => ({
+  margin: theme.spacing(1, 0),
+}))
+
+const OutputFormatFormHelperText = styled(FormHelperText)(({ theme }) => ({
+  marginTop: -theme.spacing(0.5),
+  marginBottom: theme.spacing(0.5),
 }))
 
 const getScreenResolution = (): string => {
@@ -38,7 +58,7 @@ export function ImageCompressionOption() {
   const { control, isApplyingLocally, isUploading } = useBookOptimize()
   const isApplying = isApplyingLocally || isUploading
   const {
-    field: { value: enabled, onChange },
+    field: { value: enabled, onChange: changeCompressionEnabled },
     fieldState: { error },
   } = useController({
     control,
@@ -46,10 +66,17 @@ export function ImageCompressionOption() {
     rules: {
       validate: (compressImages, values) =>
         !compressImages ||
-        hasCompressionDimension(values) ||
-        "Set a maximum width or height to compress.",
-      deps: ["maxWidth", "maxHeight"],
+        hasImageCompressionOperation(values) ||
+        "Set a maximum width or height when keeping the original format.",
+      deps: ["maxWidth", "maxHeight", "imageOutputMode"],
     },
+  })
+  const {
+    field: { value: outputMode, onChange: changeOutputMode },
+  } = useController({
+    control,
+    name: "imageOutputMode",
+    rules: { deps: ["compressImages"] },
   })
 
   return (
@@ -59,55 +86,98 @@ export function ImageCompressionOption() {
           <Checkbox
             checked={enabled}
             disabled={isApplying}
-            onChange={(event) => onChange(event.target.checked)}
+            onChange={function toggleImageCompression(event) {
+              changeCompressionEnabled(event.target.checked)
+            }}
           />
         }
         label="Compress images"
       />
       <Typography variant="body2" color="text.secondary">
-        Resize images to fit within the dimensions below (their aspect ratio
-        will be preserved). Leave a field empty to constrain only the other
-        dimension.
+        Choose how eligible images are written and whether they should be
+        resized.
       </Typography>
       {enabled && (
         <>
-          <Typography variant="caption" color="text.secondary">
-            This device&apos;s screen has {getScreenResolution()} physical
-            pixels. Images larger than this won&apos;t look any sharper here, so
-            it&apos;s a sensible upper bound for the maximum width or height.
-          </Typography>
-          <DimensionsStack>
-            <ControlledTextField<BookOptimizeFormValues>
-              control={control}
-              name="maxWidth"
-              rules={{ deps: ["compressImages"] }}
-              label="Max width (px)"
-              type="number"
-              size="small"
-              fullWidth
-              disabled={isApplying}
-            />
-            <ControlledTextField<BookOptimizeFormValues>
-              control={control}
-              name="maxHeight"
-              rules={{ deps: ["compressImages"] }}
-              label="Max height (px)"
-              type="number"
-              size="small"
-              fullWidth
-              disabled={isApplying}
-            />
-          </DimensionsStack>
-          {error && (
-            <Typography variant="caption" color="error">
-              {error.message}
-            </Typography>
-          )}
-          <Alert severity="info">
-            Only {convertibleFormats} images are converted to WebP for the best
-            size, and every reference to them inside the book is updated.
-            Animated GIFs and other formats are left unchanged.
-          </Alert>
+          <FormControl component="fieldset" disabled={isApplying}>
+            <FormLabel component="legend">Output format</FormLabel>
+            <RadioGroup
+              value={outputMode}
+              onChange={function selectImageOutputMode(_event, value) {
+                if (value === "webp" || value === "original") {
+                  changeOutputMode(value)
+                }
+              }}
+            >
+              <Stack>
+                <FormControlLabel
+                  value="webp"
+                  control={<Radio />}
+                  label="Convert to WebP"
+                />
+                {outputMode === "webp" && (
+                  <OutputFormatFormHelperText>
+                    {convertibleFormats} images are converted to WebP, even
+                    without resize dimensions. References are updated, and all
+                    other image formats are left unchanged.
+                  </OutputFormatFormHelperText>
+                )}
+              </Stack>
+              <Stack>
+                <FormControlLabel
+                  value="original"
+                  control={<Radio />}
+                  label="Keep original format"
+                />
+                {outputMode === "original" && (
+                  <OutputFormatFormHelperText>
+                    {preservableFormats} images are resized in their original
+                    format. All other image formats, including BMP, are left
+                    unchanged.
+                  </OutputFormatFormHelperText>
+                )}
+              </Stack>
+            </RadioGroup>
+          </FormControl>
+          <FormControl
+            component="fieldset"
+            disabled={isApplying}
+            error={Boolean(error)}
+          >
+            <FormLabel component="legend">Resize dimensions</FormLabel>
+            <ResizeDimensionsFormHelperText>
+              Optional for WebP conversion and required when keeping the
+              original format. Aspect ratio is preserved; leave either field
+              empty to constrain only the other dimension.
+            </ResizeDimensionsFormHelperText>
+            <DimensionsStack>
+              <ControlledTextField<BookOptimizeFormValues>
+                control={control}
+                name="maxWidth"
+                rules={{ deps: ["compressImages"] }}
+                label="Max width (px)"
+                type="number"
+                size="small"
+                fullWidth
+                disabled={isApplying}
+              />
+              <ControlledTextField<BookOptimizeFormValues>
+                control={control}
+                name="maxHeight"
+                rules={{ deps: ["compressImages"] }}
+                label="Max height (px)"
+                type="number"
+                size="small"
+                fullWidth
+                disabled={isApplying}
+              />
+            </DimensionsStack>
+            <ResizeDimensionsFormHelperText>
+              This device&apos;s screen has {getScreenResolution()} physical
+              pixels. Images larger than this won&apos;t look any sharper here.
+            </ResizeDimensionsFormHelperText>
+            {error && <FormHelperText>{error.message}</FormHelperText>}
+          </FormControl>
         </>
       )}
     </OptionStack>

--- a/apps/web/src/books/optimize/form.test.ts
+++ b/apps/web/src/books/optimize/form.test.ts
@@ -1,20 +1,32 @@
 import { describe, expect, it } from "vitest"
-import { parseDimension } from "./form"
+import {
+  EMPTY_BOOK_OPTIMIZE_FORM_VALUES,
+  hasImageCompressionOperation,
+} from "./form"
 
-describe("parseDimension", function testParseDimension() {
-  it.each([
-    ["", undefined],
-    ["invalid", undefined],
-    ["Infinity", undefined],
-    ["-1", undefined],
-    ["0", undefined],
-    ["0.1", undefined],
-    ["0.49", undefined],
-    ["0.5", 1],
-    ["1", 1],
-    ["1.49", 1],
-    ["1.5", 2],
-  ])("parses %s as %s", function parseValue(value, expected) {
-    expect(parseDimension(value)).toBe(expected)
+describe("hasImageCompressionOperation", () => {
+  it("allows WebP conversion without resize dimensions", () => {
+    expect(
+      hasImageCompressionOperation({
+        ...EMPTY_BOOK_OPTIMIZE_FORM_VALUES,
+        imageOutputMode: "webp",
+      }),
+    ).toBe(true)
+  })
+
+  it("requires a resize dimension when keeping the original format", () => {
+    expect(
+      hasImageCompressionOperation({
+        ...EMPTY_BOOK_OPTIMIZE_FORM_VALUES,
+        imageOutputMode: "original",
+      }),
+    ).toBe(false)
+    expect(
+      hasImageCompressionOperation({
+        ...EMPTY_BOOK_OPTIMIZE_FORM_VALUES,
+        imageOutputMode: "original",
+        maxHeight: "1600",
+      }),
+    ).toBe(true)
   })
 })

--- a/apps/web/src/books/optimize/form.ts
+++ b/apps/web/src/books/optimize/form.ts
@@ -1,3 +1,4 @@
+import type { ImageOutputMode } from "@oboku/archive-metadata/web"
 import type { FileInspection } from "./useFileInspection"
 import {
   EMPTY_METADATA_FIXER_FORM_VALUES,
@@ -7,6 +8,7 @@ import type { MetadataFixerFormValues } from "./metadata/types"
 
 export type BookOptimizeFormValues = MetadataFixerFormValues & {
   compressImages: boolean
+  imageOutputMode: ImageOutputMode
   maxWidth: string
   maxHeight: string
 }
@@ -14,6 +16,7 @@ export type BookOptimizeFormValues = MetadataFixerFormValues & {
 export const EMPTY_BOOK_OPTIMIZE_FORM_VALUES: BookOptimizeFormValues = {
   ...EMPTY_METADATA_FIXER_FORM_VALUES,
   compressImages: false,
+  imageOutputMode: "webp",
   maxWidth: "",
   maxHeight: "",
 }
@@ -32,11 +35,17 @@ export const hasCompressionDimension = (
   parseDimension(values.maxWidth) !== undefined ||
   parseDimension(values.maxHeight) !== undefined
 
+export const hasImageCompressionOperation = (
+  values: BookOptimizeFormValues,
+): boolean =>
+  values.imageOutputMode === "webp" || hasCompressionDimension(values)
+
 export const resolveBookOptimizeFormValues = (
   inspection: FileInspection,
 ): BookOptimizeFormValues => ({
   ...resolveMetadataFixerFormValues(inspection),
   compressImages: false,
+  imageOutputMode: "webp",
   maxWidth: "",
   maxHeight: "",
 })

--- a/apps/web/src/books/optimize/useFileInspection.ts
+++ b/apps/web/src/books/optimize/useFileInspection.ts
@@ -25,10 +25,26 @@ export type FileInspection = {
   fileName: string
   fileSize: number
   fileCount: number
+  fileExtensions: string[]
   imageCount: number
   imageBytes: number
   averageImageResolution: ImageResolution | undefined
   resolvedArchive: ResolvedBookArchive
+}
+
+const listFileExtensions = (records: readonly { uri: string }[]): string[] => {
+  const extensions = new Set<string>()
+
+  for (const { uri } of records) {
+    const fileName = uri.slice(uri.lastIndexOf("/") + 1)
+    const extensionSeparator = fileName.lastIndexOf(".")
+
+    if (extensionSeparator >= 0 && extensionSeparator < fileName.length - 1) {
+      extensions.add(fileName.slice(extensionSeparator + 1).toUpperCase())
+    }
+  }
+
+  return [...extensions].sort()
 }
 
 const inspectContent = (
@@ -66,6 +82,7 @@ export const useFileInspection = (bookId: string | undefined) =>
           )
 
           try {
+            const fileRecords = archive.records.filter(isFileRecord)
             const imageRecords = listImageEntries(archive)
             const { imageCount, imageBytes } = inspectContent(imageRecords)
             const averageImageResolution =
@@ -73,7 +90,8 @@ export const useFileInspection = (bookId: string | undefined) =>
             const inspection: FileInspection = {
               fileName: file.name,
               fileSize: file.size,
-              fileCount: archive.records.filter(isFileRecord).length,
+              fileCount: fileRecords.length,
+              fileExtensions: listFileExtensions(fileRecords),
               imageCount,
               imageBytes,
               averageImageResolution,

--- a/apps/web/src/common/dialogs/DialogProvider.tsx
+++ b/apps/web/src/common/dialogs/DialogProvider.tsx
@@ -40,7 +40,7 @@ function TemplateDialog({ dialog }: { dialog?: DialogTemplateType<unknown> }) {
       <DialogTitle>{currentDialog?.title}</DialogTitle>
       {message !== undefined && (
         <DialogContent>
-          <DialogContentText>{message}</DialogContentText>
+          <DialogContentText component="div">{message}</DialogContentText>
         </DialogContent>
       )}
       <DialogActions>

--- a/apps/web/src/common/dialogs/state.ts
+++ b/apps/web/src/common/dialogs/state.ts
@@ -13,7 +13,7 @@ export type DialogAction<T = undefined> = {
 export type DialogTemplateType<T = undefined> = {
   type?: "template"
   title?: string
-  message?: string
+  message?: ReactNode
   id: string
   cancellable?: boolean
   dismissible?: boolean

--- a/packages/archive-metadata/src/images/compress.test.ts
+++ b/packages/archive-metadata/src/images/compress.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { type EditableArchive, readEntryText } from "../update/editableArchive"
-import type { CompressionResult } from "./compressionPool"
+import type { ImageCompressionPool } from "./compressionPool"
+import type { ImageCompressionConfig } from "./types"
 
-const compress = vi.fn<(bytes: ArrayBuffer) => Promise<CompressionResult>>()
+const compress = vi.fn<ImageCompressionPool["compress"]>()
 const terminate = vi.fn()
 const createImageCompressionPool = vi.fn(() => ({
   compress,
@@ -46,7 +47,11 @@ const textOf = (entries: EditableArchive, path: string): Promise<string> => {
   return readEntryText(entry.content)
 }
 
-const config = { maxWidth: undefined, maxHeight: undefined }
+const config: ImageCompressionConfig = {
+  maxWidth: undefined,
+  maxHeight: undefined,
+  outputMode: "webp",
+}
 
 const stageBytes = async (bytes: ArrayBuffer): Promise<Blob> =>
   new Blob([bytes])
@@ -71,7 +76,7 @@ describe("compressArchiveImages", () => {
     expect(compress).not.toHaveBeenCalled()
   })
 
-  it("replaces images with their smaller webp output and skips the rest", async () => {
+  it("replaces successfully encoded images with webp output and skips the rest", async () => {
     compress.mockImplementation(async (bytes) =>
       new TextDecoder().decode(bytes).includes("CONVERT")
         ? { status: "ok", bytes: arrayBufferOf("x") }
@@ -96,16 +101,16 @@ describe("compressArchiveImages", () => {
     expect(terminate).toHaveBeenCalledOnce()
   })
 
-  it("does not count a non-smaller webp output as compressed", async () => {
+  it("uses a successfully encoded webp output even when its byte size grows", async () => {
     compress.mockResolvedValue({ status: "ok", bytes: arrayBufferOf("larger") })
 
     const entries = archiveOf({ "cover.jpg": bytesOf("tiny") })
 
     const result = await compressArchiveImages(entries, config, { stageBytes })
 
-    expect(result).toMatchObject({ compressedCount: 0, skippedCount: 1 })
-    expect(entries.has("cover.jpg")).toBe(true)
-    expect(entries.has("cover.webp")).toBe(false)
+    expect(result).toMatchObject({ compressedCount: 1, skippedCount: 0 })
+    expect(entries.has("cover.jpg")).toBe(false)
+    expect(entries.has("cover.webp")).toBe(true)
   })
 
   it("rewrites references only for the images it actually converted", async () => {
@@ -183,6 +188,93 @@ describe("compressArchiveImages", () => {
     expect(entries.has("images/animation.webp")).toBe(false)
     expect(entries.has("images/photo.webp")).toBe(true)
     expect(compress).toHaveBeenCalledOnce()
+  })
+
+  it("resizes jpeg and png images in place when keeping their original format", async () => {
+    compress.mockResolvedValue({
+      status: "ok",
+      bytes: arrayBufferOf("resized"),
+    })
+
+    const entries = archiveOf({
+      "images/photo.jpg": bytesOf("original-jpeg"),
+      "images/illustration.png": bytesOf("original-png"),
+      "chapter.xhtml": `<img src="images/photo.jpg"/>`,
+    })
+
+    const result = await compressArchiveImages(
+      entries,
+      { maxWidth: 800, maxHeight: 1200, outputMode: "original" },
+      { stageBytes },
+    )
+
+    expect(result).toEqual({
+      totalImages: 2,
+      compressedCount: 2,
+      skippedCount: 0,
+    })
+    expect(entries.has("images/photo.jpg")).toBe(true)
+    expect(entries.has("images/illustration.png")).toBe(true)
+    expect(entries.has("images/photo.webp")).toBe(false)
+    expect(await textOf(entries, "chapter.xhtml")).toBe(
+      `<img src="images/photo.jpg"/>`,
+    )
+    expect(compress).toHaveBeenNthCalledWith(1, expect.any(ArrayBuffer), {
+      maxWidth: 800,
+      maxHeight: 1200,
+      outputType: "image/jpeg",
+      skipIfUnscaled: true,
+    })
+    expect(compress).toHaveBeenNthCalledWith(2, expect.any(ArrayBuffer), {
+      maxWidth: 800,
+      maxHeight: 1200,
+      outputType: "image/png",
+      skipIfUnscaled: true,
+    })
+  })
+
+  it("leaves formats the browser cannot re-encode unchanged in original mode", async () => {
+    compress.mockResolvedValue({
+      status: "ok",
+      bytes: arrayBufferOf("resized"),
+    })
+
+    const entries = archiveOf({
+      "images/photo.bmp": bytesOf("original-bmp"),
+      "images/photo.jpg": bytesOf("original-jpeg"),
+    })
+
+    const result = await compressArchiveImages(
+      entries,
+      { maxWidth: 800, maxHeight: undefined, outputMode: "original" },
+      { stageBytes },
+    )
+
+    expect(result.totalImages).toBe(1)
+    expect(entries.has("images/photo.bmp")).toBe(true)
+    expect(entries.has("images/photo.jpg")).toBe(true)
+    expect(compress).toHaveBeenCalledOnce()
+  })
+
+  it("keeps a resized original-format image even when its byte size grows", async () => {
+    compress.mockResolvedValue({
+      status: "ok",
+      bytes: arrayBufferOf("resized-but-larger"),
+    })
+    const stageResizedBytes = vi.fn(stageBytes)
+
+    const entries = archiveOf({ "cover.jpg": bytesOf("tiny") })
+
+    const result = await compressArchiveImages(
+      entries,
+      { maxWidth: 800, maxHeight: undefined, outputMode: "original" },
+      { stageBytes: stageResizedBytes },
+    )
+
+    expect(result).toMatchObject({ compressedCount: 1, skippedCount: 0 })
+    expect(new TextDecoder().decode(stageResizedBytes.mock.calls[0]?.[0])).toBe(
+      "resized-but-larger",
+    )
   })
 
   it("reports progress for every processed image", async () => {

--- a/packages/archive-metadata/src/images/compress.ts
+++ b/packages/archive-metadata/src/images/compress.ts
@@ -5,13 +5,54 @@ import {
 } from "../update/editableArchive"
 import { report } from "../utils/report"
 import type { StageBytes } from "../update/staging"
-import { isConvertibleImagePath, replaceExtensionWithWebp } from "./paths"
+import {
+  getPreservableImageMediaType,
+  isConvertibleImagePath,
+  replaceExtensionWithWebp,
+  WEBP_MEDIA_TYPE,
+  type PreservableImageMediaType,
+} from "./paths"
 import { createImageCompressionPool } from "./compressionPool"
 import { mapWithConcurrency } from "../utils/mapWithConcurrency"
 import { rewriteImageReferences } from "./rewriteReferences"
 import type { ImageCompressionConfig, ImageCompressionResult } from "./types"
 
 const MAX_IMAGE_COMPRESSION_CONCURRENCY = 2
+
+type CompressibleImage = {
+  path: string
+  content: EntryContent
+  outputType: PreservableImageMediaType | typeof WEBP_MEDIA_TYPE
+}
+
+const listCompressibleImages = (
+  entries: EditableArchive,
+  outputMode: ImageCompressionConfig["outputMode"],
+): CompressibleImage[] => {
+  const images: CompressibleImage[] = []
+
+  for (const [path, entry] of entries) {
+    if (entry.dir) continue
+
+    if (outputMode === "webp") {
+      if (isConvertibleImagePath(path)) {
+        images.push({
+          path,
+          content: entry.content,
+          outputType: WEBP_MEDIA_TYPE,
+        })
+      }
+
+      continue
+    }
+
+    const outputType = getPreservableImageMediaType(path)
+
+    if (outputType) images.push({ path, content: entry.content, outputType })
+  }
+
+  return images
+}
 
 /**
  * Identifies images whose `.webp` target would clash with another archive
@@ -68,15 +109,16 @@ export const compressArchiveImages = async (
     onProgress?: (completed: number, total: number) => void
   },
 ): Promise<ImageCompressionResult> => {
-  const images: { path: string; content: EntryContent }[] = [...entries]
-    .filter(([path, entry]) => !entry.dir && isConvertibleImagePath(path))
-    .map(([path, entry]) => ({ path, content: entry.content }))
+  const images = listCompressibleImages(entries, config.outputMode)
   const total = images.length
 
   if (total === 0)
     return { totalImages: 0, compressedCount: 0, skippedCount: 0 }
 
-  const collidingNames = findCollidingWebpTargets(entries, images)
+  const collidingNames =
+    config.outputMode === "webp"
+      ? findCollidingWebpTargets(entries, images)
+      : new Set<string>()
 
   const compressionConcurrency = Math.min(
     navigator.hardwareConcurrency || MAX_IMAGE_COMPRESSION_CONCURRENCY,
@@ -102,19 +144,19 @@ export const compressArchiveImages = async (
         }
 
         const original = await readEntryArrayBuffer(image.content)
-        const originalByteLength = original.byteLength
-        const result = await pool.compress(
-          original,
-          config.maxWidth,
-          config.maxHeight,
-        )
+        const result = await pool.compress(original, {
+          maxWidth: config.maxWidth,
+          maxHeight: config.maxHeight,
+          outputType: image.outputType,
+          skipIfUnscaled: config.outputMode === "original",
+        })
 
-        const isSmaller =
-          result.status === "ok" && result.bytes.byteLength < originalByteLength
-
-        if (result.status === "ok" && isSmaller) {
+        if (result.status === "ok") {
           const oldPath = image.path
-          const newPath = replaceExtensionWithWebp(oldPath)
+          const newPath =
+            config.outputMode === "webp"
+              ? replaceExtensionWithWebp(oldPath)
+              : oldPath
 
           if (newPath !== oldPath) {
             entries.delete(oldPath)
@@ -141,6 +183,7 @@ export const compressArchiveImages = async (
   await rewriteImageReferences(entries, renamedPaths)
 
   report.info("image compression", {
+    outputMode: config.outputMode,
     totalImages: total,
     compressedCount,
     skippedCount,

--- a/packages/archive-metadata/src/images/compression.types.ts
+++ b/packages/archive-metadata/src/images/compression.types.ts
@@ -1,8 +1,16 @@
+import type { PreservableImageMediaType } from "./paths"
+
+export type ImageOutputMediaType = PreservableImageMediaType | "image/webp"
+
 export type ImageCompressionRequest = {
   bytes: ArrayBuffer
   maxWidth: number | undefined
   maxHeight: number | undefined
+  outputType: ImageOutputMediaType
+  skipIfUnscaled: boolean
 }
+
+export type ImageCompressionOptions = Omit<ImageCompressionRequest, "bytes">
 
 export type ImageCompressionResponse =
   | { status: "ok"; bytes: ArrayBuffer }

--- a/packages/archive-metadata/src/images/compression.worker.ts
+++ b/packages/archive-metadata/src/images/compression.worker.ts
@@ -20,10 +20,19 @@ const compress = async ({
   bytes,
   maxWidth,
   maxHeight,
+  outputType,
+  skipIfUnscaled,
 }: ImageCompressionRequest): Promise<ImageCompressionResponse> => {
   try {
     const bitmap = await createImageBitmap(new Blob([bytes]))
     const scale = computeScale(bitmap.width, bitmap.height, maxWidth, maxHeight)
+
+    if (skipIfUnscaled && scale === 1) {
+      bitmap.close()
+
+      return { status: "skipped" }
+    }
+
     const targetWidth = Math.max(1, Math.round(bitmap.width * scale))
     const targetHeight = Math.max(1, Math.round(bitmap.height * scale))
 
@@ -39,7 +48,10 @@ const compress = async ({
     context.drawImage(bitmap, 0, 0, targetWidth, targetHeight)
     bitmap.close()
 
-    const blob = await canvas.convertToBlob({ type: "image/webp" })
+    const blob = await canvas.convertToBlob({ type: outputType })
+
+    if (blob.type !== outputType) return { status: "skipped" }
+
     const output = await blob.arrayBuffer()
 
     return { status: "ok", bytes: output }

--- a/packages/archive-metadata/src/images/compressionPool.ts
+++ b/packages/archive-metadata/src/images/compressionPool.ts
@@ -1,5 +1,6 @@
 import { createWorkerPool } from "../utils/workerPool/createWorkerPool"
 import type {
+  ImageCompressionOptions,
   ImageCompressionRequest,
   ImageCompressionResponse,
 } from "./compression.types"
@@ -9,8 +10,7 @@ export type CompressionResult = ImageCompressionResponse
 export type ImageCompressionPool = {
   compress: (
     bytes: ArrayBuffer,
-    maxWidth: number | undefined,
-    maxHeight: number | undefined,
+    options: ImageCompressionOptions,
   ) => Promise<CompressionResult>
   terminate: () => void
 }
@@ -30,8 +30,7 @@ export const createImageCompressionPool = (
   })
 
   return {
-    compress: (bytes, maxWidth, maxHeight) =>
-      pool.run({ bytes, maxWidth, maxHeight }, [bytes]),
+    compress: (bytes, options) => pool.run({ bytes, ...options }, [bytes]),
     terminate: pool.terminate,
   }
 }

--- a/packages/archive-metadata/src/images/paths.ts
+++ b/packages/archive-metadata/src/images/paths.ts
@@ -11,6 +11,18 @@ export const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set([
 ])
 
 export const WEBP_EXTENSION = ".webp"
+export const WEBP_MEDIA_TYPE = "image/webp"
+
+export type PreservableImageMediaType = "image/jpeg" | "image/png"
+
+const PRESERVABLE_IMAGE_MEDIA_TYPES: ReadonlyMap<
+  string,
+  PreservableImageMediaType
+> = new Map([
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".png", "image/png"],
+])
 
 /**
  * Subset of {@link IMAGE_EXTENSIONS} we convert to WebP. Restricted to static
@@ -38,6 +50,10 @@ export const CONVERTIBLE_IMAGE_FORMAT_NAMES: readonly string[] = [
   ...CONVERTIBLE_IMAGE_EXTENSIONS,
 ].map((extension) => extension.slice(1).toUpperCase())
 
+export const PRESERVABLE_IMAGE_FORMAT_NAMES: readonly string[] = [
+  ...PRESERVABLE_IMAGE_MEDIA_TYPES.keys(),
+].map((extension) => extension.slice(1).toUpperCase())
+
 export const getExtension = (path: string): string => {
   const lastDot = path.lastIndexOf(".")
   const lastSlash = path.lastIndexOf("/")
@@ -52,6 +68,11 @@ export const isImagePath = (path: string): boolean =>
 
 export const isConvertibleImagePath = (path: string): boolean =>
   CONVERTIBLE_IMAGE_EXTENSIONS.has(getExtension(path))
+
+export const getPreservableImageMediaType = (
+  path: string,
+): PreservableImageMediaType | undefined =>
+  PRESERVABLE_IMAGE_MEDIA_TYPES.get(getExtension(path))
 
 export const replaceExtensionWithWebp = (path: string): string => {
   const extension = getExtension(path)

--- a/packages/archive-metadata/src/images/rewriteReferences.ts
+++ b/packages/archive-metadata/src/images/rewriteReferences.ts
@@ -3,6 +3,7 @@ import {
   getExtension,
   IMAGE_EXTENSIONS,
   replaceExtensionWithWebp,
+  WEBP_MEDIA_TYPE,
 } from "./paths"
 
 const TEXT_REFERENCE_EXTENSIONS: ReadonlySet<string> = new Set([
@@ -16,8 +17,6 @@ const TEXT_REFERENCE_EXTENSIONS: ReadonlySet<string> = new Set([
 ])
 
 const OPF_EXTENSION = ".opf"
-const WEBP_MEDIA_TYPE = "image/webp"
-
 const getDirname = (path: string): string => {
   const lastSlash = path.lastIndexOf("/")
 

--- a/packages/archive-metadata/src/images/types.ts
+++ b/packages/archive-metadata/src/images/types.ts
@@ -1,6 +1,9 @@
+export type ImageOutputMode = "webp" | "original"
+
 export type ImageCompressionConfig = {
   maxWidth: number | undefined
   maxHeight: number | undefined
+  outputMode: ImageOutputMode
 }
 
 export type ImageCompressionResult = {

--- a/packages/archive-metadata/src/update/actions.ts
+++ b/packages/archive-metadata/src/update/actions.ts
@@ -15,8 +15,8 @@ export type PatchMetadataAction = {
 }
 
 /**
- * Re-encodes the archive's images to WebP and rewrites every reference to them.
- * Needs a canvas-and-worker runtime, so only the web entrypoint accepts it.
+ * Resizes the archive's images and optionally re-encodes them to WebP. Needs a
+ * canvas-and-worker runtime, so only the web entrypoint accepts it.
  */
 export type CompressImagesAction = {
   kind: "compress-images"

--- a/packages/archive-metadata/src/web.ts
+++ b/packages/archive-metadata/src/web.ts
@@ -15,8 +15,14 @@ import {
 export * from "./common"
 
 export type { CompressImagesAction } from "./update/actions"
-export type { ImageCompressionConfig } from "./images/types"
-export { CONVERTIBLE_IMAGE_FORMAT_NAMES } from "./images/paths"
+export type {
+  ImageCompressionConfig,
+  ImageOutputMode,
+} from "./images/types"
+export {
+  CONVERTIBLE_IMAGE_FORMAT_NAMES,
+  PRESERVABLE_IMAGE_FORMAT_NAMES,
+} from "./images/paths"
 export type { ImageResolution } from "./images/inspect"
 export {
   listImageEntries,


### PR DESCRIPTION
## Summary

- require confirmation before applying local book updates
- list each effective metadata, image, reference, and file-replacement action in a structured MUI dialog
- highlight important values such as ISBNs, formats, dimensions, and output formats with chips
- log the exact pending action array before confirmation for debugging
- allow structured React content in template-dialog messages

## Why

Applying locally previously started the archive mutation immediately and replaced the downloaded file without showing the user exactly what would change. The new confirmation uses the same action array that is passed to the mutation, so the review cannot drift from the actual update.

## User impact

Users can review or cancel every local update before the downloaded book is rewritten.

## Validation

- 49 Vitest files passed (280 tests)
- TypeScript project build passed
- Biome checks passed