### PR TITLE
refactor(web): use shared ControlledTextField for hand-rolled form fields

### DIFF
--- a/apps/web/src/auth/AuthorizeActionDialog.tsx
+++ b/apps/web/src/auth/AuthorizeActionDialog.tsx
@@ -7,11 +7,10 @@ import {
   DialogContentText,
   DialogTitle,
   FormControlLabel,
-  TextField,
 } from "@mui/material"
 import { useEffect } from "react"
 import { Controller, useForm } from "react-hook-form"
-import { errorToHelperText } from "../common/forms/errorToHelperText"
+import { ControlledTextField } from "../common/forms/ControlledTextField"
 import { signal, useMutation$, useSignalValue } from "reactjrx"
 import { type Observable, from, map, mergeMap, of } from "rxjs"
 import { getLatestDatabase } from "../rxdb/RxDbProvider"
@@ -168,25 +167,15 @@ export const AuthorizeActionDialog = () => {
               })
             })}
           >
-            <Controller
+            <ControlledTextField
               name="password"
               control={control}
               rules={{ required: true }}
-              render={({ field: { ref, ...rest }, fieldState }) => {
-                return (
-                  <TextField
-                    {...rest}
-                    label="Password"
-                    type="password"
-                    fullWidth
-                    margin="normal"
-                    inputRef={ref}
-                    autoComplete="current-password"
-                    error={fieldState.invalid}
-                    helperText={errorToHelperText(fieldState.error)}
-                  />
-                )
-              }}
+              label="Password"
+              type="password"
+              fullWidth
+              margin="normal"
+              autoComplete="current-password"
             />
             <Controller
               name="authorizeFor5Min"

--- a/apps/web/src/auth/CompleteSignUpForm.tsx
+++ b/apps/web/src/auth/CompleteSignUpForm.tsx
@@ -1,6 +1,6 @@
-import { Button, Stack, TextField } from "@mui/material"
-import { Controller, useForm } from "react-hook-form"
-import { errorToHelperText } from "../common/forms/errorToHelperText"
+import { Button, Stack } from "@mui/material"
+import { useForm } from "react-hook-form"
+import { ControlledTextField } from "../common/forms/ControlledTextField"
 import { PersonAdd } from "@mui/icons-material"
 
 type Inputs = {
@@ -29,26 +29,16 @@ export const CompleteSignUpForm = ({
         gap: 1,
       }}
     >
-      <Controller
+      <ControlledTextField
         name="password"
         control={control}
         rules={{ required: true, minLength: 8 }}
-        render={({ field: { ref, ...rest }, fieldState }) => {
-          return (
-            <TextField
-              {...rest}
-              label="Password"
-              type="password"
-              fullWidth
-              inputRef={ref}
-              autoComplete="new-password"
-              error={fieldState.invalid}
-              helperText={errorToHelperText(fieldState.error)}
-            />
-          )
-        }}
+        label="Password"
+        type="password"
+        fullWidth
+        autoComplete="new-password"
       />
-      <Controller
+      <ControlledTextField
         name="confirmPassword"
         control={control}
         rules={{
@@ -56,20 +46,10 @@ export const CompleteSignUpForm = ({
           validate: (value) =>
             value === getValues("password") || "Passwords must match",
         }}
-        render={({ field: { ref, ...rest }, fieldState }) => {
-          return (
-            <TextField
-              {...rest}
-              label="Confirm password"
-              type="password"
-              fullWidth
-              inputRef={ref}
-              autoComplete="new-password"
-              error={fieldState.invalid}
-              helperText={errorToHelperText(fieldState.error)}
-            />
-          )
-        }}
+        label="Confirm password"
+        type="password"
+        fullWidth
+        autoComplete="new-password"
       />
       <Button
         type="submit"

--- a/apps/web/src/auth/SignInForm.tsx
+++ b/apps/web/src/auth/SignInForm.tsx
@@ -1,10 +1,6 @@
-import { Button, Stack, TextField } from "@mui/material"
-import {
-  Controller,
-  type Control,
-  type UseFormHandleSubmit,
-} from "react-hook-form"
-import { errorToHelperText } from "../common/forms/errorToHelperText"
+import { Button, Stack } from "@mui/material"
+import type { Control, UseFormHandleSubmit } from "react-hook-form"
+import { ControlledTextField } from "../common/forms/ControlledTextField"
 import { Login } from "@mui/icons-material"
 
 export type SignInFormInputs = {
@@ -30,43 +26,23 @@ export const SignInForm = ({
         gap: 1,
       }}
     >
-      <Controller
+      <ControlledTextField
         name="email"
         control={control}
         rules={{ required: true }}
-        render={({ field: { ref, ...rest }, fieldState }) => {
-          return (
-            <TextField
-              {...rest}
-              label="Email"
-              type="email"
-              fullWidth
-              inputRef={ref}
-              autoComplete="email"
-              error={fieldState.invalid}
-              helperText={errorToHelperText(fieldState.error)}
-            />
-          )
-        }}
+        label="Email"
+        type="email"
+        fullWidth
+        autoComplete="email"
       />
-      <Controller
+      <ControlledTextField
         name="password"
         control={control}
         rules={{ required: true }}
-        render={({ field: { ref, ...rest }, fieldState }) => {
-          return (
-            <TextField
-              {...rest}
-              label="Password"
-              type="password"
-              fullWidth
-              inputRef={ref}
-              autoComplete="current-password"
-              error={fieldState.invalid}
-              helperText={errorToHelperText(fieldState.error)}
-            />
-          )
-        }}
+        label="Password"
+        type="password"
+        fullWidth
+        autoComplete="current-password"
       />
       <Button
         type="submit"

--- a/apps/web/src/auth/SignUpForm.tsx
+++ b/apps/web/src/auth/SignUpForm.tsx
@@ -1,6 +1,6 @@
-import { Button, Stack, TextField } from "@mui/material"
-import { Controller, useForm } from "react-hook-form"
-import { errorToHelperText } from "../common/forms/errorToHelperText"
+import { Button, Stack } from "@mui/material"
+import { useForm } from "react-hook-form"
+import { ControlledTextField } from "../common/forms/ControlledTextField"
 import { PersonAdd } from "@mui/icons-material"
 
 type Inputs = {
@@ -27,7 +27,7 @@ export const SignUpForm = ({
         gap: 1,
       }}
     >
-      <Controller
+      <ControlledTextField
         name="email"
         control={control}
         rules={{
@@ -37,20 +37,10 @@ export const SignUpForm = ({
             message: "Invalid email format",
           },
         }}
-        render={({ field: { ref, ...rest }, fieldState }) => {
-          return (
-            <TextField
-              {...rest}
-              label="Email"
-              type="email"
-              fullWidth
-              inputRef={ref}
-              autoComplete="email"
-              error={fieldState.invalid}
-              helperText={errorToHelperText(fieldState.error)}
-            />
-          )
-        }}
+        label="Email"
+        type="email"
+        fullWidth
+        autoComplete="email"
       />
       <Button
         type="submit"

--- a/apps/web/src/tags/AddTagDialog.tsx
+++ b/apps/web/src/tags/AddTagDialog.tsx
@@ -5,12 +5,11 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  TextField,
 } from "@mui/material"
-import { Controller, type SubmitHandler, useForm } from "react-hook-form"
+import { type SubmitHandler, useForm } from "react-hook-form"
 import { signal, useSignalValue } from "reactjrx"
 import { useCreateTag } from "./helpers"
-import { errorToHelperText } from "../common/forms/errorToHelperText"
+import { ControlledTextField } from "../common/forms/ControlledTextField"
 import { CancelButton } from "../common/forms/CancelButton"
 
 type Inputs = {
@@ -67,24 +66,14 @@ export function AddTagDialog() {
       <DialogTitle>Create a new tag</DialogTitle>
       <DialogContent>
         <form id={FORM_ID} onSubmit={handleSubmit(onSubmit)}>
-          <Controller
+          <ControlledTextField
             name="name"
             control={control}
             rules={{ required: true }}
-            render={({ field: { ref, ...rest }, fieldState }) => {
-              return (
-                <TextField
-                  {...rest}
-                  label="Name"
-                  type="text"
-                  fullWidth
-                  margin="normal"
-                  inputRef={ref}
-                  error={fieldState.invalid}
-                  helperText={errorToHelperText(fieldState.error)}
-                />
-              )
-            }}
+            label="Name"
+            type="text"
+            fullWidth
+            margin="normal"
           />
         </form>
       </DialogContent>


### PR DESCRIPTION
## Consolidation: `Controller` + `TextField` + `errorToHelperText` → `ControlledTextField`

**What was duplicated**

`apps/web/src/common/forms/ControlledTextField.tsx` already exists and renders exactly the `Controller` → `TextField` wiring (spread field, `inputRef={ref}`, `error={fieldState.invalid}`, `helperText` from `errorToHelperText`). Seven call sites hand-rolled that same render prop instead:

- `apps/web/src/auth/SignInForm.tsx` (email, password)
- `apps/web/src/auth/SignUpForm.tsx` (email)
- `apps/web/src/auth/CompleteSignUpForm.tsx` (password, confirm password)
- `apps/web/src/auth/AuthorizeActionDialog.tsx` (password — the checkbox `Controller` in the same form stays as-is)
- `apps/web/src/tags/AddTagDialog.tsx` (name)

**What it became**

Each block is now a `<ControlledTextField name … control … rules … />` with the same `label` / `type` / `fullWidth` / `margin` / `autoComplete` props, matching how `SetupSecretDialog`, `ConnectorForm`, `DataSourceFormLayout`, `MetadataForm` and the webdav data-source form already call it.

**Net LOC delta:** 48 insertions / 124 deletions → **−76 lines**, 5 files, no new files or abstractions.

**Why these are the same concept**

They are not merely similar — they are the same render prop, character for character, differing only in the props forwarded to `TextField`. Error wiring lived in seven places and now lives in one. Behaviour is identical: for an invalid field both paths produce `errorToHelperText(fieldState.error)`; for a valid field the hand-rolled version produced `undefined` (`errorToHelperText(undefined)`) and `ControlledTextField` falls back to the passed `helperText`, which none of these call sites set.

## Gates

Run before and after on the same checkout:

| Gate | Baseline (develop) | After |
| --- | --- | --- |
| `pnpm run lint` | pass (3 warnings, 7 infos) | pass (same 3 warnings, 7 infos) |
| `pnpm run build` | pass (7 projects) | pass (7 projects) |
| `pnpm run test` | **15 failing** in `apps/web/src/http/HttpClientApi.web.test.ts` (12) and `httpClientApi.sw.test.ts` (3) | same 15 failing, same tests — no new failures |

The failing http auth-refresh specs are pre-existing on `develop` and untouched by this PR.

## Other duplication found, left for a follow-up

Recorded here so it is not re-discovered from scratch:

1. **Dead copy of the book-action drawer signal.** `apps/web/src/secrets/SecretActionDrawer.tsx` carries a verbatim copy of `bookActionDrawerSignal` + `useBookActionDrawer` from `books/drawer/BookActionsDrawer.tsx` — including the same `"bookActionDrawerState"` signal key — with no consumers. ~30 lines of pure deletion.
2. **Optimistic notification mutation options.** `useArchiveNotification.ts`, `useMarkNotificationAsSeen.ts` and `useMarkAllNotificationsAsSeen.ts` share the same skeleton (`networkMode`, snapshot in `onMutate`, rollback in `onError`, invalidate in `onSettled`); only the optimistic list/count update differs. A factory taking that update as a callback would remove ~40 lines.
3. **Form-bound `ConnectorSelector`.** `plugins/server/DataSourceForm.tsx` and `plugins/webdav/DataSourceForm.tsx` repeat the identical `Controller` → `ConnectorSelector` block; roughly LOC-neutral to extract, so it did not meet the bar here.

Deliberately **not** consolidated: the twin `migrateResourceIdToData` implementations in `apps/api/src/migrations/migration.service.ts` and `apps/web/src/rxdb/collections/utils.ts`. They are near-identical, but the api file documents the choice explicitly ("intentionally does not rely on shared runtime helpers because a data migration should keep working the same way in the future"), so the duplication is a frozen migration snapshot by design. Same reasoning for the per-plugin `useRefreshMetadata` / `useSynchronize` pairs in dropbox and one-drive: their bodies coincide today, but they are separate plugin capabilities that already diverge in the google plugin.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYdvjtZuXtbUfFEaA42dcm)_