### PR TITLE
fix: address release review feedback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,6 +146,8 @@ jobs:
           context: ./
           file: dockerfile
           target: web
+          build-args: |
+            GITHUB_SHA=${{ needs.release.outputs.sha }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/apps/web/src/books/optimize/actions/useRevertLocalChanges.test.tsx
+++ b/apps/web/src/books/optimize/actions/useRevertLocalChanges.test.tsx
@@ -16,6 +16,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
   downloadBook,
+  getBookFile,
   removeDownloadFile,
   showConfirmDialog,
   useDownloadBook,
@@ -26,6 +27,11 @@ const {
 
   return {
     downloadBook,
+    getBookFile: vi.fn(async function getCachedBookFile(): Promise<{
+      data: File
+    } | null> {
+      return null
+    }),
     removeDownloadFile,
     showConfirmDialog: vi.fn(async function confirmRevert() {
       return true
@@ -44,6 +50,9 @@ vi.mock("../../../common/dialogs/presets", function mockDialogs() {
 })
 vi.mock("../../../download", function mockDownloads() {
   return { useDownloadBook }
+})
+vi.mock("../../../download/getBookFile.shared", function mockGetBookFile() {
+  return { getBookFile }
 })
 vi.mock(
   "../../../download/useRemoveDownloadFile",
@@ -191,6 +200,47 @@ describe("useRevertLocalChanges", function testUseRevertLocalChanges() {
 
       await replacementDownload.promise.catch(function ignoreExpectedError() {})
     })
+
+    await waitFor(function waitForErrorNotification() {
+      expect(onMutationError).toHaveBeenCalledTimes(1)
+      expect(onMutationError.mock.calls[0]?.[0]).toBe(error)
+      expect(result.current.isReverting).toBe(false)
+    })
+  })
+
+  it("puts the previous local file back when the replacement download fails", async function restorePreviousLocalFile() {
+    const previousLocalFile = new File(["previous"], "book.epub")
+    const error = new Error("replacement download failed")
+    const onMutationError = vi.fn(function reportGlobalMutationError(
+      _error: Error,
+    ) {})
+    getBookFile.mockResolvedValueOnce({ data: previousLocalFile })
+    downloadBook.mockRejectedValueOnce(error)
+    const { result } = renderHook(
+      function renderUseRevertLocalChanges() {
+        return useRevertLocalChanges({ book, link })
+      },
+      {
+        wrapper: createWrapper(onMutationError),
+      },
+    )
+
+    await act(async function startRevert() {
+      await result.current.revertLocalChanges()
+    })
+
+    await waitFor(function waitForLocalFileRestore() {
+      expect(downloadBook).toHaveBeenNthCalledWith(2, {
+        _id: book._id,
+        links: book.links,
+        file: previousLocalFile,
+      })
+    })
+
+    expect(getBookFile).toHaveBeenCalledWith(book._id)
+    expect(getBookFile.mock.invocationCallOrder[0]).toBeLessThan(
+      removeDownloadFile.mock.invocationCallOrder[0] ?? 0,
+    )
 
     await waitFor(function waitForErrorNotification() {
       expect(onMutationError).toHaveBeenCalledTimes(1)

--- a/apps/web/src/books/optimize/actions/useRevertLocalChanges.ts
+++ b/apps/web/src/books/optimize/actions/useRevertLocalChanges.ts
@@ -7,7 +7,9 @@ import {
 } from "@oboku/shared"
 import type { DeepReadonlyObject } from "rxdb"
 import { showConfirmDialog } from "../../../common/dialogs/presets"
+import { Logger } from "../../../debug/logger.shared"
 import { useDownloadBook } from "../../../download"
+import { getBookFile } from "../../../download/getBookFile.shared"
 import { useRemoveDownloadFile } from "../../../download/useRemoveDownloadFile"
 
 export const useRevertLocalChanges = ({
@@ -36,8 +38,27 @@ export const useRevertLocalChanges = ({
 
   const { mutate: revert, isPending: isReverting } = useMutation({
     mutationFn: async function restoreOriginalDownload() {
+      const previousLocalFile = await getBookFile(bookId)
+
+      // The download flow resolves immediately when a file is already cached,
+      // so the local file has to be gone before the original can be fetched.
       await removeDownloadFile({ bookId })
-      await downloadBook({ _id: bookId, links: bookLinks })
+
+      try {
+        await downloadBook({ _id: bookId, links: bookLinks })
+      } catch (downloadError) {
+        if (previousLocalFile) {
+          await downloadBook({
+            _id: bookId,
+            links: bookLinks,
+            file: previousLocalFile.data,
+          }).catch(function reportLocalFileRestoreFailure(restoreError) {
+            Logger.error(restoreError)
+          })
+        }
+
+        throw downloadError
+      }
     },
   })
 

--- a/apps/web/src/queries/persister.ts
+++ b/apps/web/src/queries/persister.ts
@@ -7,11 +7,11 @@ import { dexieDb } from "../rxdb/dexie"
 const PERSIST_KEY = "queryCache.persistedClient"
 
 /**
- * Cache namespace for persisted queries/mutations. Keyed on the build rather
- * than the product version, so state persisted by an older build is discarded
- * on restore instead of rehydrated even when several builds ship under the same
- * version. Shared by every writer (the provider and any manual
- * `persistQueryClientSave`) so a snapshot always survives restore.
+ * Cache namespace for persisted queries/mutations. Keyed on the build id (the
+ * commit sha when the build knows it, the product version otherwise), so state
+ * persisted by an older build is discarded on restore instead of rehydrated.
+ * Shared by every writer (the provider and any manual `persistQueryClientSave`)
+ * so a snapshot always survives restore.
  */
 export const persistBuster = __BUILD_ID__
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -11,11 +11,14 @@ const productVersion = JSON.parse(
   readFileSync(path.resolve(__dirname, "../../package.json"), "utf8"),
 ).version
 
-const buildId = (
-  process.env.GITHUB_SHA ??
-  process.env.VERCEL_GIT_COMMIT_SHA ??
-  "dev"
-).slice(0, 7)
+const commitSha = [
+  process.env.GITHUB_SHA,
+  process.env.VERCEL_GIT_COMMIT_SHA,
+].find(function isNonEmptySha(sha) {
+  return !!sha
+})
+
+const buildId = commitSha?.slice(0, 7) ?? productVersion
 
 const manualChunkGroups = [
   ["dropbox", ["dropbox"]],

--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,9 @@
-# node:25 no longer bundles corepack, so install pnpm explicitly
-# (version kept in sync with the root package.json `packageManager` field).
+# node:25 no longer bundles corepack, so install pnpm explicitly, reading the
+# version from the root package.json `packageManager` field so it cannot drift.
 FROM node:25 AS node-pnpm
-RUN npm install -g pnpm@11.17.0
+WORKDIR /usr/src/app
+COPY package.json ./
+RUN npm install -g "pnpm@$(node -p 'require("./package.json").packageManager.replace(/^pnpm@/, "").split("+")[0]')"
 
 # pnpm needs every workspace manifest present to install with a frozen
 # lockfile, so the base stage installs once for the whole monorepo and app
@@ -46,6 +48,8 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]
 
 FROM node-pnpm AS web-build
+ARG GITHUB_SHA
+ENV GITHUB_SHA=${GITHUB_SHA}
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app .
 COPY apps/web ./apps/web


### PR DESCRIPTION
Fixes the three Codex review comments left on the release PR #551.

## Revert: keep the local file until the replacement is secured

`useRevertLocalChanges` deleted the cached book file before knowing whether the original could be re-downloaded, so a failed or cancelled download (expired credentials, network outage, remote file removed) left the book with no local copy at all.

The delete-first order is required — `DownloadFlowRequestItem` resolves immediately when a file is already cached — so instead the file is captured with `getBookFile` up front and re-persisted through `downloadBook({ file })` if the replacement download fails. That path also restores the download state signal, so the UI does not show "not downloaded" over a file that is still there. The download error remains what the mutation throws; a failed restore is only logged.

## Docker web builds: a real build id

`persistBuster` keys the persisted React Query cache on `__BUILD_ID__`, which fell back to the literal `dev` outside Vercel/GitHub-hosted builds — so Docker releases kept rehydrating state persisted by older builds.

- The `web-build` stage takes `GITHUB_SHA` as a build arg, and the deploy workflow passes the release SHA, keying official images on the commit exactly like Vercel.
- `buildId` falls back to the product version instead of `dev`, covering self-hosted builds that pass no arg. Empty-string env vars are filtered, since an unset `ARG` yields `""` rather than undefined.

## Docker pnpm version

The root `packageManager` pin moved to `pnpm@11.18.0` while the Dockerfile still installed `11.17.0`, despite a comment claiming the two were in sync. The stage now reads the version from `packageManager` (stripping any corepack `+sha` suffix) so it cannot drift again.

## Verification

- `tsc -b` and `biome check` clean; `useRevertLocalChanges` tests pass, including a new one covering the restore path.
- The full web suite has 37 pre-existing failures in this environment (`navigator.locks`/msal/rxdb), identical before and after these changes.
- The Dockerfile changes are unverified beyond the extracted shell expression — no Docker available here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaSeCFNdvzsbVpbdveuoof)_