### PR TITLE
chore(web): upgrade react-router to v8

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,7 +52,7 @@
     "react-hook-form": "^7.84.0",
     "react-icons": "^5.7.0",
     "react-markdown": "^10.1.0",
-    "react-router": "^7.18.2",
+    "react-router": "^8.3.0",
     "react-use": "^17.6.1",
     "react-virtuoso": "^4.18.11",
     "reactjrx": "^1.141.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,8 +565,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.8)(supports-color@8.1.1)
       react-router:
-        specifier: ^7.18.2
-        version: 7.18.2(react-dom@19.2.8(patch_hash=eda7f72ff7076aa1e9cbd0658e127b62fc003ed7c2288ee37641781916dad53e)(react@19.2.8))(react@19.2.8)
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.8(patch_hash=eda7f72ff7076aa1e9cbd0658e127b62fc003ed7c2288ee37641781916dad53e)(react@19.2.8))(react@19.2.8)
       react-use:
         specifier: ^17.6.1
         version: 17.6.1(react-dom@19.2.8(patch_hash=eda7f72ff7076aa1e9cbd0658e127b62fc003ed7c2288ee37641781916dad53e)(react@19.2.8))(react@19.2.8)
@@ -7154,10 +7154,6 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
-
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
@@ -7221,6 +7217,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -11091,12 +11088,12 @@ packages:
       '@types/react':
         optional: true
 
-  react-router@7.18.2:
-    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -11547,9 +11544,6 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -20550,8 +20544,6 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  cookie@1.1.1: {}
-
   cookiejar@2.1.4: {}
 
   copy-to-clipboard@3.3.3:
@@ -25458,11 +25450,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  react-router@7.18.2(react-dom@19.2.8(patch_hash=eda7f72ff7076aa1e9cbd0658e127b62fc003ed7c2288ee37641781916dad53e)(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(patch_hash=eda7f72ff7076aa1e9cbd0658e127b62fc003ed7c2288ee37641781916dad53e)(react@19.2.8))(react@19.2.8):
     dependencies:
-      cookie: 1.1.1
+      cookie-es: 3.1.1
       react: 19.2.8
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.8(patch_hash=eda7f72ff7076aa1e9cbd0658e127b62fc003ed7c2288ee37641781916dad53e)(react@19.2.8)
 
@@ -26070,8 +26061,6 @@ snapshots:
       send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## The update

| | |
|---|---|
| **Package** | `react-router` (in `@oboku/web`) |
| **Version** | `^7.18.2` → `^8.3.0` |
| **Type** | Major |
| **Motivation** | Security (advisory closed) |

**Why now (security):** `pnpm audit` flags react-router **HIGH** — *"React Router: RSC Mode CSRF Bypass Allows Action Execution Before 400 Response"*, affecting `>=7.12.0 <8.3.0` (patched in `8.3.0`). The installed `7.18.2` is in range. This app is a Vite SPA that does not use RSC mode, so it isn't exploitable here in practice, but the bump closes the advisory outright rather than pinning below it.

**Breaking changes in v8 & why no code changes were needed** — v8's removals do not touch this app's usage:
- `react-router-dom` package removed (import from `react-router` / `react-router/dom`) → this app already imports everything from `"react-router"`; no `react-router-dom` anywhere.
- `hasErrorBoundary` no longer accepted on routes → not used.
- `future.v8_middleware` / `v8_passThroughRequests` / `v8_trailingSlashAwareDataRequests` flags removed (behaviour now default) → not used.
- `loader`/`action`/`middleware` `context` is now always a `RouterContextProvider` → this app has no data-router loaders/actions (declarative `<BrowserRouter><Routes><Route>` only).
- New minimums: Node `>=22.22.0` (CI uses Node 25), React `>=19.2.7` (catalog is `19.2.8`), ESM-only (Vite/Vitest are ESM). All satisfied.

The full API surface in use — `BrowserRouter`, `MemoryRouter`, `Routes`, `Route`, `Link`, `Navigate`, `Outlet`, `useNavigate`, `useParams`, `useLocation`, `useSearchParams`, `matchPath`, `generatePath`, `createSearchParams` — is unchanged across the v8 boundary. Diff is `apps/web/package.json` + `pnpm-lock.yaml` only.

## Gates

Run on a clean `develop` checkout for baseline, then re-run with the update. Same Node/pnpm the project pins.

| Gate | Baseline (`develop`) | With update |
|---|---|---|
| `pnpm run lint` | ✅ pass (3 warnings, 7 infos) | ✅ pass (identical) |
| `pnpm run build` | ✅ pass (7 projects) | ✅ pass (7 projects) |
| `pnpm run test` | ⚠️ 15 pre-existing failures | ⚠️ **same** 15, no new failures |

The 15 pre-existing test failures are all in `apps/web/src/http/HttpClientApi.web.test.ts` (12) and `apps/web/src/http/httpClientApi.sw.test.ts` (3) — auth/token-refresh tests, unrelated to routing. They fail identically with and without this change, so this PR introduces **no new failures**.

## Pending queue (other outdated deps found this run)

Not touched by this PR — one reviewable update per PR. Ordered by risk within tier.

**Patch**
- `@mui/material` 9.3.0 → 9.3.1
- `@mui/icons-material` 9.3.0 → 9.3.1
- `@tanstack/react-router` 1.170.19 → 1.170.20 (admin)
- `@tanstack/router-plugin` 1.168.24 → 1.168.25 (admin)
- `@types/react` 19.2.17 → 19.2.18 (dev)
- `@types/react-dom` 19.2.3 → 19.2.4 (dev)
- `dexie` 4.4.2 → 4.4.4 (web)
- `postcss` 8.5.25 → 8.5.26 (admin, dev)

**Minor**
- `@aws-sdk/client-s3` 3.1103.0 → 3.1104.0
- `@aws-sdk/client-ssm` 3.1103.0 → 3.1104.0
- `@mui/x-tree-view` 9.10.1 → 9.11.0 (web)
- `dropbox` 10.43.0 → 10.44.0
- `next` 16.2.12 → 16.3.0 (landing)
- `eslint-config-next` 16.2.12 → 16.3.0 (landing, dev)
- `reactjrx` 1.141.6 → 1.142.0
- `@swc/cli` 0.7.10 → 0.8.1 (api, dev)
- `@mui/lab` 9.0.0-beta.6 → 9.0.0-beta.8 (prerelease line)

**Major** (breaking — each needs its own migration PR)
- 🔴 `pdfjs-dist` 5.7.284 → 6.2.108 (web) — **HIGH security** (*PDF.js: arbitrary JS execution on opening a malicious PDF*, patched `>=6.2.108`). **Blocked**, see below.
- `jose` 5.10.0 → 6.2.8 (api, web)
- `googleapis` 171.4.0 → 174.0.1 (api)
- `google-auth-library` 10.9.1 → 11.0.0 (api)
- `typeorm` 0.3.31 → 1.1.0 (api)
- `react-dropzone` 15.0.0 → 20.0.0 (web)
- `typescript` 5.9.3 → 7.0.2 (dev)
- `eslint` 9.39.5 → 10.8.0 (landing, dev)
- `jsdom` 27.4.0 → 30.0.1 (admin, dev)
- `vercel` 54.21.1 → 58.7.1 (dev)
- `lerna` 9.0.7 → 10.0.0 (dev)
- `lint-staged` 16.4.0 → 17.3.0 (dev)
- `rollup-plugin-node-externals` 8.1.2 → 9.0.1 (dev)
- `@types/node` 25.9.5 → 26.1.2 (dev)
- `@types/uuid` 10.0.0 → 11.0.0 (dev, now deprecated — `uuid` ships its own types)

## Needs manual attention

- **`pdfjs-dist` 5.7.284 → 6.2.108 (HIGH security).** This was the top security candidate — a direct dep of `@oboku/web` and a real RCE surface for a PDF reader. It is **blocked**: `@prose-reader/enhancer-pdf@1.344.0` (pinned via `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`) declares `pdfjs-dist` at `5.x` as a peer/dependency. Bumping the app to `pdfjs-dist@6` would break that peer contract and the enhancer is built against the pdfjs 5.x API. Unblocking requires `@prose-reader` to ship a build supporting pdfjs 6.x first, then bumping both together.
- **Transitive security advisories (overrides, not manifest updates).** `pnpm audit` reports advisories in transitive deps not in the outdated list, incl. one **critical** (`tar` decompression/parse DoS, patched `>=7.5.19` — build-time tooling only) plus HIGH/moderate in `undici`, `js-yaml`, `brace-expansion`, `minimatch`, `path-to-regexp`, `sharp`. Resolving these needs `pnpm.overrides` rather than a single manifest bump, so they're out of scope for a one-dependency PR and left for a dedicated override PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jZGWQC9JeUtNMaTZEuYau)_