### PR TITLE
fix(ci): surface every commit type in generated release notes

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -3,6 +3,40 @@
  * for any commit that is not a feature or a breaking change, instead of the
  * default behavior of skipping chore/docs-only pushes.
  */
+
+/**
+ * The conventionalcommits preset hides every type it is not told about, so a
+ * type missing from this list is silently dropped from the release notes
+ * rather than rendered under a fallback section. The list therefore has to
+ * cover the informal spellings that land here alongside the canonical types
+ * (`bugfix`, `deps`, `infra` from bots and agents), and must stay
+ * exhaustive rather than be trimmed to the types currently in use.
+ */
+const releaseNoteSections = [
+  { type: "feat", section: "Features" },
+  { type: "feature", section: "Features" },
+  { type: "fix", section: "Bug Fixes" },
+  { type: "bugfix", section: "Bug Fixes" },
+  { type: "hotfix", section: "Bug Fixes" },
+  { type: "security", section: "Security" },
+  { type: "perf", section: "Performance Improvements" },
+  { type: "performance", section: "Performance Improvements" },
+  { type: "revert", section: "Reverts" },
+  { type: "refactor", section: "Code Refactoring" },
+  { type: "deps", section: "Dependencies" },
+  { type: "dep", section: "Dependencies" },
+  { type: "dependencies", section: "Dependencies" },
+  { type: "chore", section: "Chores" },
+  { type: "build", section: "Build System" },
+  { type: "ci", section: "Continuous Integration" },
+  { type: "infra", section: "Continuous Integration" },
+  { type: "docs", section: "Documentation" },
+  { type: "doc", section: "Documentation" },
+  { type: "style", section: "Styles" },
+  { type: "test", section: "Tests" },
+  { type: "tests", section: "Tests" },
+]
+
 export default {
   branches: ["master"],
   plugins: [
@@ -24,7 +58,10 @@ export default {
       // Handlebars (conventional-changelog-writer@8) and silently drops every
       // commit, leaving release notes with only a compare link.
       "@semantic-release/release-notes-generator",
-      { preset: "conventionalcommits" },
+      {
+        preset: "conventionalcommits",
+        presetConfig: { types: releaseNoteSections },
+      },
     ],
     ["@semantic-release/npm", { npmPublish: false }],
     [


### PR DESCRIPTION
## Problem

[v2.1.0](https://github.com/mbret/oboku/releases/tag/v2.1.0) lists a single line — `feat: self update pnpm` — and no sign of the prose-reader upgrades, even though they are in the tag:

```
$ git log --oneline v2.0.1..v2.1.0
0ac39ee chore: release v2.1.0
8bbb0b2 Merge pull request #579 from mbret/develop
84e50c1 Merge pull request #572 (prose-reader upgrade)
03da52b chore(deps): upgrade prose-reader to 1.352.0 and drop the local ISBN helper
ad4626e chore(deps): exempt the prose-reader scope from the release-age gate
b5fbe72 chore(deps): upgrade prose-reader to 1.350.0
5ab67c3 Merge pull request #560
fd0cf2e feat: self update pnpm
2e6f41d Merge pull request #571
b88aa4a chore(deps): bump google-auth-library from 10.9.1 to 11.0.2
b9b2e72 chore(web): upgrade react-router to v8
```

Nine of the eleven commits were dropped from the body. As with #568, the release itself is correct — the bump, the tag, and the commit range are all right; only the rendering loses content, and it fails silently.

This is a *different* filter from the one #568 fixed. That was the v9/v10 Handlebars mismatch that dropped **every** commit; this is the preset's own type allowlist dropping **most** of them.

## Cause

`release.config.mjs` passed `{ preset: "conventionalcommits" }` with no `presetConfig`, so the notes generator used the preset's `DEFAULT_COMMIT_TYPES` (`conventional-changelog-conventionalcommits@9.3.1`, `src/constants.js`). Only four types are visible; the rest carry `hidden: true`:

| Rendered | Hidden |
| --- | --- |
| `feat`/`feature`, `fix`, `perf`, `revert` | `docs`, `style`, **`chore`**, `refactor`, `test`, `build`, `ci` |

Every prose-reader commit is `chore(deps): …`, so all three were hidden. The merge commits carry no conventional type and are skipped by the parser. That leaves exactly the one `feat` line that shipped.

The commit-analyzer is unaffected — the `{ release: "patch" }` catch-all still bumps on a `chore`-only push, which is why v2.1.0 exists at all. The writer simply would not print those commits.

## Fix

Pass an explicit `presetConfig.types`. Because the preset hides anything absent from that list, the list has to be positively exhaustive rather than trimmed to the types currently in use — a type nobody thought to add is silently dropped rather than rendered under a fallback section. It therefore covers the canonical types plus the informal spellings that land in this repo from bots and agents (`bugfix`, `hotfix`, `deps`, `dependencies`, `security`, `infra`, `doc`, `tests`, …), all grouped onto shared sections so `feat`/`feature` and `deps`/`dep`/`dependencies` collapse into one heading each.

`chore(deps)` needs no entry of its own: the parser splits type from scope, so `chore` matches and the scope renders as a bold **deps:** prefix.

## Verification

Ran `@semantic-release/release-notes-generator@14` with this branch's config against the real `v2.0.1..v2.1.0` commit range:

```
### Features

* self update pnpm (fd0cf2e)

### Chores

* **deps:** bump google-auth-library from 10.9.1 to 11.0.2 (b88aa4a)
* **deps:** exempt the prose-reader scope from the release-age gate (ad4626e)
* **deps:** upgrade prose-reader to 1.350.0 (b5fbe72)
* **deps:** upgrade prose-reader to 1.352.0 and drop the local ISBN helper (03da52b)
* **web:** upgrade react-router to v8 (b9b2e72)
```

All three prose-reader commits now appear. A second synthetic run over one commit per listed type confirmed each renders under its intended heading, and that an unlisted type (`wibble:`) is still discarded — see Limitations. `biome check release.config.mjs` is clean.

Also confirmed that making `chore` visible does not pull `chore: release vX` into the notes: that commit is created by `@semantic-release/git` *after* the notes are generated, and it becomes the tagged commit of its own release, so the next range excludes it. Verified against the real ranges — `v2.0.1..v2.1.0` contains no `chore: release v2.0.1`.

## Limitations

A type that is not in the list is still dropped without a trace; the preset has no wildcard or fallback section, so no allowlist can be exhaustive against an arbitrarily invented type. Two possible follow-ups, both out of scope here:

- Add a commitlint / PR-title check rejecting unknown types, moving the failure to commit time instead of silently at release time.
- Note the accepted type list in `AGENTS.md` so agents pick from it rather than inventing one.

This does not retroactively fix the v2.1.0 body already stored on GitHub; that has to be edited separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ryee53UuuSQJ6Kwc9hvja)_