### PR TITLE
chore(deps): upgrade googleapis to v176

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
     "dropbox": "^10.43.0",
     "express": "^5.2.1",
     "google-auth-library": "^11.0.2",
-    "googleapis": "^171.4.0",
+    "googleapis": "^176.0.0",
     "http-proxy-3": "^1.23.3",
     "joi": "^18.2.3",
     "jose": "^5.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,8 +245,8 @@ importers:
         specifier: ^11.0.2
         version: 11.0.2(supports-color@8.1.1)
       googleapis:
-        specifier: ^171.4.0
-        version: 171.4.0(supports-color@8.1.1)
+        specifier: ^176.0.0
+        version: 176.0.0(supports-color@8.1.1)
       http-proxy-3:
         specifier: ^1.23.3
         version: 1.23.3(supports-color@8.1.1)
@@ -8176,16 +8176,8 @@ packages:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
     engines: {node: '>=18'}
 
-  gaxios@7.3.0:
-    resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
-    engines: {node: '>=18'}
-
   gaxios@7.3.1:
     resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
-    engines: {node: '>=18'}
-
-  gcp-metadata@8.1.2:
-    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
   gcp-metadata@8.1.4:
@@ -8344,10 +8336,6 @@ packages:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
     engines: {node: '>=18'}
 
-  google-auth-library@10.9.1:
-    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
-    engines: {node: '>=18'}
-
   google-auth-library@11.0.2:
     resolution: {integrity: sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==}
     engines: {node: '>=22'}
@@ -8368,8 +8356,8 @@ packages:
     resolution: {integrity: sha512-7g1yzQKx0mmNTjiK0H9dJ8eqKqDBveES9vLHeg5neb3BMQy/d1oQefIMhIpOVT8a+f+LOcixMEdRbFIW/cQUJw==}
     engines: {node: '>=18'}
 
-  googleapis@171.4.0:
-    resolution: {integrity: sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==}
+  googleapis@176.0.0:
+    resolution: {integrity: sha512-v24+WfeIw3R9iF8LT7eixlawezy5SGGNB/WjFV8qeiBS9G6KCsqaFngsnTXvBrVH4womehN2Co8UYJxZ0KpbvQ==}
     engines: {node: '>=18'}
 
   gopd@1.2.0:
@@ -21665,27 +21653,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gaxios@7.3.0(supports-color@8.1.1):
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
-      node-fetch: 3.3.2
-    transitivePeerDependencies:
-      - supports-color
-
   gaxios@7.3.1(supports-color@8.1.1):
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 3.3.2
-    transitivePeerDependencies:
-      - supports-color
-
-  gcp-metadata@8.1.2(supports-color@8.1.1):
-    dependencies:
-      gaxios: 7.3.0(supports-color@8.1.1)
-      google-logging-utils: 1.2.0
-      json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -21865,21 +21837,10 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.3.0(supports-color@8.1.1)
+      gaxios: 7.3.1(supports-color@8.1.1)
       gcp-metadata: 8.1.4(supports-color@8.1.1)
       google-logging-utils: 1.2.0
       gtoken: 8.0.0(supports-color@8.1.1)
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  google-auth-library@10.9.1(supports-color@8.1.1):
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.3.0(supports-color@8.1.1)
-      gcp-metadata: 8.1.2(supports-color@8.1.1)
-      google-logging-utils: 1.1.3
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
@@ -21912,9 +21873,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@171.4.0(supports-color@8.1.1):
+  googleapis@176.0.0(supports-color@8.1.1):
     dependencies:
-      google-auth-library: 10.9.1(supports-color@8.1.1)
+      google-auth-library: 10.5.0(supports-color@8.1.1)
       googleapis-common: 8.0.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -21947,7 +21908,7 @@ snapshots:
 
   gtoken@8.0.0(supports-color@8.1.1):
     dependencies:
-      gaxios: 7.3.0(supports-color@8.1.1)
+      gaxios: 7.3.1(supports-color@8.1.1)
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## The update

| | |
|---|---|
| **Package** | `googleapis` (`@oboku/api`) |
| **Version** | `^171.4.0` → `^176.0.0` |
| **Type** | Major |
| **Motivation** | Keep the Google Drive client current |

The Google datasource plugin (`apps/api/src/plugins/google/*`) uses the stable surface only — `google.drive({...})`, `google.auth.OAuth2`, and `drive_v3` types. These are unchanged across v171→v176 (googleapis majors are mostly regenerated API definitions plus the underlying `google-auth-library` major, which is already on v11 here). No source changes required.

## Gates (Node 24)

| Gate | Result |
|---|---|
| `pnpm --filter @oboku/api exec tsc --noEmit` | ✅ pass |
| `pnpm run lint` | ✅ pass (3 warnings, 7 infos) |
| `pnpm run build` (no nx cache) | ✅ pass (7 projects) |
| `pnpm --filter @oboku/api test` | ✅ 20 suites / 128 tests pass |

---

Part of the batch of individual major-dependency PRs (moderate tier). Sibling in this tier: #581 (`jsdom` v30).

---
_Generated by [Claude Code](https://claude.ai/code/session_018jZGWQC9JeUtNMaTZEuYau)_