### PR TITLE
chore(deps): upgrade jose to v6 (web)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,7 +41,7 @@
     "firebase": "^12.17.1",
     "fuse.js": "^7.5.0",
     "gesturx": "^1.11.0",
-    "jose": "^5.10.0",
+    "jose": "^6.2.8",
     "libarchive.js": "^2.0.2",
     "next-themes": "^0.4.6",
     "pdfjs-dist": "^5.7.284",

--- a/apps/web/src/auth/proofKey.ts
+++ b/apps/web/src/auth/proofKey.ts
@@ -28,7 +28,7 @@ export const createProofKey = async (): Promise<StoredProofKey> => {
   const keyPair = await crypto.subtle.generateKey(
     ECDSA_P256_KEY_PARAMS,
     false,
-    ["sign"],
+    ["sign", "verify"],
   )
   const publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey)
   const { kty } = publicJwk

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,8 +532,8 @@ importers:
         specifier: ^1.11.0
         version: 1.11.0(rxjs@7.8.2)
       jose:
-        specifier: ^5.10.0
-        version: 5.10.0
+        specifier: ^6.2.8
+        version: 6.2.10
       libarchive.js:
         specifier: ^2.0.2
         version: 2.0.2
@@ -9123,6 +9123,9 @@ packages:
 
   jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+
+  jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
@@ -22880,6 +22883,8 @@ snapshots:
   jose@5.10.0: {}
 
   jose@5.9.6: {}
+
+  jose@6.2.10: {}
 
   jose@6.2.3: {}
 


### PR DESCRIPTION
## The update

| | |
|---|---|
| **Package** | `jose` (`@oboku/web`) |
| **Version** | `^5.10.0` → `^6.2.8` |
| **Type** | Major |
| **Motivation** | Keep the JWT/crypto library current |

jose 6 is **ESM-only** and ships the **WebCrypto** implementation, which enforces `CryptoKey` usages strictly. `@oboku/web` runs under Vite/Vitest (ESM-native) so the packaging change is fine, but the strict usage enforcement surfaced a latent issue in the proof-key code.

### Code change (required by v6)

`createProofKey` generated the ECDSA P-256 pair with usages `["sign"]` only. WebCrypto then gives the **public** key no usages, so its exported JWK carried no `verify` op. jose 5 (Node crypto) ignored this, but jose 6's `jwtVerify(proof, EmbeddedJWK, …)` imports that JWK and rejects it:

```
TypeError: CryptoKey does not support this operation, its usages must include verify.
```

Fix: generate the pair with `["sign", "verify"]` so the public key (and its exported JWK) carries `verify`.
- The **private** key remains non-extractable (`extractable=false`) — the fail-closed security property described in `proofKey.ts` is unchanged.
- The public JWK now advertises `key_ops: ["verify"]`, which is accepted by both jose 5 (the API's current verifier) and jose 6, so it's forward-compatible.

## Scope: web only — API deferred

`@oboku/api` stays on **jose 5** in this PR. The API is CommonJS (NestJS, compiled by `tsc`, tested with `ts-jest`), and jose 6 being ESM-only breaks it two ways that amount to a test-infra migration rather than a dependency bump:
1. **Jest can't load the ESM package** — `SyntaxError: Unexpected token 'export'` from `jose/dist/webapi/index.js`; the CJS `ts-jest` setup would need `transformIgnorePatterns`/ESM-mode changes affecting all 20 api suites.
2. **Removed type** — jose 6 dropped the `KeyLike` type used in `refresh-proof.service.spec.ts` (would become `CryptoKey`).

Both are tracked under **needs manual attention**; doing them safely is a separate change to the API test toolchain, not something to fold into a dep bump.

## Gates (Node 24)

| Gate | Result |
|---|---|
| `pnpm install --frozen-lockfile` | ✅ consistent |
| `pnpm run lint` | ✅ pass |
| `pnpm run build` (no nx cache) | ✅ pass (7 projects) |
| `pnpm --filter @oboku/web test` | ✅ 57 files / 297 tests pass |
| `pnpm --filter @oboku/api test` | ✅ 20 suites / 128 tests pass (still on jose 5) |

---

Part of the batch of individual major-dependency PRs (heavy tier). Siblings: #581 (`jsdom`), #582 (`googleapis`), #583 (`react-dropzone`).

---
_Generated by [Claude Code](https://claude.ai/code/session_018jZGWQC9JeUtNMaTZEuYau)_