### PR TITLE
feat(optimize): replace the ISBN field with a list of scheme-tagged identifiers

### DIFF
--- a/apps/web/src/books/optimize/actions/BookOptimizeActionBar.test.tsx
+++ b/apps/web/src/books/optimize/actions/BookOptimizeActionBar.test.tsx
@@ -61,7 +61,7 @@ const INDETERMINATE_PHASE_CASES: [ApplyLocallyProgress, string][] = [
 const values: BookOptimizeFormValues = {
   compressImages: false,
   imageOutputMode: "webp",
-  isbn: "9781234567897",
+  identifiers: [{ scheme: "ISBN", value: "9781234567897", unique: false }],
   maxHeight: "",
   maxWidth: "",
 }

--- a/apps/web/src/books/optimize/apply/buildUpdateActions.test.ts
+++ b/apps/web/src/books/optimize/apply/buildUpdateActions.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest"
 import { EMPTY_BOOK_OPTIMIZE_FORM_VALUES } from "../form"
+import type { MetadataIdentifierFormValue } from "../metadata/formValues"
 import type { FileInspection } from "../useFileInspection"
 import {
   CONTAINER_XML,
@@ -10,156 +11,118 @@ import {
 } from "../metadata/identifiers/inspection.fixture"
 import { buildUpdateActions } from "./buildUpdateActions"
 
-const metadataPatch = (isbn: string, inspection: FileInspection) => {
-  const [action] = buildUpdateActions(
-    { ...EMPTY_BOOK_OPTIMIZE_FORM_VALUES, isbn },
+const actionsFor = (
+  identifiers: MetadataIdentifierFormValue[],
+  inspection: FileInspection,
+) =>
+  buildUpdateActions(
+    { ...EMPTY_BOOK_OPTIMIZE_FORM_VALUES, identifiers },
     inspection,
   )
 
-  if (action?.kind !== "patch-metadata") {
-    throw new Error("expected a patch-metadata action")
-  }
-
-  return action
+const GOOGLE_BOOKS: MetadataIdentifierFormValue = {
+  scheme: "GoogleBooks",
+  value: "zyTCAlFPjgYC",
+  unique: false,
 }
 
 describe("buildUpdateActions, the metadata patch it plans", () => {
-  it("carries the identifiers it is not editing through the patch", async () => {
+  it("targets the containers the archive carries", async () => {
+    const withOpf = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
+    })
+    const withoutOpf = await inspect({ "page-001.jpg": "binary" })
+
+    expect(actionsFor([GOOGLE_BOOKS], withOpf)).toEqual([
+      {
+        kind: "patch-metadata",
+        patch: { identifiers: [GOOGLE_BOOKS], removedIdentifiers: [] },
+        targets: { comicInfo: false, opf: true },
+      },
+    ])
+    expect(actionsFor([GOOGLE_BOOKS], withoutOpf)).toEqual([
+      {
+        kind: "patch-metadata",
+        patch: { identifiers: [GOOGLE_BOOKS], removedIdentifiers: [] },
+        targets: { comicInfo: true, opf: false },
+      },
+    ])
+  })
+
+  it("plans nothing when the identifiers are untouched", async () => {
     const inspection = await inspect({
       "META-INF/container.xml": CONTAINER_XML,
       "OEBPS/content.opf": opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
-          '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>' +
-          '<dc:identifier opf:scheme="DOI">10.1000/182</dc:identifier>',
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
       ),
     })
 
-    const { patch } = metadataPatch("9783161484100", inspection)
-
-    expect(patch.identifiers).toEqual([
-      {
-        scheme: "Unknown",
-        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
-        unique: true,
-      },
-      { scheme: "ISBN", value: "9783161484100", unique: false },
-      { scheme: "DOI", value: "10.1000/182", unique: false },
-    ])
+    expect(
+      actionsFor(
+        [{ scheme: "ISBN", value: "9783161484100", unique: false }],
+        inspection,
+      ),
+    ).toEqual([])
   })
 
-  it("appends an ISBN a book announced none of", async () => {
+  it("plans a patch for an edited value, a new row and a removed row", async () => {
     const inspection = await inspect({
       "META-INF/container.xml": CONTAINER_XML,
       "OEBPS/content.opf": opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>',
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
       ),
     })
+    const isbn: MetadataIdentifierFormValue = {
+      scheme: "ISBN",
+      value: "9783161484100",
+      unique: false,
+    }
 
-    const { patch } = metadataPatch("9783161484100", inspection)
-
-    expect(patch.identifiers).toEqual([
-      {
-        scheme: "Unknown",
-        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
-        unique: true,
-      },
-      { scheme: "ISBN", value: "9783161484100" },
-    ])
+    expect(
+      actionsFor([{ ...isbn, value: "9780306406157" }], inspection),
+    ).toHaveLength(1)
+    expect(actionsFor([isbn, GOOGLE_BOOKS], inspection)).toHaveLength(1)
+    expect(actionsFor([], inspection)).toHaveLength(1)
   })
 
-  it("drops only the ISBN when the field is cleared", async () => {
+  it("plans nothing for a book with nowhere to store identifiers", async () => {
     const inspection = await inspect({
       "META-INF/container.xml": CONTAINER_XML,
-      "OEBPS/content.opf": opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
-          '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
-      ),
+      "OEBPS/content.opf": "<root><child></wrong></root>",
     })
 
-    const { patch } = metadataPatch("", inspection)
-
-    expect(patch.identifiers).toEqual([
-      {
-        scheme: "Unknown",
-        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
-        unique: true,
-      },
-    ])
-  })
-
-  it("edits a ComicInfo GTIN as the ISBN it announces", async () => {
-    const inspection = await inspect({
-      "ComicInfo.xml": comicInfo("<GTIN>0000000000</GTIN>"),
-      "page-001.jpg": "binary",
-    })
-
-    const { patch, targets } = metadataPatch("9783161484100", inspection)
-
-    expect(patch.identifiers).toEqual([
-      { scheme: "GTIN", value: "9783161484100", unique: false },
-    ])
-    expect(targets).toEqual({ comicInfo: true, opf: false })
-  })
-})
-
-describe("buildUpdateActions, an ISBN both containers announce", () => {
-  const bothAnnounce = () =>
-    inspect({
-      "META-INF/container.xml": CONTAINER_XML,
-      "OEBPS/content.opf": opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
-          '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
-      ),
-      "ComicInfo.xml": comicInfo("<GTIN>9783161484100</GTIN>"),
-    })
-
-  it("leaves the previous ISBN behind under no scheme", async () => {
-    const { patch } = metadataPatch("9780306406157", await bothAnnounce())
-
-    expect(patch.identifiers).toEqual([
-      {
-        scheme: "Unknown",
-        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
-        unique: true,
-      },
-      { scheme: "ISBN", value: "9780306406157", unique: false },
-    ])
-  })
-
-  it("clears every entry announcing it", async () => {
-    const { patch } = metadataPatch("", await bothAnnounce())
-
-    expect(patch.identifiers).toEqual([
-      {
-        scheme: "Unknown",
-        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
-        unique: true,
-      },
-    ])
+    expect(actionsFor([GOOGLE_BOOKS], inspection)).toEqual([])
   })
 })
 
 describe("buildUpdateActions, what it asks to be removed", () => {
-  it("names nothing when the edit only changes a value", async () => {
-    const inspection = await inspect({
-      "META-INF/container.xml": CONTAINER_XML,
-      "OEBPS/content.opf": opf(
-        '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>' +
-          '<dc:identifier opf:scheme="DOI">10.1000/182</dc:identifier>',
-      ),
-    })
+  const patchFor = async (
+    rows: MetadataIdentifierFormValue[],
+    files: Record<string, string>,
+  ) => {
+    const [action] = actionsFor(rows, await inspect(files))
 
-    const { patch } = metadataPatch("9783161484100", inspection)
+    if (action?.kind !== "patch-metadata") {
+      throw new Error("expected a patch-metadata action")
+    }
 
-    expect(patch.removedIdentifiers).toEqual([])
-    expect(patch.identifiers).toEqual([
-      { scheme: "ISBN", value: "9783161484100", unique: false },
-      { scheme: "DOI", value: "10.1000/182", unique: false },
-    ])
-  })
+    return action.patch
+  }
 
-  it("names the ISBN it dropped when the field is cleared", async () => {
-    const inspection = await inspect({
+  const ISBN: MetadataIdentifierFormValue = {
+    scheme: "ISBN",
+    value: "9783161484100",
+    unique: false,
+  }
+  const DOI: MetadataIdentifierFormValue = {
+    scheme: "DOI",
+    value: "10.1000/182",
+    unique: false,
+  }
+
+  it("names nothing when a row only changes its value", async () => {
+    const patch = await patchFor([{ ...ISBN, value: "9780306406157" }, DOI], {
       "META-INF/container.xml": CONTAINER_XML,
       "OEBPS/content.opf": opf(
         '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>' +
@@ -167,18 +130,25 @@ describe("buildUpdateActions, what it asks to be removed", () => {
       ),
     })
 
-    const { patch } = metadataPatch("", inspection)
+    expect(patch.removedIdentifiers).toEqual([])
+  })
+
+  it("names the identifier whose row was deleted", async () => {
+    const patch = await patchFor([DOI], {
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>' +
+          '<dc:identifier opf:scheme="DOI">10.1000/182</dc:identifier>',
+      ),
+    })
 
     expect(patch.removedIdentifiers).toEqual([
-      { scheme: "ISBN", value: "9783161484100", unique: false },
-    ])
-    expect(patch.identifiers).toEqual([
-      { scheme: "DOI", value: "10.1000/182", unique: false },
+      { scheme: "ISBN", value: "9783161484100" },
     ])
   })
 
-  it("names both entries when the containers each announced the ISBN", async () => {
-    const inspection = await inspect({
+  it("names both entries the one row stood for", async () => {
+    const patch = await patchFor([], {
       "META-INF/container.xml": CONTAINER_XML,
       "OEBPS/content.opf": opf(
         '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
@@ -186,13 +156,24 @@ describe("buildUpdateActions, what it asks to be removed", () => {
       "ComicInfo.xml": comicInfo("<GTIN>9783161484100</GTIN>"),
     })
 
-    const { patch } = metadataPatch("9780306406157", inspection)
-
-    expect(patch.identifiers).toEqual([
-      { scheme: "ISBN", value: "9780306406157", unique: false },
-    ])
     expect(patch.removedIdentifiers).toEqual([
-      { scheme: "GTIN", value: "9783161484100", unique: false },
+      { scheme: "ISBN", value: "9783161484100" },
+      { scheme: "GTIN", value: "9783161484100" },
+    ])
+  })
+
+  it("names nothing for the row that stands for both", async () => {
+    const patch = await patchFor([ISBN], {
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>' +
+          '<dc:identifier opf:scheme="DOI">10.1000/182</dc:identifier>',
+      ),
+      "ComicInfo.xml": comicInfo("<GTIN>9783161484100</GTIN>"),
+    })
+
+    expect(patch.removedIdentifiers).toEqual([
+      { scheme: "DOI", value: "10.1000/182" },
     ])
   })
 })

--- a/apps/web/src/books/optimize/apply/buildUpdateActions.ts
+++ b/apps/web/src/books/optimize/apply/buildUpdateActions.ts
@@ -3,74 +3,85 @@ import type {
   ArchiveMetadataPatch,
   WebArchiveUpdateAction,
 } from "@oboku/archive-metadata/web"
-import { isIsbnBearingScheme } from "@prose-reader/archive-reader"
 import type { FileInspection } from "../useFileInspection"
+import type {
+  MetadataFixerFormValues,
+  MetadataIdentifierFormValue,
+} from "../metadata/formValues"
+import { canonicalIdentifier } from "../metadata/identifiers/canonicalIdentifier"
 import { resolveMetadataTargets } from "../metadata/identifiers/containers"
-import { resolveMetadataFixerFormValues } from "../metadata/identifiers/resolveMetadataFixerFormValues"
+import {
+  identifierRowScheme,
+  resolveMetadataFixerFormValues,
+  toIdentifierRow,
+} from "../metadata/identifiers/resolveMetadataFixerFormValues"
 import {
   hasImageCompressionOperation,
   parseDimension,
   type BookOptimizeFormValues,
 } from "../form"
 
-const normalizeFormIsbn = (isbn: string): string | undefined => {
-  const trimmed = isbn.trim()
+const trimIdentifiers = ({
+  identifiers,
+}: MetadataFixerFormValues): MetadataIdentifierFormValue[] =>
+  identifiers.map(function trimIdentifier({ scheme, value, unique }) {
+    return { scheme: scheme.trim(), value: value.trim(), unique }
+  })
 
-  return trimmed === "" ? undefined : trimmed
-}
+const haveIdentifiersChanged = (
+  left: ReadonlyArray<MetadataIdentifierFormValue>,
+  right: ReadonlyArray<MetadataIdentifierFormValue>,
+): boolean =>
+  left.length !== right.length ||
+  left.some(function differsFromCounterpart(identifier, index) {
+    const other = right[index]
 
-const announcesIsbn = ({ scheme }: ArchiveMetadataIdentifier): boolean =>
-  isIsbnBearingScheme(scheme)
+    return (
+      identifier.scheme !== other?.scheme || identifier.value !== other?.value
+    )
+  })
+
+const toPatchIdentifier = ({
+  scheme,
+  value,
+  unique,
+}: MetadataIdentifierFormValue): ArchiveMetadataIdentifier => ({
+  ...canonicalIdentifier({ scheme, value }),
+  unique,
+})
 
 /**
  * What the archive should carry after the edit, and what the edit dropped.
  *
- * The archive's own identifiers are the baseline, so the difference between
- * them and the edited set is exactly what the user removed — which is the only
- * thing the writer is asked to delete. An identifier neither list names is left
- * alone, including ones the reader never reported and no one here could know
- * about.
+ * The archive's own identifiers are the baseline, and one is dropped when the
+ * edited list has no row on its scheme any more. Matching on the scheme rather
+ * than the value is what makes editing a value an edit: the row still stands
+ * for the identifier it was seeded from, so its element keeps its `id` and the
+ * refinements pointing at it instead of being deleted and rebuilt. It also
+ * keeps the one row an ISBN and the `GTIN` of the same value collapse into from
+ * dropping either of them.
  *
- * An ISBN is usually announced more than once: a book whose OPF and ComicInfo
- * both carry it is read as an `ISBN` and a `GTIN` of the same value. They are
- * one fact, so the edit lands on the first and the rest are dropped.
+ * Nothing else is named, so an identifier the reader never reported — which no
+ * row could stand for and no one here knows about — is left alone.
+ *
+ * The identifiers go to every container the archive can carry. Keeping them in
+ * sync is the point — an archive whose containers disagree has no identifier
+ * the user can trust, and picking a winner per container was never their call.
  */
 const identifierPatch = (
   inspection: FileInspection,
-  isbn: string | undefined,
+  rows: ReadonlyArray<MetadataIdentifierFormValue>,
 ): Pick<ArchiveMetadataPatch, "identifiers" | "removedIdentifiers"> => {
-  const announced = (inspection.resolvedArchive.metadata.identifiers ?? []).map(
-    function toPatchIdentifier({ scheme, value, unique }) {
-      return { scheme, value, unique: unique === true }
-    },
-  )
-  const editedIndex = announced.findIndex(announcesIsbn)
+  const kept = new Set(rows.map(identifierRowScheme))
+  const removedIdentifiers = (
+    inspection.resolvedArchive.metadata.identifiers ?? []
+  ).flatMap(function whenNoRowStandsForIt(resolved) {
+    return kept.has(identifierRowScheme(toIdentifierRow(resolved)))
+      ? []
+      : [{ scheme: resolved.scheme, value: resolved.value }]
+  })
 
-  const identifiers = announced.flatMap(
-    function keepOrReplace(identifier, index) {
-      if (!announcesIsbn(identifier)) return [identifier]
-      if (index !== editedIndex || isbn === undefined) return []
-
-      return [{ ...identifier, value: isbn }]
-    },
-  )
-
-  const removedIdentifiers = announced.filter(
-    function wasDropped(identifier, index) {
-      return (
-        announcesIsbn(identifier) &&
-        (index !== editedIndex || isbn === undefined)
-      )
-    },
-  )
-
-  return {
-    identifiers:
-      editedIndex === -1 && isbn !== undefined
-        ? [...identifiers, { scheme: "ISBN", value: isbn }]
-        : identifiers,
-    removedIdentifiers,
-  }
+  return { identifiers: rows.map(toPatchIdentifier), removedIdentifiers }
 }
 
 const resolveMetadataPatchAction = (
@@ -81,13 +92,15 @@ const resolveMetadataPatchAction = (
 
   if (targets.comicInfo !== true && targets.opf !== true) return undefined
 
-  const isbn = normalizeFormIsbn(values.isbn)
+  const identifiers = trimIdentifiers(values)
+  const resolved = resolveMetadataFixerFormValues(inspection)
 
-  if (isbn === resolveMetadataFixerFormValues(inspection).isbn) return undefined
+  if (!haveIdentifiersChanged(identifiers, resolved.identifiers))
+    return undefined
 
   return {
     kind: "patch-metadata",
-    patch: identifierPatch(inspection, isbn),
+    patch: identifierPatch(inspection, identifiers),
     targets,
   }
 }

--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
@@ -43,7 +43,12 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
     const actions: WebArchiveUpdateAction[] = [
       {
         kind: "patch-metadata",
-        patch: { identifiers: [{ scheme: "ISBN", value: "9781234567897" }] },
+        patch: {
+          identifiers: [
+            { scheme: "ISBN", value: "9781234567897" },
+            { scheme: "GoogleBooks", value: "zyTCAlFPjgYC" },
+          ],
+        },
         targets: { comicInfo: true, opf: true },
       },
       {
@@ -63,19 +68,24 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
     ).not.toBeNull()
     const listItems = screen.getAllByRole("listitem")
 
-    expect(listItems).toHaveLength(5)
-    expect(listItems[0]?.textContent).toContain("Set the ISBN to")
-    expect(screen.getByText("9781234567897")).not.toBeNull()
-    expect(screen.getByText("ComicInfo.xml")).not.toBeNull()
-    expect(screen.getByText("OPF package document")).not.toBeNull()
-    expect(listItems[1]?.textContent).toContain("Resize eligible")
+    expect(listItems).toHaveLength(7)
+    expect(listItems[0]?.textContent).toBe(
+      "Set ISBN to 9781234567897 in ComicInfo.xml and OPF package document.",
+    )
+    expect(listItems[1]?.textContent).toBe(
+      "Set Google Books id to zyTCAlFPjgYC in ComicInfo.xml and OPF package document.",
+    )
+    expect(listItems[2]?.textContent).toBe(
+      "Remove any other identifier from ComicInfo.xml and OPF package document.",
+    )
+    expect(listItems[3]?.textContent).toContain("Resize eligible")
     expect(screen.getByText("1200 × 1600 px")).not.toBeNull()
     expect(screen.getAllByText("JPG · JPEG · PNG · BMP")).toHaveLength(2)
-    expect(listItems[2]?.textContent).toContain(
+    expect(listItems[4]?.textContent).toContain(
       "Convert JPG · JPEG · PNG · BMP images to WebP",
     )
     expect(screen.getByText("WebP")).not.toBeNull()
-    expect(listItems[3]?.textContent).toBe(
+    expect(listItems[5]?.textContent).toBe(
       "Update references to converted images.",
     )
     expect(
@@ -113,7 +123,9 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
     const listItems = screen.getAllByRole("listitem")
 
     expect(listItems).toHaveLength(5)
-    expect(listItems[0]?.textContent).toContain("Remove the ISBN from")
+    expect(listItems[0]?.textContent).toBe(
+      "Remove every identifier from ComicInfo.xml.",
+    )
     expect(screen.getByText("ComicInfo.xml")).not.toBeNull()
     expect(listItems[1]?.textContent).toContain("to a maximum height of")
     expect(screen.getByText("1600 px")).not.toBeNull()
@@ -123,6 +135,32 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
     )
     expect(listItems[3]?.textContent).toContain(
       "Leave all other image formats unchanged",
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+
+    await expect(confirmation).resolves.toBe(false)
+  })
+
+  it("calls out an identifier no container in the book can carry", async function listUnstorableIdentifier() {
+    const actions: WebArchiveUpdateAction[] = [
+      {
+        kind: "patch-metadata",
+        patch: {
+          identifiers: [{ scheme: "AcmeCatalog", value: "acme-42" }],
+        },
+        targets: { comicInfo: true },
+      },
+    ]
+    renderDialogProvider()
+
+    const confirmation = openConfirmation(actions)
+
+    expect(await screen.findByRole("dialog")).not.toBeNull()
+    const listItems = screen.getAllByRole("listitem")
+
+    expect(listItems[0]?.textContent).toBe(
+      "Drop AcmeCatalog acme-42: no container in this book can carry it.",
     )
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }))

--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
@@ -48,6 +48,7 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
             { scheme: "ISBN", value: "9781234567897" },
             { scheme: "GoogleBooks", value: "zyTCAlFPjgYC" },
           ],
+          removedIdentifiers: [{ scheme: "DOI", value: "10.1000/182" }],
         },
         targets: { comicInfo: true, opf: true },
       },
@@ -76,7 +77,7 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
       "Set Google Books id to zyTCAlFPjgYC in ComicInfo.xml and OPF package document.",
     )
     expect(listItems[2]?.textContent).toBe(
-      "Remove any other identifier from ComicInfo.xml and OPF package document.",
+      "Remove DOI 10.1000/182 from ComicInfo.xml and OPF package document.",
     )
     expect(listItems[3]?.textContent).toContain("Resize eligible")
     expect(screen.getByText("1200 × 1600 px")).not.toBeNull()
@@ -103,7 +104,10 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
     const actions: WebArchiveUpdateAction[] = [
       {
         kind: "patch-metadata",
-        patch: { identifiers: [] },
+        patch: {
+          identifiers: [],
+          removedIdentifiers: [{ scheme: "ISBN", value: "9781234567897" }],
+        },
         targets: { comicInfo: true },
       },
       {
@@ -124,7 +128,7 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
 
     expect(listItems).toHaveLength(5)
     expect(listItems[0]?.textContent).toBe(
-      "Remove every identifier from ComicInfo.xml.",
+      "Remove ISBN 9781234567897 from ComicInfo.xml.",
     )
     expect(screen.getByText("ComicInfo.xml")).not.toBeNull()
     expect(listItems[1]?.textContent).toContain("to a maximum height of")

--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
@@ -78,15 +78,6 @@ function MetadataUpdateItems({ action }: { action: PatchMetadataAction }) {
     action.targets,
   )
 
-  if (action.patch.identifiers.length === 0) {
-    return (
-      <UpdateListItem>
-        Remove every identifier from{" "}
-        <MetadataTargetChips targets={containers} />.
-      </UpdateListItem>
-    )
-  }
-
   return (
     <>
       {action.patch.identifiers.map(
@@ -99,13 +90,17 @@ function MetadataUpdateItems({ action }: { action: PatchMetadataAction }) {
           const schemeLabel = identifierSchemeLabel(identifier.scheme)
 
           return storedIn.length === 0 ? (
-            <UpdateListItem key={`${identifier.scheme}:${identifier.value}`}>
+            <UpdateListItem
+              key={`set:${identifier.scheme}:${identifier.value}`}
+            >
               Drop <KeyChip label={schemeLabel} />{" "}
               <KeyChip label={identifier.value} />: no container in this book
               can carry it.
             </UpdateListItem>
           ) : (
-            <UpdateListItem key={`${identifier.scheme}:${identifier.value}`}>
+            <UpdateListItem
+              key={`set:${identifier.scheme}:${identifier.value}`}
+            >
               Set <KeyChip label={schemeLabel} /> to{" "}
               <KeyChip label={identifier.value} /> in{" "}
               <MetadataTargetChips targets={storedIn} />.
@@ -113,10 +108,20 @@ function MetadataUpdateItems({ action }: { action: PatchMetadataAction }) {
           )
         },
       )}
-      <UpdateListItem>
-        Remove any other identifier from{" "}
-        <MetadataTargetChips targets={containers} />.
-      </UpdateListItem>
+      {(action.patch.removedIdentifiers ?? []).map(
+        function renderIdentifierRemoval(identifier) {
+          return (
+            <UpdateListItem
+              key={`removed:${identifier.scheme}:${identifier.value}`}
+            >
+              Remove{" "}
+              <KeyChip label={identifierSchemeLabel(identifier.scheme)} />{" "}
+              <KeyChip label={identifier.value} /> from{" "}
+              <MetadataTargetChips targets={containers} />.
+            </UpdateListItem>
+          )
+        },
+      )}
     </>
   )
 }

--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
@@ -3,7 +3,6 @@ import {
   PRESERVABLE_IMAGE_FORMAT_NAMES,
   type WebArchiveUpdateAction,
 } from "@oboku/archive-metadata/web"
-import { isIsbnBearingScheme } from "@prose-reader/archive-reader"
 import { FiberManualRecord } from "@mui/icons-material"
 import {
   List,
@@ -16,7 +15,11 @@ import {
 import { Fragment, type ReactNode } from "react"
 import { showConfirmDialog } from "../../../common/dialogs/presets"
 import { KeyChip } from "../KeyChip"
-import { CONTAINER_LABELS } from "../metadata/identifiers/containers"
+import {
+  CONTAINER_LABELS,
+  identifierDestinations,
+} from "../metadata/identifiers/containers"
+import { identifierSchemeLabel } from "../metadata/identifiers/schemes"
 
 const BulletListItemIcon = styled(ListItemIcon)(({ theme }) => ({
   minWidth: theme.spacing(3),
@@ -54,31 +57,67 @@ function MetadataTargetChips({ targets }: { targets: string[] }) {
   })
 }
 
-function MetadataUpdateItems({
-  action,
-}: {
-  action: Extract<WebArchiveUpdateAction, { kind: "patch-metadata" }>
-}) {
-  const targets: string[] = []
+type PatchMetadataAction = Extract<
+  WebArchiveUpdateAction,
+  { kind: "patch-metadata" }
+>
 
-  if (action.targets.comicInfo) targets.push(CONTAINER_LABELS.comicInfo)
-  if (action.targets.opf) targets.push(CONTAINER_LABELS.opf)
+const patchedContainerLabels = ({ targets }: PatchMetadataAction): string[] => {
+  const labels: string[] = []
 
-  const isbn = action.patch.identifiers.find(function announcesIsbn({
-    scheme,
-  }) {
-    return isIsbnBearingScheme(scheme)
-  })?.value
+  if (targets.comicInfo) labels.push(CONTAINER_LABELS.comicInfo)
+  if (targets.opf) labels.push(CONTAINER_LABELS.opf)
 
-  return isbn === undefined ? (
-    <UpdateListItem>
-      Remove the ISBN from <MetadataTargetChips targets={targets} />.
-    </UpdateListItem>
-  ) : (
-    <UpdateListItem>
-      Set the ISBN to <KeyChip label={isbn} /> in{" "}
-      <MetadataTargetChips targets={targets} />.
-    </UpdateListItem>
+  return labels
+}
+
+function MetadataUpdateItems({ action }: { action: PatchMetadataAction }) {
+  const containers = patchedContainerLabels(action)
+  const destinations = identifierDestinations(
+    action.patch.identifiers,
+    action.targets,
+  )
+
+  if (action.patch.identifiers.length === 0) {
+    return (
+      <UpdateListItem>
+        Remove every identifier from{" "}
+        <MetadataTargetChips targets={containers} />.
+      </UpdateListItem>
+    )
+  }
+
+  return (
+    <>
+      {action.patch.identifiers.map(
+        function renderIdentifierUpdate(identifier, index) {
+          const storedIn = (destinations[index] ?? []).map(
+            function toContainerLabel(container) {
+              return CONTAINER_LABELS[container]
+            },
+          )
+          const schemeLabel = identifierSchemeLabel(identifier.scheme)
+
+          return storedIn.length === 0 ? (
+            <UpdateListItem key={`${identifier.scheme}:${identifier.value}`}>
+              Drop <KeyChip label={schemeLabel} />{" "}
+              <KeyChip label={identifier.value} />: no container in this book
+              can carry it.
+            </UpdateListItem>
+          ) : (
+            <UpdateListItem key={`${identifier.scheme}:${identifier.value}`}>
+              Set <KeyChip label={schemeLabel} /> to{" "}
+              <KeyChip label={identifier.value} /> in{" "}
+              <MetadataTargetChips targets={storedIn} />.
+            </UpdateListItem>
+          )
+        },
+      )}
+      <UpdateListItem>
+        Remove any other identifier from{" "}
+        <MetadataTargetChips targets={containers} />.
+      </UpdateListItem>
+    </>
   )
 }
 

--- a/apps/web/src/books/optimize/form.ts
+++ b/apps/web/src/books/optimize/form.ts
@@ -13,7 +13,7 @@ export type BookOptimizeFormValues = MetadataFixerFormValues & {
 const DEFAULT_IMAGE_OUTPUT_MODE: ImageOutputMode = "original"
 
 export const EMPTY_BOOK_OPTIMIZE_FORM_VALUES: BookOptimizeFormValues = {
-  isbn: "",
+  identifiers: [],
   compressImages: false,
   imageOutputMode: DEFAULT_IMAGE_OUTPUT_MODE,
   maxWidth: "",

--- a/apps/web/src/books/optimize/metadata/MetadataForm.test.tsx
+++ b/apps/web/src/books/optimize/metadata/MetadataForm.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { useForm } from "react-hook-form"
+import {
+  EMPTY_BOOK_OPTIMIZE_FORM_VALUES,
+  type BookOptimizeFormValues,
+} from "../form"
+import { MetadataForm } from "./MetadataForm"
+import type { MetadataIdentifierFormValue } from "./formValues"
+
+const mocks = vi.hoisted(function createMocks() {
+  return {
+    useBookOptimize: vi.fn(),
+    useIsApplyingLocally: vi.fn(function isNotApplyingLocally() {
+      return false
+    }),
+  }
+})
+
+vi.mock("../BookOptimizeProvider", function mockBookOptimizeProvider() {
+  return { useBookOptimize: mocks.useBookOptimize }
+})
+
+vi.mock("../apply/useApplyLocally", function mockUseApplyLocally() {
+  return { useIsApplyingLocally: mocks.useIsApplyingLocally }
+})
+
+function MetadataFormHarness({
+  identifiers,
+}: {
+  identifiers: MetadataIdentifierFormValue[]
+}) {
+  const { control } = useForm<BookOptimizeFormValues>({
+    defaultValues: { ...EMPTY_BOOK_OPTIMIZE_FORM_VALUES, identifiers },
+    mode: "onChange",
+  })
+
+  mocks.useBookOptimize.mockReturnValue({
+    bookId: "book-id",
+    control,
+    isUploading: false,
+    inspection: {
+      resolvedArchive: { sources: { opf: {} }, unreadableSources: [] },
+    },
+  })
+
+  return <MetadataForm />
+}
+
+const identifierRows = (): HTMLElement[] =>
+  screen.queryAllByRole("group", { name: "Identifier" })
+
+const identifierRow = (index: number): HTMLElement => {
+  const row = identifierRows()[index]
+
+  if (!row) throw new Error(`Expected an identifier row at index ${index}`)
+
+  return row
+}
+
+const openSchemePicker = (index: number) => {
+  fireEvent.mouseDown(within(identifierRow(index)).getByRole("combobox"))
+}
+
+const removeIdentifierButton = (index: number): HTMLElement =>
+  within(identifierRow(index)).getByLabelText("Remove identifier")
+
+describe("MetadataForm", function testMetadataForm() {
+  afterEach(function cleanUpMetadataForm() {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it("seeds one row per identifier the book carries", function seedIdentifiers() {
+    render(
+      <MetadataFormHarness
+        identifiers={[
+          { scheme: "ISBN", value: "9783161484100", unique: false },
+          { scheme: "GoogleBooks", value: "zyTCAlFPjgYC", unique: false },
+        ]}
+      />,
+    )
+
+    expect(screen.getByDisplayValue("9783161484100")).not.toBeNull()
+    expect(screen.getByDisplayValue("zyTCAlFPjgYC")).not.toBeNull()
+    expect(screen.getByText("ISBN")).not.toBeNull()
+    expect(screen.getByText("Google Books id")).not.toBeNull()
+  })
+
+  it("appends an empty ISBN row on demand", function appendIdentifier() {
+    render(<MetadataFormHarness identifiers={[]} />)
+
+    expect(identifierRows()).toHaveLength(0)
+
+    fireEvent.click(screen.getByRole("button", { name: "Add identifier" }))
+
+    expect(identifierRows()).toHaveLength(1)
+    expect(screen.getByText("ISBN")).not.toBeNull()
+  })
+
+  it("lets a row switch to the Google Books scheme", function pickGoogleBooksScheme() {
+    render(
+      <MetadataFormHarness
+        identifiers={[{ scheme: "ISBN", value: "", unique: false }]}
+      />,
+    )
+
+    openSchemePicker(0)
+    fireEvent.click(screen.getByRole("option", { name: "Google Books id" }))
+
+    expect(screen.getByPlaceholderText("zyTCAlFPjgYC")).not.toBeNull()
+  })
+
+  it("reveals a free-text scheme field for a custom scheme", function typeCustomScheme() {
+    render(
+      <MetadataFormHarness
+        identifiers={[{ scheme: "ISBN", value: "", unique: false }]}
+      />,
+    )
+
+    openSchemePicker(0)
+    fireEvent.click(screen.getByRole("option", { name: "Custom…" }))
+
+    const schemeField = screen.getByLabelText("Custom scheme")
+
+    fireEvent.change(schemeField, { target: { value: "AcmeCatalog" } })
+
+    expect(schemeField).toHaveProperty("value", "AcmeCatalog")
+  })
+
+  it("shows an identifier read from the file under a custom scheme as custom", function seedCustomScheme() {
+    render(
+      <MetadataFormHarness
+        identifiers={[
+          { scheme: "AcmeCatalog", value: "acme-42", unique: false },
+        ]}
+      />,
+    )
+
+    expect(screen.getByLabelText("Custom scheme")).toHaveProperty(
+      "value",
+      "AcmeCatalog",
+    )
+  })
+
+  it("removes the row it is asked to remove", function removeIdentifier() {
+    render(
+      <MetadataFormHarness
+        identifiers={[
+          { scheme: "ISBN", value: "9783161484100", unique: false },
+          { scheme: "GoogleBooks", value: "zyTCAlFPjgYC", unique: false },
+        ]}
+      />,
+    )
+
+    fireEvent.click(removeIdentifierButton(0))
+
+    expect(screen.queryByDisplayValue("9783161484100")).toBeNull()
+    expect(screen.getByDisplayValue("zyTCAlFPjgYC")).not.toBeNull()
+  })
+
+  it("keeps the book's unique identifier from being removed", function protectUniqueIdentifier() {
+    render(
+      <MetadataFormHarness
+        identifiers={[
+          { scheme: "ISBN", value: "9783161484100", unique: true },
+          { scheme: "GoogleBooks", value: "zyTCAlFPjgYC", unique: false },
+        ]}
+      />,
+    )
+
+    expect(removeIdentifierButton(0)).toHaveProperty("disabled", true)
+    expect(removeIdentifierButton(1)).toHaveProperty("disabled", false)
+  })
+
+  it("rejects a value that is not a valid ISBN", async function rejectInvalidIsbn() {
+    render(
+      <MetadataFormHarness
+        identifiers={[{ scheme: "ISBN", value: "", unique: false }]}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText("Value"), {
+      target: { value: "not-an-isbn" },
+    })
+
+    expect(
+      await screen.findByText("Not a recognizable ISBN-10 or ISBN-13"),
+    ).not.toBeNull()
+  })
+
+  it("accepts any value once the scheme is Google Books", async function acceptGoogleVolumeId() {
+    render(
+      <MetadataFormHarness
+        identifiers={[{ scheme: "GoogleBooks", value: "", unique: false }]}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText("Value"), {
+      target: { value: "zyTCAlFPjgYC" },
+    })
+
+    expect(
+      screen.queryByText("Not a recognizable ISBN-10 or ISBN-13"),
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/books/optimize/metadata/MetadataForm.tsx
+++ b/apps/web/src/books/optimize/metadata/MetadataForm.tsx
@@ -1,50 +1,78 @@
-import { Stack } from "@mui/material"
-import { identifierValue, normalizeIsbn } from "@prose-reader/archive-reader"
-import { ControlledTextField } from "../../../common/forms/ControlledTextField"
-import type { BookOptimizeFormValues } from "../form"
+import { Add } from "@mui/icons-material"
+import {
+  Button,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Stack,
+  styled,
+} from "@mui/material"
+import { useFieldArray } from "react-hook-form"
 import { useBookOptimize } from "../BookOptimizeProvider"
 import { useIsApplyingLocally } from "../apply/useApplyLocally"
+import { IdentifierField } from "./identifiers/IdentifierField"
 import { hasWritableMetadataTarget } from "./identifiers/containers"
+import { DEFAULT_IDENTIFIER_SCHEME } from "./identifiers/schemes"
 
-const validateIsbn = (raw: string | boolean): true | string => {
-  if (typeof raw !== "string") return true
+const IdentifiersFormHelperText = styled(FormHelperText)(({ theme }) => ({
+  margin: theme.spacing(1, 0),
+}))
 
-  const trimmed = raw.trim()
-
-  if (trimmed === "") return true
-
-  return normalizeIsbn(trimmed) !== undefined
-    ? true
-    : "Not a recognizable ISBN-10 or ISBN-13"
-}
+const AddIdentifierButton = styled(Button)(({ theme }) => ({
+  alignSelf: "flex-start",
+  marginTop: theme.spacing(1),
+}))
 
 export function MetadataForm() {
   const { bookId, control, inspection, isUploading } = useBookOptimize()
   const isApplyingLocally = useIsApplyingLocally(bookId)
   const isApplying = isApplyingLocally || isUploading
   const isStorable = hasWritableMetadataTarget(inspection)
+  const isDisabled = isApplying || !isStorable
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "identifiers",
+  })
 
   return (
-    <Stack spacing={2}>
-      <ControlledTextField<BookOptimizeFormValues>
-        name="isbn"
-        control={control}
-        rules={{ validate: validateIsbn }}
-        label="ISBN"
-        size="small"
-        fullWidth
-        helperText={
-          isStorable
-            ? identifierValue(
-                inspection.resolvedArchive.metadata.identifiers,
-                "ISBN",
-              )
-              ? undefined
-              : "No ISBN found in this book yet."
-            : "This book has nowhere to store an ISBN."
-        }
-        disabled={isApplying || !isStorable}
-      />
-    </Stack>
+    <FormControl component="fieldset" disabled={isDisabled}>
+      <FormLabel component="legend">
+        Identifiers (e.g. ISBN, Google Books id)
+      </FormLabel>
+      <IdentifiersFormHelperText>
+        {isStorable
+          ? "Pick a known scheme or name your own. Saving makes the book carry exactly these identifiers."
+          : "This book has nowhere to store identifiers, so they cannot be edited."}
+      </IdentifiersFormHelperText>
+      <Stack spacing={2}>
+        {fields.map(function renderIdentifier(field, index) {
+          return (
+            <IdentifierField
+              key={field.id}
+              control={control}
+              index={index}
+              unique={field.unique}
+              disabled={isDisabled}
+              onRemove={function removeIdentifier() {
+                remove(index)
+              }}
+            />
+          )
+        })}
+      </Stack>
+      <AddIdentifierButton
+        startIcon={<Add />}
+        disabled={isDisabled}
+        onClick={function appendIdentifier() {
+          append({
+            scheme: DEFAULT_IDENTIFIER_SCHEME,
+            value: "",
+            unique: false,
+          })
+        }}
+      >
+        Add identifier
+      </AddIdentifierButton>
+    </FormControl>
   )
 }

--- a/apps/web/src/books/optimize/metadata/MetadataReport.tsx
+++ b/apps/web/src/books/optimize/metadata/MetadataReport.tsx
@@ -1,12 +1,11 @@
-import {
-  identifierValue,
-  type ResolvedArchiveSourceKind,
-} from "@prose-reader/archive-reader"
+import type { ResolvedArchiveSourceKind } from "@prose-reader/archive-reader"
 import { memo } from "react"
 import { useBookOptimize } from "../BookOptimizeProvider"
 import { Report, ReportRow } from "../Report"
 import type { ResolvedBookArchive } from "../useFileInspection"
 import { CONTAINER_LABELS } from "./identifiers/containers"
+import { resolveMetadataFixerFormValues } from "./identifiers/resolveMetadataFixerFormValues"
+import { identifierSchemeLabel } from "./identifiers/schemes"
 
 const containerValue = (
   kind: ResolvedArchiveSourceKind,
@@ -20,6 +19,7 @@ const containerValue = (
 export const MetadataReport = memo(function MetadataReport() {
   const { inspection } = useBookOptimize()
   const { resolvedArchive } = inspection
+  const { identifiers } = resolveMetadataFixerFormValues(inspection)
 
   return (
     <Report title="Metadata report">
@@ -31,12 +31,19 @@ export const MetadataReport = memo(function MetadataReport() {
         label={CONTAINER_LABELS.opf}
         value={containerValue("opf", resolvedArchive)}
       />
-      <ReportRow
-        label="ISBN"
-        value={
-          identifierValue(resolvedArchive.metadata.identifiers, "ISBN") ?? "—"
-        }
-      />
+      {identifiers.length === 0 ? (
+        <ReportRow label="Identifiers" value="—" />
+      ) : (
+        identifiers.map(function renderIdentifier({ scheme, value }) {
+          return (
+            <ReportRow
+              key={`${scheme}:${value}`}
+              label={identifierSchemeLabel(scheme)}
+              value={value}
+            />
+          )
+        })
+      )}
     </Report>
   )
 })

--- a/apps/web/src/books/optimize/metadata/MetadataWarnings.test.tsx
+++ b/apps/web/src/books/optimize/metadata/MetadataWarnings.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { useForm } from "react-hook-form"
+import {
+  EMPTY_BOOK_OPTIMIZE_FORM_VALUES,
+  type BookOptimizeFormValues,
+} from "../form"
+import { MetadataWarnings } from "./MetadataWarnings"
+import type { MetadataIdentifierFormValue } from "./formValues"
+
+const mocks = vi.hoisted(function createMocks() {
+  return { useBookOptimize: vi.fn() }
+})
+
+vi.mock("../BookOptimizeProvider", function mockBookOptimizeProvider() {
+  return { useBookOptimize: mocks.useBookOptimize }
+})
+
+const inspectionWithoutOpf = {
+  resolvedArchive: { unreadableSources: [], sources: {} },
+}
+
+function MetadataWarningsHarness({
+  identifiers,
+}: {
+  identifiers: MetadataIdentifierFormValue[]
+}) {
+  const { control } = useForm<BookOptimizeFormValues>({
+    defaultValues: { ...EMPTY_BOOK_OPTIMIZE_FORM_VALUES, identifiers },
+  })
+
+  mocks.useBookOptimize.mockReturnValue({
+    control,
+    inspection: inspectionWithoutOpf,
+  })
+
+  return <MetadataWarnings />
+}
+
+const identifier = (
+  scheme: string,
+  value: string,
+): MetadataIdentifierFormValue => ({ scheme, value, unique: false })
+
+describe("MetadataWarnings", function testMetadataWarnings() {
+  afterEach(function cleanUpMetadataWarnings() {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it("names the identifier a book with no OPF cannot store", function warnUnstorable() {
+    render(
+      <MetadataWarningsHarness
+        identifiers={[identifier("AcmeCatalog", "acme-42")]}
+      />,
+    )
+
+    expect(
+      screen.getByText(/has no field left for AcmeCatalog acme-42/),
+    ).not.toBeNull()
+  })
+
+  it("names a second ISBN as dropped, ComicInfo having one GTIN field", function warnSecondIsbn() {
+    render(
+      <MetadataWarningsHarness
+        identifiers={[
+          identifier("ISBN", "9783161484100"),
+          identifier("ISBN", "9780306406157"),
+        ]}
+      />,
+    )
+
+    expect(
+      screen.getByText(/has no field left for ISBN 9780306406157/),
+    ).not.toBeNull()
+  })
+
+  it("stays quiet about a row still being filled in", function ignoreIncompleteRows() {
+    render(
+      <MetadataWarningsHarness
+        identifiers={[identifier("", ""), identifier("AcmeCatalog", "")]}
+      />,
+    )
+
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("stays quiet about schemes ComicInfo can carry", function ignoreStorableSchemes() {
+    render(
+      <MetadataWarningsHarness
+        identifiers={[
+          identifier("ISBN", "9783161484100"),
+          identifier("GoogleBooks", "zyTCAlFPjgYC"),
+          identifier("DOI", "10.1000/182"),
+        ]}
+      />,
+    )
+
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+})

--- a/apps/web/src/books/optimize/metadata/MetadataWarnings.tsx
+++ b/apps/web/src/books/optimize/metadata/MetadataWarnings.tsx
@@ -1,21 +1,44 @@
 import { Alert, Stack } from "@mui/material"
 import { memo } from "react"
+import { useWatch } from "react-hook-form"
 import { useBookOptimize } from "../BookOptimizeProvider"
-import { CONTAINER_LABELS } from "./identifiers/containers"
+import {
+  CONTAINER_LABELS,
+  hasWritableMetadataTarget,
+  identifierDestinations,
+  resolveMetadataTargets,
+} from "./identifiers/containers"
+import { identifierSchemeLabel } from "./identifiers/schemes"
 
 export const MetadataWarnings = memo(function MetadataWarnings() {
-  const { inspection } = useBookOptimize()
+  const { control, inspection } = useBookOptimize()
   const { unreadableSources } = inspection.resolvedArchive
+  const identifiers = useWatch({ control, name: "identifiers" })
+  const targets = resolveMetadataTargets(inspection)
+  const destinations = identifierDestinations(identifiers, targets)
+  const droppedIdentifiers = hasWritableMetadataTarget(inspection)
+    ? identifiers.filter(function isCompleteAndUnstorable(
+        { scheme, value },
+        index,
+      ) {
+        return (
+          scheme.trim() !== "" &&
+          value.trim() !== "" &&
+          destinations[index]?.length === 0
+        )
+      })
+    : []
 
-  if (unreadableSources.length === 0) return null
+  if (unreadableSources.length === 0 && droppedIdentifiers.length === 0)
+    return null
 
   return (
     <Stack spacing={1}>
       {unreadableSources.includes("opf") && (
         <Alert severity="warning" variant="standard">
           This book&apos;s {CONTAINER_LABELS.opf} could not be read, so none of
-          its own metadata could be recovered and nothing can be saved back to
-          it. Editing it anyway would mean replacing it, which would cost the
+          its own identifiers could be recovered and nothing can be saved back
+          to it. Editing it anyway would mean replacing it, which would cost the
           book everything the document holds beyond what oboku understands.
         </Alert>
       )}
@@ -24,6 +47,18 @@ export const MetadataWarnings = memo(function MetadataWarnings() {
           This book&apos;s {CONTAINER_LABELS.comicInfo} could not be read, so
           nothing can be saved back to it. Replacing it would lose whatever else
           it contained.
+        </Alert>
+      )}
+      {droppedIdentifiers.length > 0 && (
+        <Alert severity="warning" variant="standard">
+          There is no writable {CONTAINER_LABELS.opf} in this book, and{" "}
+          {CONTAINER_LABELS.comicInfo} has no field left for{" "}
+          {droppedIdentifiers
+            .map(function describeIdentifier({ scheme, value }) {
+              return `${identifierSchemeLabel(scheme)} ${value}`
+            })
+            .join(", ")}
+          . Saving will drop {droppedIdentifiers.length > 1 ? "them" : "it"}.
         </Alert>
       )}
     </Stack>

--- a/apps/web/src/books/optimize/metadata/formValues.ts
+++ b/apps/web/src/books/optimize/metadata/formValues.ts
@@ -1,4 +1,15 @@
+export type MetadataIdentifierFormValue = {
+  scheme: string
+  value: string
+  /**
+   * Set for the identifier the book's OPF points at as its unique identifier.
+   * That element is structural, so the row stays in the list — it can be
+   * edited but not removed.
+   */
+  unique: boolean
+}
+
 /** The metadata slice of the optimize form. */
 export type MetadataFixerFormValues = {
-  isbn: string
+  identifiers: MetadataIdentifierFormValue[]
 }

--- a/apps/web/src/books/optimize/metadata/identifiers/IdentifierField.tsx
+++ b/apps/web/src/books/optimize/metadata/identifiers/IdentifierField.tsx
@@ -1,0 +1,155 @@
+import { Delete } from "@mui/icons-material"
+import {
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  styled,
+} from "@mui/material"
+import { useState } from "react"
+import { useController, type Control } from "react-hook-form"
+import { ControlledTextField } from "../../../../common/forms/ControlledTextField"
+import { errorToHelperText } from "../../../../common/forms/errorToHelperText"
+import type { BookOptimizeFormValues } from "../../form"
+import {
+  CUSTOM_SCHEME_OPTION,
+  IDENTIFIER_SCHEME_OPTIONS,
+  identifierValuePlaceholder,
+  isPredefinedIdentifierScheme,
+  validateIdentifierScheme,
+  validateIdentifierValue,
+} from "./schemes"
+
+const IdentifierGroupStack = styled(Stack)(({ theme }) => ({
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.shape.borderRadius,
+  padding: theme.spacing(1.5),
+  gap: theme.spacing(2),
+}))
+
+const RemoveIdentifierStack = styled(Stack)({
+  alignItems: "flex-end",
+})
+
+type Props = {
+  control: Control<BookOptimizeFormValues>
+  index: number
+  unique: boolean
+  disabled: boolean
+  onRemove: () => void
+}
+
+export function IdentifierField({
+  control,
+  index,
+  unique,
+  disabled,
+  onRemove,
+}: Props) {
+  const valueName = `identifiers.${index}.value` as const
+  const schemeName = `identifiers.${index}.scheme` as const
+
+  const {
+    field: { value: scheme, onChange: changeScheme, onBlur: blurScheme, ref },
+    fieldState: { error: schemeError, invalid: schemeInvalid },
+  } = useController({
+    control,
+    name: schemeName,
+    rules: { validate: validateIdentifierScheme, deps: [valueName] },
+  })
+
+  const [isCustomScheme, setIsCustomScheme] = useState(
+    () => !isPredefinedIdentifierScheme(scheme),
+  )
+
+  return (
+    <IdentifierGroupStack role="group" aria-label="Identifier">
+      <FormControl size="small" fullWidth disabled={disabled}>
+        <InputLabel>Scheme</InputLabel>
+        <Select
+          name={schemeName}
+          label="Scheme"
+          value={isCustomScheme ? CUSTOM_SCHEME_OPTION : scheme}
+          onBlur={blurScheme}
+          onChange={function selectScheme(event) {
+            const selectsCustomScheme =
+              event.target.value === CUSTOM_SCHEME_OPTION
+
+            setIsCustomScheme(selectsCustomScheme)
+            changeScheme(selectsCustomScheme ? "" : event.target.value)
+          }}
+        >
+          {IDENTIFIER_SCHEME_OPTIONS.map(function renderSchemeOption(option) {
+            return (
+              <MenuItem key={option.scheme} value={option.scheme}>
+                {option.label}
+              </MenuItem>
+            )
+          })}
+          <MenuItem value={CUSTOM_SCHEME_OPTION}>Custom…</MenuItem>
+        </Select>
+      </FormControl>
+      {isCustomScheme && (
+        <TextField
+          name={schemeName}
+          inputRef={ref}
+          label="Custom scheme"
+          placeholder="AcmeCatalog"
+          size="small"
+          fullWidth
+          disabled={disabled}
+          value={scheme}
+          onBlur={blurScheme}
+          onChange={changeScheme}
+          error={schemeInvalid}
+          helperText={
+            schemeInvalid ? errorToHelperText(schemeError) : undefined
+          }
+        />
+      )}
+      <ControlledTextField<BookOptimizeFormValues, typeof valueName>
+        control={control}
+        name={valueName}
+        rules={{
+          validate: function validateValueAgainstItsScheme(value, values) {
+            return validateIdentifierValue(
+              values.identifiers[index]?.scheme ?? "",
+              value,
+            )
+          },
+        }}
+        label="Value"
+        placeholder={identifierValuePlaceholder(scheme)}
+        size="small"
+        fullWidth
+        disabled={disabled}
+      />
+      <RemoveIdentifierStack>
+        <Tooltip
+          title={
+            unique
+              ? "This is the book's unique identifier and cannot be removed"
+              : ""
+          }
+        >
+          <span>
+            <Button
+              aria-label="Remove identifier"
+              size="small"
+              color="inherit"
+              startIcon={<Delete />}
+              disabled={disabled || unique}
+              onClick={onRemove}
+            >
+              Remove
+            </Button>
+          </span>
+        </Tooltip>
+      </RemoveIdentifierStack>
+    </IdentifierGroupStack>
+  )
+}

--- a/apps/web/src/books/optimize/metadata/identifiers/canonicalIdentifier.ts
+++ b/apps/web/src/books/optimize/metadata/identifiers/canonicalIdentifier.ts
@@ -1,0 +1,38 @@
+import {
+  catalogIdentifierFromUrl,
+  catalogUrlFromIdentifier,
+  normalizeIdentifierScheme,
+  type MetadataIdentifier,
+} from "@prose-reader/archive-reader"
+import { URL_IDENTIFIER_SCHEME } from "@oboku/archive-metadata/web"
+
+/**
+ * A catalog link is the same identifier as the tagged one it points at, so it
+ * is folded back to that scheme and its bare id — which is also what makes it
+ * dedupe against the OPF's copy.
+ */
+export const catalogIdentifier = ({
+  scheme,
+  value,
+}: MetadataIdentifier): MetadataIdentifier | undefined =>
+  normalizeIdentifierScheme(scheme) === URL_IDENTIFIER_SCHEME
+    ? catalogIdentifierFromUrl(value)
+    : undefined
+
+/**
+ * A catalog accepts more spellings of its own id than it addresses records by
+ * — a bare `OL7353617M` for `/books/OL7353617M` — and the two containers can
+ * each hold a different one. Rebuilding the link and reading it back yields
+ * the spelling the catalog itself uses, so the same identifier collapses to
+ * one row however it was written.
+ */
+export const canonicalIdentifier = (
+  identifier: MetadataIdentifier,
+): MetadataIdentifier => {
+  const url = catalogUrlFromIdentifier(identifier)
+
+  return (
+    (url === undefined ? undefined : catalogIdentifierFromUrl(url)) ??
+    identifier
+  )
+}

--- a/apps/web/src/books/optimize/metadata/identifiers/containers.test.ts
+++ b/apps/web/src/books/optimize/metadata/identifiers/containers.test.ts
@@ -1,106 +1,111 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest"
+import {
+  hasWritableMetadataTarget,
+  identifierDestinations,
+  resolveMetadataTargets,
+} from "./containers"
 import { CONTAINER_XML, comicInfo, inspect, opf } from "./inspection.fixture"
-import { hasWritableMetadataTarget, resolveMetadataTargets } from "./containers"
 
-const UNPARSEABLE = "<root><child></wrong></root>"
+describe("identifierDestinations", function testIdentifierDestinations() {
+  const both = { comicInfo: true, opf: true }
+  const comicInfoOnly = { comicInfo: true }
 
-describe("resolveMetadataTargets", () => {
-  it("writes only the OPF of an EPUB carrying nothing else", async () => {
-    const inspection = await inspect({
-      "META-INF/container.xml": CONTAINER_XML,
-      "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
-    })
-
-    expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: false,
-      opf: true,
-    })
+  it("keeps a scheme ComicInfo cannot represent out of it", function excludeComicInfo() {
+    expect(identifierDestinations([{ scheme: "AcmeCatalog" }], both)).toEqual([
+      ["opf"],
+    ])
+    expect(
+      identifierDestinations([{ scheme: "AcmeCatalog" }], comicInfoOnly),
+    ).toEqual([[]])
   })
 
-  it("writes both when the EPUB also carries a ComicInfo", async () => {
-    const inspection = await inspect({
-      "META-INF/container.xml": CONTAINER_XML,
-      "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
-      "ComicInfo.xml": comicInfo("<Title>Sample</Title>"),
-    })
-
-    expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: true,
-      opf: true,
-    })
+  it("stores identifiers ComicInfo has a field for in both containers", function includeComicInfo() {
+    for (const scheme of [
+      "ISBN",
+      "GTIN",
+      "URL",
+      "GoogleBooks",
+      "ProjectGutenberg",
+      "OpenLibrary",
+      "DOI",
+    ]) {
+      expect(identifierDestinations([{ scheme }], both)).toEqual([
+        ["comicInfo", "opf"],
+      ])
+    }
   })
 
-  it("writes the ComicInfo an archive with no OPF carries", async () => {
-    const inspection = await inspect({
-      "ComicInfo.xml": comicInfo("<Title>Sample</Title>"),
-      "page-001.jpg": "binary",
-    })
-
-    expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: true,
-      opf: false,
-    })
+  it("gives ComicInfo's single GTIN field to the first ISBN-bearing identifier only", function shareOneGtinField() {
+    expect(
+      identifierDestinations([{ scheme: "ISBN" }, { scheme: "GTIN" }], both),
+    ).toEqual([["comicInfo", "opf"], ["opf"]])
+    expect(
+      identifierDestinations(
+        [{ scheme: "ISBN" }, { scheme: "ISBN" }],
+        comicInfoOnly,
+      ),
+    ).toEqual([["comicInfo"], []])
   })
 
-  it("creates a ComicInfo for an archive carrying no metadata at all", async () => {
-    const inspection = await inspect({ "page-001.jpg": "binary" })
+  it("lets several links share the Web field", function shareWebField() {
+    expect(
+      identifierDestinations(
+        [{ scheme: "URL" }, { scheme: "GoogleBooks" }, { scheme: "DOI" }],
+        comicInfoOnly,
+      ),
+    ).toEqual([["comicInfo"], ["comicInfo"], ["comicInfo"]])
+  })
+})
 
-    expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: true,
-      opf: false,
-    })
+describe("resolveMetadataTargets", function testMetadataTargets() {
+  const UNPARSEABLE = "<root><child></wrong></root>"
+
+  it("writes every container the archive carries", async function targetCarried() {
+    expect(
+      resolveMetadataTargets(
+        await inspect({
+          "META-INF/container.xml": CONTAINER_XML,
+          "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
+        }),
+      ),
+    ).toEqual({ comicInfo: false, opf: true })
+
+    expect(
+      resolveMetadataTargets(
+        await inspect({
+          "META-INF/container.xml": CONTAINER_XML,
+          "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
+          "ComicInfo.xml": comicInfo("<Title>Sample</Title>"),
+        }),
+      ),
+    ).toEqual({ comicInfo: true, opf: true })
   })
 
-  it("writes nothing when the OPF cannot be read", async () => {
-    const inspection = await inspect({
+  it("creates a ComicInfo for an archive carrying no metadata", async function synthesizeComicInfo() {
+    expect(
+      resolveMetadataTargets(await inspect({ "page-001.jpg": "binary" })),
+    ).toEqual({ comicInfo: true, opf: false })
+  })
+
+  it("writes nothing when a container it carries cannot be read", async function refuseUnreadable() {
+    const brokenOpf = await inspect({
       "META-INF/container.xml": CONTAINER_XML,
       "OEBPS/content.opf": UNPARSEABLE,
-    })
-
-    expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: false,
-      opf: false,
-    })
-    expect(hasWritableMetadataTarget(inspection)).toBe(false)
-  })
-
-  it("writes nothing when the OPF cannot be read even alongside a ComicInfo", async () => {
-    const inspection = await inspect({
-      "META-INF/container.xml": CONTAINER_XML,
-      "OEBPS/content.opf": UNPARSEABLE,
       "ComicInfo.xml": comicInfo("<Title>Sample</Title>"),
     })
-
-    expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: false,
-      opf: false,
-    })
-  })
-
-  it("writes nothing when the ComicInfo cannot be read", async () => {
-    const inspection = await inspect({
-      "ComicInfo.xml": UNPARSEABLE,
-      "page-001.jpg": "binary",
-    })
-
-    expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: false,
-      opf: false,
-    })
-    expect(hasWritableMetadataTarget(inspection)).toBe(false)
-  })
-
-  it("writes nothing when the ComicInfo cannot be read even alongside a readable OPF", async () => {
-    const inspection = await inspect({
+    const brokenComicInfo = await inspect({
       "META-INF/container.xml": CONTAINER_XML,
       "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
       "ComicInfo.xml": UNPARSEABLE,
     })
 
-    expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: false,
-      opf: false,
-    })
+    for (const inspection of [brokenOpf, brokenComicInfo]) {
+      expect(resolveMetadataTargets(inspection)).toEqual({
+        comicInfo: false,
+        opf: false,
+      })
+      expect(hasWritableMetadataTarget(inspection)).toBe(false)
+    }
   })
 })

--- a/apps/web/src/books/optimize/metadata/identifiers/containers.ts
+++ b/apps/web/src/books/optimize/metadata/identifiers/containers.ts
@@ -1,4 +1,8 @@
-import type { ArchiveMetadataTargets } from "@oboku/archive-metadata/web"
+import {
+  type ArchiveMetadataTargets,
+  isComicInfoWritableIdentifierScheme,
+} from "@oboku/archive-metadata/web"
+import { isIsbnBearingScheme } from "@prose-reader/archive-reader"
 import type { FileInspection } from "../../useFileInspection"
 
 type ContainerKey = "comicInfo" | "opf"
@@ -9,19 +13,10 @@ export const CONTAINER_LABELS: Record<ContainerKey, string> = {
 }
 
 /**
- * The containers a save should write.
- *
- * A container the book carries but oboku cannot parse stops the save: it
- * cannot be patched without being read, and replacing it would discard
- * whatever it holds that oboku does not model. Falling back to the other
- * container is not a fix either — a book with a package document is an EPUB
- * whether or not that document parses, and a comic sidecar does not belong in
- * one.
- *
- * Otherwise every container the book already carries is written, so they cannot
- * end up disagreeing about the same ISBN — picking a winner per container was
- * never the user's call. ComicInfo.xml is created only for an archive that
- * carries no metadata of its own: a bare comic archive.
+ * An unreadable OPF is skipped rather than replaced: the package document also
+ * carries the manifest and spine, so overwriting it with the fields oboku
+ * knows about would cost the book its reading order. ComicInfo is always a
+ * target — it is patched when present and synthesized when not.
  */
 export const resolveMetadataTargets = ({
   resolvedArchive,
@@ -40,11 +35,43 @@ export const resolveMetadataTargets = ({
   return { comicInfo: sources.comicInfo !== undefined || !opf, opf }
 }
 
-/** Whether a save has any container left to write the metadata into. */
+/** Whether a save has any container left to write the identifiers into. */
 export const hasWritableMetadataTarget = (
   inspection: FileInspection,
 ): boolean => {
   const { comicInfo, opf } = resolveMetadataTargets(inspection)
 
   return comicInfo === true || opf === true
+}
+
+/**
+ * The containers each identifier can actually be stored in, which is neither
+ * the same set for every scheme nor decidable one identifier at a time:
+ * ComicInfo takes ISBN/GTIN, links, and the catalogs that have a link form,
+ * but `<GTIN>` is a single field — so a second ISBN needs an OPF, while a
+ * second link does not. Returned positionally, one entry per identifier.
+ */
+export const identifierDestinations = (
+  identifiers: ReadonlyArray<{ scheme: string }>,
+  targets: ArchiveMetadataTargets,
+): ContainerKey[][] => {
+  let gtinFieldTaken = false
+
+  return identifiers.map(function destinationsFor({ scheme }) {
+    const containers: ContainerKey[] = []
+    const needsGtinField = isIsbnBearingScheme(scheme)
+
+    if (
+      targets.comicInfo &&
+      isComicInfoWritableIdentifierScheme(scheme) &&
+      !(needsGtinField && gtinFieldTaken)
+    ) {
+      containers.push("comicInfo")
+      gtinFieldTaken = gtinFieldTaken || needsGtinField
+    }
+
+    if (targets.opf) containers.push("opf")
+
+    return containers
+  })
 }

--- a/apps/web/src/books/optimize/metadata/identifiers/resolveMetadataFixerFormValues.test.ts
+++ b/apps/web/src/books/optimize/metadata/identifiers/resolveMetadataFixerFormValues.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest"
+import { resolveMetadataFixerFormValues } from "./resolveMetadataFixerFormValues"
+import { CONTAINER_XML, comicInfo, inspect, opf } from "./inspection.fixture"
+
+describe("resolveMetadataFixerFormValues", function testSeeding() {
+  it("seeds a row per identifier the containers carry", async function seedRows() {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>' +
+          '<dc:identifier opf:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>',
+      ),
+    })
+
+    expect(resolveMetadataFixerFormValues(inspection).identifiers).toEqual([
+      { scheme: "ISBN", value: "9783161484100", unique: false },
+      { scheme: "GoogleBooks", value: "zyTCAlFPjgYC", unique: false },
+    ])
+  })
+
+  it("marks the identifier the package points at as unique", async function flagUniqueIdentifier() {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier id="pub-id" opf:scheme="ISBN">9783161484100</dc:identifier>',
+      ),
+    })
+
+    expect(resolveMetadataFixerFormValues(inspection).identifiers).toEqual([
+      { scheme: "ISBN", value: "9783161484100", unique: true },
+    ])
+  })
+
+  it("collapses the ISBN and the ComicInfo GTIN holding it into one row", async function dedupeIsbnBearingSchemes() {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
+      ),
+      "ComicInfo.xml": comicInfo("<GTIN>9783161484100</GTIN>"),
+    })
+
+    expect(resolveMetadataFixerFormValues(inspection).identifiers).toEqual([
+      { scheme: "ISBN", value: "9783161484100", unique: false },
+    ])
+  })
+
+  it("folds a ComicInfo catalog link back to the scheme it stands for", async function seedCatalogLink() {
+    const inspection = await inspect({
+      "ComicInfo.xml": comicInfo(
+        "<Web>https://books.google.com/books?id=zyTCAlFPjgYC</Web>",
+      ),
+      "page-001.jpg": "binary",
+    })
+
+    expect(resolveMetadataFixerFormValues(inspection).identifiers).toEqual([
+      { scheme: "GoogleBooks", value: "zyTCAlFPjgYC", unique: false },
+    ])
+  })
+
+  it("collapses the OPF identifier and the ComicInfo link holding it", async function dedupeCatalogLink() {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>',
+      ),
+      "ComicInfo.xml": comicInfo(
+        "<Web>https://books.google.com/books?id=zyTCAlFPjgYC</Web>",
+      ),
+    })
+
+    expect(resolveMetadataFixerFormValues(inspection).identifiers).toEqual([
+      { scheme: "GoogleBooks", value: "zyTCAlFPjgYC", unique: false },
+    ])
+  })
+
+  it("canonicalizes a catalog id to the spelling its catalog addresses by", async function canonicalizeCatalogValue() {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="OpenLibrary">OL7353617M</dc:identifier>',
+      ),
+    })
+
+    expect(resolveMetadataFixerFormValues(inspection).identifiers).toEqual([
+      { scheme: "OpenLibrary", value: "/books/OL7353617M", unique: false },
+    ])
+  })
+
+  it("collapses a bare catalog id and the link holding it into one row", async function dedupeAcrossSpellings() {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="OpenLibrary">OL7353617M</dc:identifier>',
+      ),
+      "ComicInfo.xml": comicInfo(
+        "<Web>https://openlibrary.org/books/OL7353617M</Web>",
+      ),
+    })
+
+    expect(resolveMetadataFixerFormValues(inspection).identifiers).toEqual([
+      { scheme: "OpenLibrary", value: "/books/OL7353617M", unique: false },
+    ])
+  })
+
+  it("leaves a link no catalog claims as a URL", async function seedPlainLink() {
+    const inspection = await inspect({
+      "ComicInfo.xml": comicInfo("<Web>https://example.com/a</Web>"),
+      "page-001.jpg": "binary",
+    })
+
+    expect(resolveMetadataFixerFormValues(inspection).identifiers).toEqual([
+      { scheme: "URL", value: "https://example.com/a", unique: false },
+    ])
+  })
+
+  it("keeps a ComicInfo-only GTIN under its own scheme", async function seedComicInfoGtin() {
+    const inspection = await inspect({
+      "ComicInfo.xml": comicInfo("<GTIN>9783161484100</GTIN>"),
+      "page-001.jpg": "binary",
+    })
+
+    expect(resolveMetadataFixerFormValues(inspection).identifiers).toEqual([
+      { scheme: "GTIN", value: "9783161484100", unique: false },
+    ])
+  })
+})

--- a/apps/web/src/books/optimize/metadata/identifiers/resolveMetadataFixerFormValues.ts
+++ b/apps/web/src/books/optimize/metadata/identifiers/resolveMetadataFixerFormValues.ts
@@ -1,11 +1,69 @@
-import { identifierValue } from "@prose-reader/archive-reader"
+import {
+  isIsbnBearingScheme,
+  normalizeIdentifierScheme,
+  type ResolvedMetadataIdentifier,
+} from "@prose-reader/archive-reader"
 import type { FileInspection } from "../../useFileInspection"
-import type { MetadataFixerFormValues } from "../formValues"
+import type {
+  MetadataFixerFormValues,
+  MetadataIdentifierFormValue,
+} from "../formValues"
+import { canonicalIdentifier, catalogIdentifier } from "./canonicalIdentifier"
+
+/**
+ * The reader reports each container's identifiers as it finds them, so one
+ * identifier written to both comes back twice under whichever scheme each
+ * container has a slot for: an ISBN as `ISBN` from the OPF and `GTIN` from
+ * ComicInfo. Collapsing those keeps a saved book from growing a duplicate row
+ * every time it is inspected again.
+ */
+/**
+ * The scheme a row is keyed under, collapsing the ones that mean the same: an
+ * ISBN and a `GTIN` of the same value are the one identifier each container
+ * spells its own way.
+ */
+export const identifierRowScheme = ({
+  scheme,
+}: MetadataIdentifierFormValue): string =>
+  isIsbnBearingScheme(scheme) ? "isbn-bearing" : scheme
+
+const dedupeKey = (identifier: MetadataIdentifierFormValue): string =>
+  `${identifierRowScheme(identifier)}:${identifier.value}`
+
+/**
+ * The row an identifier the reader reported belongs to, so a caller can ask
+ * whether the edited list still represents it.
+ */
+export const toIdentifierRow = (
+  identifier: ResolvedMetadataIdentifier,
+): MetadataIdentifierFormValue => {
+  const { scheme, value } = canonicalIdentifier(
+    catalogIdentifier(identifier) ?? identifier,
+  )
+
+  return {
+    scheme: normalizeIdentifierScheme(scheme),
+    value,
+    unique: identifier.unique === true,
+  }
+}
 
 export const resolveMetadataFixerFormValues = (
   inspection: FileInspection,
-): MetadataFixerFormValues => ({
-  isbn:
-    identifierValue(inspection.resolvedArchive.metadata.identifiers, "ISBN") ??
-    "",
-})
+): MetadataFixerFormValues => {
+  const seen = new Set<string>()
+  const identifiers: MetadataIdentifierFormValue[] = []
+
+  for (const resolved of inspection.resolvedArchive.metadata.identifiers ??
+    []) {
+    const identifier = toIdentifierRow(resolved)
+    const key = dedupeKey(identifier)
+
+    if (seen.has(key)) continue
+
+    seen.add(key)
+    identifiers.push(identifier)
+  }
+
+  return { identifiers }
+}

--- a/apps/web/src/books/optimize/metadata/identifiers/schemes.ts
+++ b/apps/web/src/books/optimize/metadata/identifiers/schemes.ts
@@ -1,0 +1,149 @@
+import {
+  catalogUrlFromIdentifier,
+  normalizeIdentifierScheme,
+  type KnownMetadataIdentifierScheme,
+  normalizeGtin,
+  normalizeIsbn,
+} from "@prose-reader/archive-reader"
+
+export const CUSTOM_SCHEME_OPTION = "custom"
+
+export const DEFAULT_IDENTIFIER_SCHEME = "ISBN"
+
+type IdentifierSchemeTemplate = {
+  label: string
+  placeholder?: string
+  validate?: (value: string) => true | string
+}
+
+/**
+ * Catalog values are checked against the link the writer would build for them:
+ * a value the catalog cannot address has nowhere to live in a container that
+ * only stores links.
+ */
+const isCatalogAddressable = (scheme: string, value: string): boolean =>
+  catalogUrlFromIdentifier({ scheme, value }) !== undefined
+
+const isHttpUrl = (value: string): boolean => {
+  try {
+    const { protocol, hostname } = new URL(value)
+
+    return (protocol === "http:" || protocol === "https:") && hostname !== ""
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Keyed by the reader's scheme union so a scheme added upstream fails to
+ * compile until it is given a label and, where the format is checkable, a
+ * validator. Declaration order is the order the picker offers them in.
+ */
+const IDENTIFIER_SCHEME_TEMPLATES: Record<
+  KnownMetadataIdentifierScheme,
+  IdentifierSchemeTemplate
+> = {
+  ISBN: {
+    label: "ISBN",
+    placeholder: "9783161484100",
+    validate: function validateIsbn(value) {
+      return normalizeIsbn(value) !== undefined
+        ? true
+        : "Not a recognizable ISBN-10 or ISBN-13"
+    },
+  },
+  GoogleBooks: {
+    label: "Google Books id",
+    placeholder: "zyTCAlFPjgYC",
+    validate: function validateGoogleBooksId(value) {
+      return isCatalogAddressable("GoogleBooks", value)
+        ? true
+        : "Not a Google Books volume id"
+    },
+  },
+  GTIN: {
+    label: "GTIN / barcode",
+    placeholder: "9783161484100",
+    validate: function validateGtin(value) {
+      return normalizeGtin(value) !== undefined
+        ? true
+        : "Not a recognizable 8, 12, 13 or 14 digit GTIN"
+    },
+  },
+  OpenLibrary: {
+    label: "Open Library",
+    placeholder: "/books/OL7353617M",
+    validate: function validateOpenLibraryKey(value) {
+      return isCatalogAddressable("OpenLibrary", value)
+        ? true
+        : "Not an Open Library id, e.g. /books/OL7353617M or OL7353617M"
+    },
+  },
+  ProjectGutenberg: {
+    label: "Project Gutenberg",
+    placeholder: "2701",
+    validate: function validateProjectGutenbergId(value) {
+      return isCatalogAddressable("ProjectGutenberg", value)
+        ? true
+        : "Not a Project Gutenberg ebook number"
+    },
+  },
+  DOI: {
+    label: "DOI",
+    placeholder: "10.1000/182",
+    validate: function validateDoi(value) {
+      return isCatalogAddressable("DOI", value)
+        ? true
+        : "Not a DOI, e.g. 10.1000/182"
+    },
+  },
+  URL: {
+    label: "URL",
+    placeholder: "https://example.com/book",
+    validate: function validateUrl(value) {
+      return isHttpUrl(value) ? true : "Not an http(s) URL"
+    },
+  },
+  Unknown: {
+    label: "No scheme",
+  },
+}
+
+const SCHEME_TEMPLATE_ENTRIES = Object.entries(IDENTIFIER_SCHEME_TEMPLATES)
+
+const TEMPLATES_BY_SCHEME = new Map<string, IdentifierSchemeTemplate>(
+  SCHEME_TEMPLATE_ENTRIES,
+)
+
+export const IDENTIFIER_SCHEME_OPTIONS = SCHEME_TEMPLATE_ENTRIES.map(
+  function toSchemeOption([scheme, { label }]) {
+    return { scheme, label }
+  },
+)
+
+const templateFor = (scheme: string): IdentifierSchemeTemplate | undefined =>
+  TEMPLATES_BY_SCHEME.get(normalizeIdentifierScheme(scheme))
+
+export const isPredefinedIdentifierScheme = (scheme: string): boolean =>
+  templateFor(scheme) !== undefined
+
+export const identifierSchemeLabel = (scheme: string): string =>
+  templateFor(scheme)?.label ?? scheme
+
+export const identifierValuePlaceholder = (
+  scheme: string,
+): string | undefined => templateFor(scheme)?.placeholder
+
+export const validateIdentifierScheme = (scheme: string): true | string =>
+  scheme.trim() === "" ? "Required" : true
+
+export const validateIdentifierValue = (
+  scheme: string,
+  value: string,
+): true | string => {
+  const trimmed = value.trim()
+
+  if (trimmed === "") return "Required"
+
+  return templateFor(scheme)?.validate?.(trimmed) ?? true
+}


### PR DESCRIPTION
## What

The optimize screen's single **ISBN** field is replaced by a dynamic list of identifiers. Each row picks a scheme — ISBN, Google Books id, GTIN, Open Library, Project Gutenberg, DOI, URL, No scheme — or **Custom…** for a free-text scheme, and carries its value, validated per scheme.

## Why the field couldn't just gain a sibling

`ArchiveMetadataPatch` was `{ isbn?: string }` end to end, and each container writer had one hard-coded destination. A `googleBookId` field would have meant a second hard-coded path, then a third for DOI — and a fixed set of fields can never round-trip what the reader reports, which is an arbitrary `{ scheme, value }[]` including custom schemes. So the patch became the identifier list.

## Writer changes

The patch is now the **complete set** the archive should end up with, not a delta — an identifier the list omits is removed. Schemes fold onto canonical casing via a table keyed off `KnownMetadataIdentifierScheme`, so a scheme added upstream fails to compile until it is handled here.

The OPF writer reconciles `<dc:identifier>` elements by scheme, reusing the existing element of a scheme rather than replacing it, so its `id` — and any `<meta refines>` targeting it — survives an edit. Three latent bugs fell out on the way, each now covered:

- the element referenced by `<package unique-identifier>` is **pinned**: only rewritten through the entry flagged `unique`, never removed, so the reference can't be left dangling (previously an ISBN-tagged unique identifier could be deleted out from under the package)
- root and `<metadata>` are matched by **local name**, so a prefixed `<opf:package>` is accepted — the writer previously rejected its own output, making a second pass impossible
- new elements use `createElementNS`, so they no longer pick up `xmlns=""`

## ComicInfo carries catalog identifiers as links

ComicInfo has `<GTIN>` and `<Web>`, and `<Web>` is a list of catalog links — which is a home for every scheme whose catalog addresses a record by URL. So a Google Books id does **not** need an OPF, and a CBZ can carry one:

| scheme | stored as |
| --- | --- |
| ISBN, GTIN | `<GTIN>` |
| URL | `<Web>` verbatim |
| Google Books | `<Web>https://books.google.com/books?id=…` |
| Project Gutenberg | `<Web>https://www.gutenberg.org/ebooks/…` |
| Open Library | `<Web>https://openlibrary.org/books/OL…M` |
| DOI | `<Web>https://doi.org/10.…` |

The crosswalk runs both ways, and the read half is what makes it usable: the reader reports a `<Web>` entry as a plain `URL` identifier, so without folding it back to the scheme it stands for, an EPUB written to both containers would grow a duplicate row on every inspection.

Google Books and Project Gutenberg defer to `@prose-reader/metadata-fetcher`, which already owns those crosswalks for its own lookups. Open Library and DOI are parsed locally **only because it has no equivalent yet** — worth moving upstream alongside the other two, at which point those two entries here delete.

A candidate link is only used once it reads back, so a value its catalog cannot address (a non-numeric Gutenberg id, say) is reported as unstorable rather than written as a link nothing recovers. The form validates the same rule per scheme, so it can't get that far.

What's left with no writable OPF is what genuinely has no field: a custom scheme, or an untagged identifier. The form warns which, and the confirm dialog lists destinations per identifier.

## Round-trip detail

One identifier written to both containers comes back twice under whichever scheme each container has a slot for — an ISBN as `ISBN` from the OPF and `GTIN` from ComicInfo, a Google Books id as `GoogleBooks` and as a `URL`. Seeding collapses both cases, so a saved book doesn't grow duplicate rows.

## No new dependency

An earlier revision of this PR reached the URL crosswalk through `@prose-reader/metadata-fetcher`. That crosswalk now lives in `archive-reader` itself (prose-reader#326, shipped in 1.357.0 and picked up by #599), so this reads catalog links through `catalogIdentifierFromUrl` and adds **no dependency at all** — the local Open Library and DOI parsers it had to carry are gone with it.

What stays here is the write half, which a reader has no business owning: building each catalog's official URL. Every candidate is confirmed by reading it back before it is stored, so a value its catalog cannot express is reported as unstorable rather than written as a link nothing recovers.

One tolerance moved upstream with the parsing: an Open Library key must name its collection (`/books/OL7353617M`) to be written, since a bare id does not say whether it addresses an edition, a work or an author. Reading one stays liberal. The form validates against the same rule, so it surfaces as a field error rather than a silent drop.

## Scope

Write path only. **Nothing consumes the new schemes yet** — #587 does that for Google Books, and once this lands it should also use `identifierFromCatalogUrl` so a `<Web>` link is recognised, not just a bare `GoogleBooks` scheme.

## Verification

- `apps/web` — 59 files / 319 tests (9 `MetadataForm` interaction tests, 12 `targets` tests covering seeding, both dedupe cases and per-scheme destinations against the real reader)
- `packages/archive-metadata` — 11 files / 128 tests (21 dedicated crosswalk tests both directions, OPF reconciliation, unique-identifier pinning, namespace handling, ComicInfo GTIN/Web)
- `tsc` clean in `apps/web`, `apps/api`, `packages/archive-metadata`; biome clean; `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
