### PR TITLE
refactor(web): follow-up consolidations from #549

### DIFF
--- a/apps/web/src/common/forms/ControlledConnectorSelector.tsx
+++ b/apps/web/src/common/forms/ControlledConnectorSelector.tsx
@@ -1,0 +1,42 @@
+import type { ComponentProps } from "react"
+import { Controller, type FieldPath, type FieldValues } from "react-hook-form"
+import {
+  ConnectorSelector,
+  type ConnectorSelectorProps,
+} from "../../connectors/ConnectorSelector"
+import { errorToHelperText } from "./errorToHelperText"
+
+export const ControlledConnectorSelector = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TTransformedValues = TFieldValues,
+>({
+  control,
+  name,
+  rules,
+  ...connectorSelectorProps
+}: Omit<
+  ComponentProps<typeof Controller<TFieldValues, TName, TTransformedValues>>,
+  "render"
+> &
+  ConnectorSelectorProps) => {
+  return (
+    <Controller
+      control={control}
+      name={name}
+      rules={rules}
+      render={({ field, fieldState }) => (
+        <ConnectorSelector
+          {...field}
+          {...connectorSelectorProps}
+          helperText={
+            fieldState.invalid
+              ? errorToHelperText(fieldState.error)
+              : connectorSelectorProps.helperText
+          }
+          error={fieldState.invalid}
+        />
+      )}
+    />
+  )
+}

--- a/apps/web/src/common/forms/ControlledConnectorSelector.tsx
+++ b/apps/web/src/common/forms/ControlledConnectorSelector.tsx
@@ -25,18 +25,20 @@ export const ControlledConnectorSelector = <
       control={control}
       name={name}
       rules={rules}
-      render={({ field, fieldState }) => (
-        <ConnectorSelector
-          {...field}
-          {...connectorSelectorProps}
-          helperText={
-            fieldState.invalid
-              ? errorToHelperText(fieldState.error)
-              : connectorSelectorProps.helperText
-          }
-          error={fieldState.invalid}
-        />
-      )}
+      render={function renderConnectorSelector({ field, fieldState }) {
+        return (
+          <ConnectorSelector
+            {...field}
+            {...connectorSelectorProps}
+            helperText={
+              fieldState.invalid
+                ? errorToHelperText(fieldState.error)
+                : connectorSelectorProps.helperText
+            }
+            error={fieldState.invalid}
+          />
+        )
+      }}
     />
   )
 }

--- a/apps/web/src/notifications/inbox/createNotificationMutationOptions.ts
+++ b/apps/web/src/notifications/inbox/createNotificationMutationOptions.ts
@@ -1,0 +1,50 @@
+import type { MutationKey, QueryClient } from "@tanstack/react-query"
+import {
+  type NotificationCacheSnapshot,
+  cancelAndSnapshotNotificationQueries,
+  invalidateNotificationQueries,
+  rollbackNotificationCaches,
+} from "./queryKeys"
+
+/**
+ * Wires the snapshot / rollback / invalidation cycle every optimistic
+ * notification mutation shares. Only `applyOptimisticUpdate` differs between
+ * them: it writes the mutation's own view of the notification caches, from the
+ * snapshot taken before the request goes out.
+ */
+export const createNotificationMutationOptions = <TVariables, TData>({
+  queryClient,
+  profileId,
+  mutationKey,
+  mutationFn,
+  applyOptimisticUpdate,
+}: {
+  queryClient: QueryClient
+  profileId: string | undefined
+  mutationKey: MutationKey
+  mutationFn: (variables: TVariables) => Promise<TData>
+  applyOptimisticUpdate: (
+    variables: TVariables,
+    snapshot: NotificationCacheSnapshot,
+  ) => void
+}) => ({
+  mutationKey,
+  networkMode: "online" as const,
+  mutationFn,
+  onMutate: async (variables: TVariables) => {
+    const snapshot = await cancelAndSnapshotNotificationQueries(
+      queryClient,
+      profileId,
+    )
+
+    applyOptimisticUpdate(variables, snapshot)
+
+    return snapshot
+  },
+  onError: (
+    _err: unknown,
+    _vars: TVariables,
+    context: NotificationCacheSnapshot | undefined,
+  ) => rollbackNotificationCaches(queryClient, profileId, context),
+  onSettled: () => invalidateNotificationQueries(queryClient, profileId),
+})

--- a/apps/web/src/notifications/inbox/createNotificationMutationOptions.ts
+++ b/apps/web/src/notifications/inbox/createNotificationMutationOptions.ts
@@ -6,12 +6,6 @@ import {
   rollbackNotificationCaches,
 } from "./queryKeys"
 
-/**
- * Wires the snapshot / rollback / invalidation cycle every optimistic
- * notification mutation shares. Only `applyOptimisticUpdate` differs between
- * them: it writes the mutation's own view of the notification caches, from the
- * snapshot taken before the request goes out.
- */
 export const createNotificationMutationOptions = <TVariables, TData>({
   queryClient,
   profileId,

--- a/apps/web/src/notifications/inbox/useArchiveNotification.ts
+++ b/apps/web/src/notifications/inbox/useArchiveNotification.ts
@@ -9,13 +9,10 @@ import type {
 } from "@oboku/shared"
 import { type HttpApiClientWeb, useHttpClientApi } from "../../http"
 import { useActiveProfileId } from "../../profiles/active/activeProfileId"
+import { createNotificationMutationOptions } from "./createNotificationMutationOptions"
 import {
-  type NotificationCacheSnapshot,
   archiveMutationKey,
-  cancelAndSnapshotNotificationQueries,
   inboxNotificationsQueryKey,
-  invalidateNotificationQueries,
-  rollbackNotificationCaches,
   unreadCountQueryKey,
 } from "./queryKeys"
 
@@ -23,39 +20,28 @@ export const archiveMutationOptions = (
   queryClient: QueryClient,
   httpClientApi: HttpApiClientWeb,
   profileId: string | undefined,
-) => ({
-  mutationKey: archiveMutationKey,
-  networkMode: "online" as const,
-  mutationFn: httpClientApi.archiveNotification,
-  onMutate: async ({ id }: { id: number }) => {
-    const snapshot = await cancelAndSnapshotNotificationQueries(
-      queryClient,
-      profileId,
-    )
+) =>
+  createNotificationMutationOptions({
+    queryClient,
+    profileId,
+    mutationKey: archiveMutationKey,
+    mutationFn: httpClientApi.archiveNotification,
+    applyOptimisticUpdate: ({ id }: { id: number }, snapshot) => {
+      const removed = snapshot.previousNotifications?.find((n) => n.id === id)
 
-    const removed = snapshot.previousNotifications?.find((n) => n.id === id)
-
-    queryClient.setQueryData<GetNotificationsResponse>(
-      inboxNotificationsQueryKey(profileId),
-      (old) => old?.filter((n) => n.id !== id),
-    )
-
-    if (removed && !removed.seenAt) {
-      queryClient.setQueryData<GetUnreadNotificationsCountResponse>(
-        unreadCountQueryKey(profileId),
-        (old) => (old ? { count: Math.max(0, old.count - 1) } : old),
+      queryClient.setQueryData<GetNotificationsResponse>(
+        inboxNotificationsQueryKey(profileId),
+        (old) => old?.filter((n) => n.id !== id),
       )
-    }
 
-    return snapshot
-  },
-  onError: (
-    _err: unknown,
-    _vars: { id: number },
-    context: NotificationCacheSnapshot | undefined,
-  ) => rollbackNotificationCaches(queryClient, profileId, context),
-  onSettled: () => invalidateNotificationQueries(queryClient, profileId),
-})
+      if (removed && !removed.seenAt) {
+        queryClient.setQueryData<GetUnreadNotificationsCountResponse>(
+          unreadCountQueryKey(profileId),
+          (old) => (old ? { count: Math.max(0, old.count - 1) } : old),
+        )
+      }
+    },
+  })
 
 export const useArchiveNotification = () => {
   const queryClient = useQueryClient()

--- a/apps/web/src/notifications/inbox/useMarkAllNotificationsAsSeen.ts
+++ b/apps/web/src/notifications/inbox/useMarkAllNotificationsAsSeen.ts
@@ -9,13 +9,10 @@ import type {
 } from "@oboku/shared"
 import { type HttpApiClientWeb, useHttpClientApi } from "../../http"
 import { useActiveProfileId } from "../../profiles/active/activeProfileId"
+import { createNotificationMutationOptions } from "./createNotificationMutationOptions"
 import {
-  type NotificationCacheSnapshot,
-  cancelAndSnapshotNotificationQueries,
   inboxNotificationsQueryKey,
-  invalidateNotificationQueries,
   markAllSeenMutationKey,
-  rollbackNotificationCaches,
   unreadCountQueryKey,
 } from "./queryKeys"
 
@@ -23,38 +20,27 @@ export const markAllSeenMutationOptions = (
   queryClient: QueryClient,
   httpClientApi: HttpApiClientWeb,
   profileId: string | undefined,
-) => ({
-  mutationKey: markAllSeenMutationKey,
-  networkMode: "online" as const,
-  mutationFn: httpClientApi.markAllNotificationsAsSeen,
-  onMutate: async () => {
-    const snapshot = await cancelAndSnapshotNotificationQueries(
-      queryClient,
-      profileId,
-    )
+) =>
+  createNotificationMutationOptions({
+    queryClient,
+    profileId,
+    mutationKey: markAllSeenMutationKey,
+    mutationFn: httpClientApi.markAllNotificationsAsSeen,
+    applyOptimisticUpdate: (_vars: undefined) => {
+      queryClient.setQueryData<GetNotificationsResponse>(
+        inboxNotificationsQueryKey(profileId),
+        (old) =>
+          old?.map((n) =>
+            n.seenAt ? n : { ...n, seenAt: new Date().toISOString() },
+          ),
+      )
 
-    queryClient.setQueryData<GetNotificationsResponse>(
-      inboxNotificationsQueryKey(profileId),
-      (old) =>
-        old?.map((n) =>
-          n.seenAt ? n : { ...n, seenAt: new Date().toISOString() },
-        ),
-    )
-
-    queryClient.setQueryData<GetUnreadNotificationsCountResponse>(
-      unreadCountQueryKey(profileId),
-      (old) => (old ? { count: 0 } : old),
-    )
-
-    return snapshot
-  },
-  onError: (
-    _err: unknown,
-    _vars: undefined,
-    context: NotificationCacheSnapshot | undefined,
-  ) => rollbackNotificationCaches(queryClient, profileId, context),
-  onSettled: () => invalidateNotificationQueries(queryClient, profileId),
-})
+      queryClient.setQueryData<GetUnreadNotificationsCountResponse>(
+        unreadCountQueryKey(profileId),
+        (old) => (old ? { count: 0 } : old),
+      )
+    },
+  })
 
 export const useMarkAllNotificationsAsSeen = () => {
   const queryClient = useQueryClient()

--- a/apps/web/src/notifications/inbox/useMarkNotificationAsSeen.ts
+++ b/apps/web/src/notifications/inbox/useMarkNotificationAsSeen.ts
@@ -9,13 +9,10 @@ import type {
 } from "@oboku/shared"
 import { type HttpApiClientWeb, useHttpClientApi } from "../../http"
 import { useActiveProfileId } from "../../profiles/active/activeProfileId"
+import { createNotificationMutationOptions } from "./createNotificationMutationOptions"
 import {
-  type NotificationCacheSnapshot,
-  cancelAndSnapshotNotificationQueries,
   inboxNotificationsQueryKey,
-  invalidateNotificationQueries,
   markSeenMutationKey,
-  rollbackNotificationCaches,
   unreadCountQueryKey,
 } from "./queryKeys"
 
@@ -23,41 +20,31 @@ export const markSeenMutationOptions = (
   queryClient: QueryClient,
   httpClientApi: HttpApiClientWeb,
   profileId: string | undefined,
-) => ({
-  mutationKey: markSeenMutationKey,
-  networkMode: "online" as const,
-  mutationFn: httpClientApi.markNotificationAsSeen,
-  onMutate: async ({ id }: { id: number }) => {
-    const snapshot = await cancelAndSnapshotNotificationQueries(
-      queryClient,
-      profileId,
-    )
-    const target = snapshot.previousNotifications?.find((n) => n.id === id)
+) =>
+  createNotificationMutationOptions({
+    queryClient,
+    profileId,
+    mutationKey: markSeenMutationKey,
+    mutationFn: httpClientApi.markNotificationAsSeen,
+    applyOptimisticUpdate: ({ id }: { id: number }, snapshot) => {
+      const target = snapshot.previousNotifications?.find((n) => n.id === id)
 
-    queryClient.setQueryData<GetNotificationsResponse>(
-      inboxNotificationsQueryKey(profileId),
-      (old) =>
-        old?.map((n) =>
-          n.id === id ? { ...n, seenAt: new Date().toISOString() } : n,
-        ),
-    )
-
-    if (target && !target.seenAt) {
-      queryClient.setQueryData<GetUnreadNotificationsCountResponse>(
-        unreadCountQueryKey(profileId),
-        (old) => (old ? { count: Math.max(0, old.count - 1) } : old),
+      queryClient.setQueryData<GetNotificationsResponse>(
+        inboxNotificationsQueryKey(profileId),
+        (old) =>
+          old?.map((n) =>
+            n.id === id ? { ...n, seenAt: new Date().toISOString() } : n,
+          ),
       )
-    }
 
-    return snapshot
-  },
-  onError: (
-    _err: unknown,
-    _vars: { id: number },
-    context: NotificationCacheSnapshot | undefined,
-  ) => rollbackNotificationCaches(queryClient, profileId, context),
-  onSettled: () => invalidateNotificationQueries(queryClient, profileId),
-})
+      if (target && !target.seenAt) {
+        queryClient.setQueryData<GetUnreadNotificationsCountResponse>(
+          unreadCountQueryKey(profileId),
+          (old) => (old ? { count: Math.max(0, old.count - 1) } : old),
+        )
+      }
+    },
+  })
 
 export const useMarkNotificationAsSeen = () => {
   const queryClient = useQueryClient()

--- a/apps/web/src/plugins/server/DataSourceForm.tsx
+++ b/apps/web/src/plugins/server/DataSourceForm.tsx
@@ -1,7 +1,6 @@
 import { memo } from "react"
-import { Controller, useForm } from "react-hook-form"
-import { errorToHelperText } from "../../common/forms/errorToHelperText"
-import { ConnectorSelector } from "../../connectors/ConnectorSelector"
+import { useForm } from "react-hook-form"
+import { ControlledConnectorSelector } from "../../common/forms/ControlledConnectorSelector"
 import { DataSourceFormLayout } from "../common/DataSourceFormLayout"
 import {
   buildDataSourceSubmitPayload,
@@ -40,22 +39,11 @@ export const DataSourceForm = memo(
         )}
         submitLabel={submitLabel}
       >
-        <Controller
+        <ControlledConnectorSelector
           control={control}
           name="connectorId"
           rules={{ required: true }}
-          render={({ field, fieldState }) => (
-            <ConnectorSelector
-              {...field}
-              connectorType="server"
-              helperText={
-                fieldState.invalid
-                  ? errorToHelperText(fieldState.error)
-                  : undefined
-              }
-              error={fieldState.invalid}
-            />
-          )}
+          connectorType="server"
         />
       </DataSourceFormLayout>
     )

--- a/apps/web/src/plugins/webdav/DataSourceForm.tsx
+++ b/apps/web/src/plugins/webdav/DataSourceForm.tsx
@@ -1,11 +1,10 @@
 import { memo } from "react"
 import { Alert, InputAdornment, Link } from "@mui/material"
-import { Controller, useForm } from "react-hook-form"
+import { useForm } from "react-hook-form"
+import { ControlledConnectorSelector } from "../../common/forms/ControlledConnectorSelector"
 import { ControlledTextField } from "../../common/forms/ControlledTextField"
-import { errorToHelperText } from "../../common/forms/errorToHelperText"
 import { links } from "@oboku/shared"
 import type { WebDAVDataSourceDocType } from "@oboku/shared"
-import { ConnectorSelector } from "../../connectors/ConnectorSelector"
 import { TestConnection } from "../../connectors/TestConnection"
 import { useConnector } from "../../connectors/useConnector"
 import { testConnection } from "./connectors/ConnectorForm"
@@ -74,22 +73,11 @@ export const DataSourceForm = memo(
             },
           }}
         />
-        <Controller
+        <ControlledConnectorSelector
           control={control}
           name="connectorId"
           rules={{ required: true }}
-          render={({ field, fieldState }) => (
-            <ConnectorSelector
-              {...field}
-              connectorType="webdav"
-              helperText={
-                fieldState.invalid
-                  ? errorToHelperText(fieldState.error)
-                  : undefined
-              }
-              error={fieldState.invalid}
-            />
-          )}
+          connectorType="webdav"
         />
         <TestConnection
           connectionData={{

--- a/apps/web/src/secrets/SecretActionDrawer.tsx
+++ b/apps/web/src/secrets/SecretActionDrawer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from "react"
+import { memo } from "react"
 import List from "@mui/material/List"
 import ListItemText from "@mui/material/ListItemText"
 import { DeleteForeverRounded, EditRounded } from "@mui/icons-material"
@@ -10,43 +10,10 @@ import {
   useTheme,
   useMediaQuery,
 } from "@mui/material"
-import { signal, useLiveRef } from "reactjrx"
 import { useDismissibleOverlay } from "../navigation/modalHistory"
 import { setupSecretDialogSignal } from "./SetupSecretDialog"
 import { useRemoveSecret } from "./useRemoveSecret"
 import { notify } from "../notifications/toasts"
-
-type SignalState = {
-  openedWith: undefined | string
-  actions?: ("removeDownload" | "goToDetails")[]
-  actionsBlackList?: ("removeDownload" | "goToDetails")[]
-  onDeleteBook?: () => void
-}
-
-export const bookActionDrawerSignal = signal<SignalState>({
-  key: "bookActionDrawerState",
-  default: { openedWith: undefined },
-})
-
-export const useBookActionDrawer = ({
-  onDeleteBook,
-}: {
-  onDeleteBook?: () => void
-} = {}) => {
-  const onDeleteBookRef = useLiveRef(onDeleteBook)
-
-  return useCallback(
-    (params: Omit<SignalState, "onDeleteBook">) => {
-      bookActionDrawerSignal.setValue({
-        ...params,
-        onDeleteBook: () => {
-          onDeleteBookRef.current?.()
-        },
-      })
-    },
-    [onDeleteBookRef],
-  )
-}
 
 export const SecretActionDrawer = memo(
   ({


### PR DESCRIPTION
Follow-ups to #549, one commit per item.

## 1. Dead copy of the book action drawer signal

**Duplicated:** `apps/web/src/secrets/SecretActionDrawer.tsx` carried a verbatim copy of `bookActionDrawerSignal`, its `SignalState` type and `useBookActionDrawer` from `apps/web/src/books/drawer/BookActionsDrawer.tsx` — same `"bookActionDrawerState"` signal key, same body. Nothing imported the copy: the only consumers (`BookDetailsScreen`, `BookListItemHorizontal`, `BookListItemVertical`, `ManageStorageScreen`) import from `BookActionsDrawer`, and `SecretActionDrawer` itself never referenced it.

**Became:** deleted, along with the now-unused `useCallback` / `reactjrx` imports. `reactjrx` `signal()` returns an independent instance per call and the key only matters for `usePersistSignals`, which the dead copy was never registered with, so nothing observable changes.

**Net:** +1 / −34 → **−33 lines**.

## 2. Optimistic notification mutation options

**Duplicated:** `useArchiveNotification.ts`, `useMarkNotificationAsSeen.ts` and `useMarkAllNotificationsAsSeen.ts` each repeated the same option skeleton — `networkMode: "online"`, `onMutate` taking a cache snapshot, `onError` rolling it back, `onSettled` invalidating both notification queries — around one differing optimistic cache write.

**Became:** `notifications/inbox/createNotificationMutationOptions.ts`, which owns the shared cycle and takes the differing part as an `applyOptimisticUpdate(variables, snapshot)` callback. Each builder now supplies only its mutation key, its `httpClientApi` method and its own cache write; the exported `*MutationOptions` signatures are unchanged, so `QueryClientProvider`'s `setMutationDefaults` registration and the three hooks are untouched.

**Net:** +114 / −105 → **−9 lines** across four files (the new module is 50 of those insertions; the three builders lost 91 lines between them).

These are the same concept, not just the same shape: all three are profile-scoped optimistic writes against the same two query keys, and the snapshot/rollback contract has to stay identical between them or a resumed mutation restores the wrong cache.

## 3. Form-bound `ConnectorSelector`

**Duplicated:** `plugins/server/DataSourceForm.tsx` and `plugins/webdav/DataSourceForm.tsx` repeated an identical `Controller` → `ConnectorSelector` block, differing only in `connectorType`.

**Became:** `common/forms/ControlledConnectorSelector.tsx`, following the existing `ControlledTextField` / `ControlledSelect` / `ControlledSecretSelect` shape in that folder (same generic parameters, same `helperText` fallback via `errorToHelperText`).

**Net:** +50 / −32 → **+18 lines**, because the wrapper's generic signature costs more than the two blocks it replaces. It is included because it removes the last hand-rolled `Controller` render prop for a connector field and puts the error wiring in one place; if you would rather keep the two inline blocks, this commit can be dropped on its own.

`plugins/synology-drive/DataSourceForm.tsx` is deliberately left alone — its connector field uses `useController` and resets session, tree and item selection state on change, so it is not the same block.

## Gates

| Gate | Baseline (`develop` @ 68840b6) | After |
| --- | --- | --- |
| `pnpm run lint` | pass (3 warnings, 7 infos) | pass (same 3 warnings, 7 infos) |
| `pnpm run build` | **fails** — see below | same failure, unchanged |
| `apps/web` `tsc -b` | pass | pass |
| `pnpm run test` | 15 failing / 282 passing | same 15 failing / 282 passing |

Two pre-existing failures on `develop`, neither touched here:

- `pnpm run build` is currently red at `@oboku/archive-metadata:build` (and the library builds behind it) with `TypeError: undefined is not a function` in `rollup-plugin-node-externals@9.0.1` under `vite@8.2.0` / `rolldown@1.2.3`. It reproduces on a clean `develop` checkout with no changes, so `tsc -b` on `apps/web` was used to typecheck this PR instead.
- The 15 failing tests are the `HttpClientApi.web.test.ts` (12) and `httpClientApi.sw.test.ts` (3) auth-refresh specs, failing identically before and after.

Total across the three commits: **165 insertions / 171 deletions**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYdvjtZuXtbUfFEaA42dcm)_