### PR TITLE
chore(web): remove unreferenced exports

### DIFF
--- a/apps/web/src/errors/ErrorMessage.tsx
+++ b/apps/web/src/errors/ErrorMessage.tsx
@@ -9,10 +9,6 @@ import { HttpClientError } from "../http/httpClient.shared"
 import { HttpClientNetworkError } from "../http/httpClient.web"
 import { Alert } from "@mui/material"
 
-export const ErrorMessage = ({ error }: { error: unknown }) => {
-  return <>{errorToMessage(error)}</>
-}
-
 export const ErrorAlert = ({ error }: { error: unknown }) => {
   const severity = error instanceof ObokuSharedError ? error.severity : "error"
 

--- a/apps/web/src/google/useDriveFile.ts
+++ b/apps/web/src/google/useDriveFile.ts
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryOptions } from "@tanstack/react-query"
+import type { UseQueryOptions } from "@tanstack/react-query"
 import { type DriveFileGetResponse, useDriveFilesGet } from "./useDriveFilesGet"
 import { firstValueFrom } from "rxjs"
 import { useCallback } from "react"
@@ -56,10 +56,4 @@ export const useCreateDriveFileQuery = () => {
     }),
     [getFile, gapi, accessToken],
   )
-}
-
-export const useDriveFile = ({ id }: { id?: string }) => {
-  const createQuery = useCreateDriveFileQuery()
-
-  return useQuery(createQuery(id))
 }

--- a/apps/web/src/profiles/useProfiles.ts
+++ b/apps/web/src/profiles/useProfiles.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useQuery } from "@tanstack/react-query"
+import { queryOptions } from "@tanstack/react-query"
 import { dexieDb } from "../rxdb/dexie"
 import type { Profile } from "./types"
 
@@ -10,5 +10,3 @@ export const profilesQueryOptions = queryOptions({
 })
 
 export const profilesQueryKey = profilesQueryOptions.queryKey
-
-export const useProfiles = () => useQuery(profilesQueryOptions)


### PR DESCRIPTION
Part 2 of 3, split out of #566. Scope: `apps/web` source only — no manifest or lockfile changes.

Three exports with no importers. In all three cases the module itself stays, because its *other* exports are used — only the dead export goes.

| Item | File | Evidence |
| --- | --- | --- |
| `ErrorMessage` (component) | `src/errors/ErrorMessage.tsx` | The module has 11 importers, every one of them for `ErrorAlert` or `errorToMessage`. No import of `ErrorMessage` itself. Both other exports stay. |
| `useDriveFile` | `src/google/useDriveFile.ts` | The module is imported twice, for `useCreateDriveFileQuery` and `getUseDriveFileQueryKey`. No reference to `useDriveFile`. `useQuery` import narrowed to a type-only `UseQueryOptions` import as a result. |
| `useProfiles` | `src/profiles/useProfiles.ts` | Ten modules import from `./useProfiles`, all for `profilesQueryOptions` or `profilesQueryKey`. The `export * from "./useProfiles"` barrel in `profiles/index.ts` stays — it carries those two — and nothing reaches `useProfiles` through it either. `useQuery` import dropped. |

## Gates

`pnpm run lint` passes. `pnpm --filter @oboku/web run build` passes.

`pnpm --filter @oboku/web run test` reports 15 failed / 282 passed — an identical failure set to `develop` without this branch, all of it in `src/http/HttpClientApi.web.test.ts` and `src/http/httpClientApi.sw.test.ts`. Those failures pre-date this PR and are untouched by it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk4htMp4vaHPHeE6BxAoCp)_