### PR TITLE
fix(metadata): report a failed metadata refresh once instead of twice

### DIFF
--- a/apps/web/src/books/useIncrementalBookPatch.ts
+++ b/apps/web/src/books/useIncrementalBookPatch.ts
@@ -1,10 +1,14 @@
 import type { RxDocument } from "rxdb"
 import type { BookDocType } from "@oboku/shared"
+import type { UseMutationOptions } from "@tanstack/react-query"
 import { useMutation$ } from "reactjrx"
 import { incrementalBookMutation } from "./incrementalBookMutation"
 
-export const useIncrementalBookPatch = () =>
+export const useIncrementalBookPatch = (
+  options?: Pick<UseMutationOptions, "meta">,
+) =>
   useMutation$({
+    ...options,
     mutationFn: ({
       doc,
       patch,

--- a/apps/web/src/books/useRefreshBookMetadata.ts
+++ b/apps/web/src/books/useRefreshBookMetadata.ts
@@ -9,10 +9,6 @@ import { useIncrementalBookPatch } from "./useIncrementalBookPatch"
 import { CancelError } from "../errors/errors.shared"
 import { notifyError } from "../notifications/toasts"
 
-/**
- * This flow reports every failure itself through `notifyError`, so the
- * mutations it drives must not also raise the global toast.
- */
 const withoutGlobalErrorToast = { meta: { suppressGlobalErrorToast: true } }
 
 export const useRefreshBookMetadata = () => {

--- a/apps/web/src/books/useRefreshBookMetadata.ts
+++ b/apps/web/src/books/useRefreshBookMetadata.ts
@@ -9,12 +9,22 @@ import { useIncrementalBookPatch } from "./useIncrementalBookPatch"
 import { CancelError } from "../errors/errors.shared"
 import { notifyError } from "../notifications/toasts"
 
+/**
+ * This flow reports every failure itself through `notifyError`, so the
+ * mutations it drives must not also raise the global toast.
+ */
+const withoutGlobalErrorToast = { meta: { suppressGlobalErrorToast: true } }
+
 export const useRefreshBookMetadata = () => {
   const httpClientApi = useHttpClientApi()
   const { db: database } = useDatabase()
-  const { mutateAsync: incrementalPatchBook } = useIncrementalBookPatch()
+  const { mutateAsync: incrementalPatchBook } = useIncrementalBookPatch(
+    withoutGlobalErrorToast,
+  )
   const network = useNetworkState()
-  const refreshPluginMetadata = usePluginRefreshMetadata()
+  const refreshPluginMetadata = usePluginRefreshMetadata(
+    withoutGlobalErrorToast,
+  )
 
   return async (bookId: string, { force }: { force?: boolean } = {}) => {
     try {

--- a/apps/web/src/collections/useCollectionIncrementalModify.ts
+++ b/apps/web/src/collections/useCollectionIncrementalModify.ts
@@ -1,11 +1,14 @@
 import type { CollectionDocType } from "@oboku/shared"
 import { useDatabase } from "../rxdb"
-import { useMutation } from "@tanstack/react-query"
+import { type UseMutationOptions, useMutation } from "@tanstack/react-query"
 
-export const useCollectionIncrementalModify = () => {
+export const useCollectionIncrementalModify = (
+  options?: Pick<UseMutationOptions, "meta">,
+) => {
   const { db } = useDatabase()
 
   return useMutation({
+    ...options,
     mutationFn: async ({
       _id,
       name,

--- a/apps/web/src/collections/useRefreshCollectionMetadata.ts
+++ b/apps/web/src/collections/useRefreshCollectionMetadata.ts
@@ -8,10 +8,6 @@ import { getCollectionById } from "./dbHelpers"
 import { CancelError, OfflineError } from "../errors/errors.shared"
 import { useMutation$ } from "reactjrx"
 
-/**
- * Failures propagate to this mutation, whose own rejection raises the global
- * toast, so the mutations it drives must not raise one too.
- */
 const withoutGlobalErrorToast = { meta: { suppressGlobalErrorToast: true } }
 
 export const useRefreshCollectionMetadata = () => {

--- a/apps/web/src/collections/useRefreshCollectionMetadata.ts
+++ b/apps/web/src/collections/useRefreshCollectionMetadata.ts
@@ -8,10 +8,20 @@ import { getCollectionById } from "./dbHelpers"
 import { CancelError, OfflineError } from "../errors/errors.shared"
 import { useMutation$ } from "reactjrx"
 
+/**
+ * Failures propagate to this mutation, whose own rejection raises the global
+ * toast, so the mutations it drives must not raise one too.
+ */
+const withoutGlobalErrorToast = { meta: { suppressGlobalErrorToast: true } }
+
 export const useRefreshCollectionMetadata = () => {
   const httpClientApi = useHttpClientApi()
-  const { mutateAsync: updateCollection } = useCollectionIncrementalModify()
-  const getRefreshMetadataPluginData = usePluginRefreshMetadata()
+  const { mutateAsync: updateCollection } = useCollectionIncrementalModify(
+    withoutGlobalErrorToast,
+  )
+  const getRefreshMetadataPluginData = usePluginRefreshMetadata(
+    withoutGlobalErrorToast,
+  )
   const withNetwork = useWithNetwork()
 
   return useMutation$({

--- a/apps/web/src/plugins/common/createConnectorRefreshMetadata.ts
+++ b/apps/web/src/plugins/common/createConnectorRefreshMetadata.ts
@@ -1,17 +1,19 @@
 import { ObokuErrorCode, ObokuSharedError } from "@oboku/shared"
 import type { SettingsConnectorType } from "@oboku/shared"
-import { useMutation } from "@tanstack/react-query"
+import { type UseMutationOptions, useMutation } from "@tanstack/react-query"
 import { useExtractConnectorData } from "../../connectors/useExtractConnectorData"
 import type { UseRefreshMetadataVariables } from "../types"
 
 export const createConnectorRefreshMetadata =
   <T extends SettingsConnectorType>(type: T) =>
-  () => {
-    const { mutateAsync: extractConnectorData } = useExtractConnectorData({
-      type,
-    })
+  ({ meta }: Pick<UseMutationOptions, "meta">) => {
+    const { mutateAsync: extractConnectorData } = useExtractConnectorData(
+      { type },
+      { meta },
+    )
 
     return useMutation({
+      meta,
       mutationFn: async ({ linkData }: UseRefreshMetadataVariables<T>) => {
         // Every connector provider (server, webdav, synology-drive) carries an
         // optional connectorId on its link data, but LinkDataForProvider<T>

--- a/apps/web/src/plugins/dropbox/useRefreshMetadata.ts
+++ b/apps/web/src/plugins/dropbox/useRefreshMetadata.ts
@@ -4,10 +4,11 @@ import { useMutation } from "@tanstack/react-query"
 import { useConfig } from "../../config/useConfig"
 
 export const useRefreshMetadata: ObokuPlugin<"dropbox">[`useRefreshMetadata`] =
-  ({ requestPopup }) => {
+  ({ requestPopup, meta }) => {
     const { data: config } = useConfig()
 
     return useMutation({
+      meta,
       mutationFn: async () => {
         const auth = await authUser({
           requestPopup,

--- a/apps/web/src/plugins/google/useRefreshMetadata.ts
+++ b/apps/web/src/plugins/google/useRefreshMetadata.ts
@@ -8,6 +8,7 @@ import { GOOGLE_DRIVE_FILE_SCOPES } from "./lib/constants"
 
 export const useRefreshMetadata: ObokuPlugin<"DRIVE">[`useRefreshMetadata`] = ({
   requestPopup,
+  meta,
 }) => {
   const { getGoogleScripts } = useGoogleScripts()
   const { requestToken } = useRequestToken({ requestPopup })
@@ -16,6 +17,7 @@ export const useRefreshMetadata: ObokuPlugin<"DRIVE">[`useRefreshMetadata`] = ({
   })
 
   return useMutation({
+    meta,
     mutationFn: async ({ linkData }) => {
       const fileId =
         linkData && "fileId" in linkData ? linkData.fileId : undefined

--- a/apps/web/src/plugins/local/useRefreshMetadata.ts
+++ b/apps/web/src/plugins/local/useRefreshMetadata.ts
@@ -1,11 +1,13 @@
 import { useMutation } from "@tanstack/react-query"
 import type { ObokuPlugin } from "../types"
 
-export const useRefreshMetadata: ObokuPlugin<"file">["useRefreshMetadata"] =
-  () => {
-    return useMutation({
-      mutationFn: async () => ({
-        providerCredentials: {},
-      }),
-    })
-  }
+export const useRefreshMetadata: ObokuPlugin<"file">["useRefreshMetadata"] = ({
+  meta,
+}) => {
+  return useMutation({
+    meta,
+    mutationFn: async () => ({
+      providerCredentials: {},
+    }),
+  })
+}

--- a/apps/web/src/plugins/one-drive/useRefreshMetadata.ts
+++ b/apps/web/src/plugins/one-drive/useRefreshMetadata.ts
@@ -4,10 +4,11 @@ import { requestOneDriveProviderCredentials } from "./auth/auth"
 import { useConfig } from "../../config/useConfig"
 
 export const useRefreshMetadata: ObokuPlugin<"one-drive">["useRefreshMetadata"] =
-  ({ requestPopup }) => {
+  ({ requestPopup, meta }) => {
     const { data: config } = useConfig()
 
     return useMutation({
+      meta,
       mutationFn: async () => {
         return {
           providerCredentials: await requestOneDriveProviderCredentials({

--- a/apps/web/src/plugins/types.ts
+++ b/apps/web/src/plugins/types.ts
@@ -18,7 +18,10 @@ import type {
 } from "react"
 import type { SvgIconProps } from "@mui/material"
 import type { DeepReadonly } from "rxdb"
-import type { UseMutationResult } from "@tanstack/react-query"
+import type {
+  UseMutationOptions,
+  UseMutationResult,
+} from "@tanstack/react-query"
 
 /** Link fields that upload payloads can provide (dialog fills book, normalizes data, createdAt, modifiedAt) */
 type PostLink<T extends DataSourceDocType["type"] = DataSourceDocType["type"]> =
@@ -74,7 +77,11 @@ export type UseRefreshMetadataRequest = UseRefreshMetadataVariables<
 
 export type UseRefreshMetadataHook<
   T extends DataSourceDocType["type"] = DataSourceDocType["type"],
-> = (options: { requestPopup: () => Promise<boolean> }) => UseMutationResult<
+> = (
+  options: {
+    requestPopup: () => Promise<boolean>
+  } & Pick<UseMutationOptions, "meta">,
+) => UseMutationResult<
   {
     providerCredentials: ProviderApiCredentials<T>
   },

--- a/apps/web/src/plugins/uri/useRefreshMetadata.ts
+++ b/apps/web/src/plugins/uri/useRefreshMetadata.ts
@@ -1,11 +1,13 @@
 import { useMutation } from "@tanstack/react-query"
 import type { ObokuPlugin } from "../types"
 
-export const useRefreshMetadata: ObokuPlugin<"URI">["useRefreshMetadata"] =
-  () => {
-    return useMutation({
-      mutationFn: async () => ({
-        providerCredentials: {},
-      }),
-    })
-  }
+export const useRefreshMetadata: ObokuPlugin<"URI">["useRefreshMetadata"] = ({
+  meta,
+}) => {
+  return useMutation({
+    meta,
+    mutationFn: async () => ({
+      providerCredentials: {},
+    }),
+  })
+}

--- a/apps/web/src/plugins/usePluginRefreshMetadata.test.tsx
+++ b/apps/web/src/plugins/usePluginRefreshMetadata.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react"
+import type { DataSourceDocType } from "@oboku/shared"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const PLUGIN_TYPES = [
+  "webdav",
+  "synology-drive",
+  "dropbox",
+  "DRIVE",
+  "one-drive",
+  "file",
+  "URI",
+  "server",
+] as const satisfies ReadonlyArray<DataSourceDocType["type"]>
+
+const { pluginsByType } = vi.hoisted(function createPluginMocks() {
+  const types = [
+    "webdav",
+    "synology-drive",
+    "dropbox",
+    "DRIVE",
+    "one-drive",
+    "file",
+    "URI",
+    "server",
+  ]
+
+  return {
+    pluginsByType: Object.fromEntries(
+      types.map(function createPluginMock(type) {
+        return [
+          type,
+          {
+            useRefreshMetadata: vi.fn(function useMockRefreshMetadata() {
+              return { mutateAsync: vi.fn() }
+            }),
+          },
+        ]
+      }),
+    ),
+  }
+})
+
+vi.mock("./configure", function mockPlugins() {
+  return { pluginsByType }
+})
+vi.mock("./useCreateRequestPopupDialog", function mockRequestPopupDialog() {
+  return {
+    useCreateRequestPopupDialog: function useMockCreateRequestPopupDialog() {
+      return function createRequestPopup() {
+        return async function requestPopup() {
+          return true
+        }
+      }
+    },
+  }
+})
+
+import { usePluginRefreshMetadata } from "./usePluginRefreshMetadata"
+
+describe("usePluginRefreshMetadata", function testUsePluginRefreshMetadata() {
+  beforeEach(function resetMocks() {
+    vi.clearAllMocks()
+  })
+
+  it("forwards the caller's meta to every provider hook", function forwardMeta() {
+    const meta = { suppressGlobalErrorToast: true }
+
+    renderHook(function renderWithMeta() {
+      return usePluginRefreshMetadata({ meta })
+    })
+
+    for (const type of PLUGIN_TYPES) {
+      expect(pluginsByType[type]?.useRefreshMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({ meta }),
+      )
+    }
+  })
+
+  it("leaves meta unset when the caller wants the global toast", function defaultMeta() {
+    renderHook(function renderWithoutOptions() {
+      return usePluginRefreshMetadata()
+    })
+
+    for (const type of PLUGIN_TYPES) {
+      expect(pluginsByType[type]?.useRefreshMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({ meta: undefined }),
+      )
+    }
+  })
+})

--- a/apps/web/src/plugins/usePluginRefreshMetadata.ts
+++ b/apps/web/src/plugins/usePluginRefreshMetadata.ts
@@ -3,6 +3,7 @@ import {
   type DataSourceDocType,
   type ProviderApiCredentials,
 } from "@oboku/shared"
+import type { UseMutationOptions } from "@tanstack/react-query"
 import { useCallback } from "react"
 import { useCreateRequestPopupDialog } from "./useCreateRequestPopupDialog"
 import type {
@@ -15,42 +16,53 @@ type RefreshMetadataResult = {
   providerCredentials: ProviderApiCredentials<DataSourceDocType["type"]>
 }
 
-export const usePluginRefreshMetadata = () => {
+export const usePluginRefreshMetadata = (
+  options?: Pick<UseMutationOptions, "meta">,
+) => {
   const createRequestPopupDialog = useCreateRequestPopupDialog()
+  const meta = options?.meta
 
   const { mutateAsync: refreshWebdavMetadata } =
     pluginsByType.webdav.useRefreshMetadata({
       requestPopup: createRequestPopupDialog({ name: "webdav" }),
+      meta,
     })
   const { mutateAsync: refreshSynologyDriveMetadata } = pluginsByType[
     "synology-drive"
   ].useRefreshMetadata({
     requestPopup: createRequestPopupDialog({ name: "synology-drive" }),
+    meta,
   })
   const { mutateAsync: refreshDropboxMetadata } =
     pluginsByType.dropbox.useRefreshMetadata({
       requestPopup: createRequestPopupDialog({ name: "dropbox" }),
+      meta,
     })
   const { mutateAsync: refreshDriveMetadata } =
     pluginsByType.DRIVE.useRefreshMetadata({
       requestPopup: createRequestPopupDialog({ name: "DRIVE" }),
+      meta,
     })
   const { mutateAsync: refreshOneDriveMetadata } = pluginsByType[
     "one-drive"
   ].useRefreshMetadata({
     requestPopup: createRequestPopupDialog({ name: "one-drive" }),
+    meta,
   })
   const { mutateAsync: refreshFileMetadata } =
     pluginsByType.file.useRefreshMetadata({
       requestPopup: createRequestPopupDialog({ name: "file" }),
+      meta,
     })
   const { mutateAsync: refreshUriMetadata } =
     pluginsByType.URI.useRefreshMetadata({
       requestPopup: createRequestPopupDialog({ name: "URI" }),
+      meta,
     })
   const { mutateAsync: refreshServerMetadata } =
     pluginsByType.server.useRefreshMetadata({
       requestPopup: createRequestPopupDialog({ name: "server" }),
+      meta,
     })
 
   return useCallback(


### PR DESCRIPTION
Follow-up to a Codex finding on #559. The duplicate toast it spotted turned out to be pre-existing in the refresh flows rather than introduced there, so it is fixed here on its own.

## Problem

Both metadata refresh flows drive nested mutations that never accepted `meta`:

- the per-provider credential fetch (`useRefreshMetadata` × 8)
- the connector secret extraction inside `createConnectorRefreshMetadata`
- the local rxdb write (`useIncrementalBookPatch` / `useCollectionIncrementalModify`)

With no `meta`, `MutationCache.onError` toasts the inner failure, and then the surrounding flow reports the same failure a second time:

| Flow | First toast | Second toast |
|---|---|---|
| `useRefreshBookMetadata` | global handler, nested mutation | its own `catch` → `notifyError` |
| `useRefreshCollectionMetadata` | global handler, nested mutation | global handler again, after it rethrows into its outer mutation |

So one network error during a token refresh surfaces as two identical toasts, in both the book and collection paths — visible today from `BookActionsDrawer` and `DataSourceSection`.

## Fix

Thread consumer-selected `meta` through, exactly as `AGENTS.md` prescribes and as `useExtractConnectorData` already does:

- `UseRefreshMetadataHook` takes `meta` alongside `requestPopup`; all eight provider hooks spread it into their `useMutation`
- `createConnectorRefreshMetadata` forwards it to both its own mutation and `useExtractConnectorData`
- `usePluginRefreshMetadata` accepts `options?: Pick<UseMutationOptions, "meta">` and passes it to every provider
- `useIncrementalBookPatch` and `useCollectionIncrementalModify` accept the same

The two refresh flows then opt their nested mutations out, since each already reports the failure itself. No hook hard-codes suppression — the decision stays at the call site.

## Not changed

`CancelError` was already filtered by both `MutationCache.onError` and the flows' own handlers, so a dismissed auth popup stayed silent before and still does. This only changes what a genuine failure looks like.

## Testing

- New `usePluginRefreshMetadata.test.tsx` asserts `meta` reaches all eight provider hooks, and stays unset when the caller wants the global toast — the wiring most likely to be missed when a ninth plugin is added
- Full web suite: 284 passed. The 15 failures in `src/http/*` are pre-existing on `develop` (verified with the branch stashed) — `navigator.locks` is unavailable in this container's jsdom
- Typecheck and biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCsLUoks19VSMP35CfU325

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCsLUoks19VSMP35CfU325)_