### PR TITLE
fix(archive-metadata): make the OPF identifier writer match what the reader reports

### DIFF
--- a/packages/archive-metadata/src/opf/write.test.ts
+++ b/packages/archive-metadata/src/opf/write.test.ts
@@ -263,3 +263,139 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
     expect(readOpfIsbn(xml)).toBe("9783161484100")
   })
 })
+
+describe("OPF editing across container spellings", () => {
+  const reparse = (xml: string): Document => {
+    const doc = new DOMParser().parseFromString(xml, "application/xml")
+    const error = doc.getElementsByTagName("parsererror").item(0)
+
+    if (error) throw new Error(`malformed: ${error.textContent}`)
+
+    return doc
+  }
+
+  it("binds the namespaces of an identifier it creates", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      '<?xml version="1.0" encoding="utf-8"?>' +
+        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id">' +
+        "<metadata/><manifest/><spine/></package>",
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+
+    expect(() => reparse(xml)).not.toThrow()
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+  })
+
+  it("patches a package that prefixes the OPF namespace", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      '<?xml version="1.0" encoding="utf-8"?>' +
+        '<opf:package xmlns:opf="http://www.idpf.org/2007/opf"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' version="3.0" unique-identifier="pub-id">' +
+        "<opf:metadata><dc:title>Sample</dc:title></opf:metadata>" +
+        "<opf:manifest/><opf:spine/></opf:package>",
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(xml).toContain("<dc:title>Sample</dc:title>")
+  })
+
+  it("updates an unprefixed <identifier> under a default DC namespace", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      '<?xml version="1.0" encoding="utf-8"?>' +
+        '<package xmlns="http://www.idpf.org/2007/opf"' +
+        ' xmlns:opf="http://www.idpf.org/2007/opf"' +
+        ' version="3.0" unique-identifier="pub-id">' +
+        '<metadata xmlns="http://purl.org/dc/elements/1.1/">' +
+        '<identifier opf:scheme="ISBN">0000000000</identifier>' +
+        "</metadata><manifest/><spine/></package>",
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(xml).not.toContain("0000000000")
+  })
+
+  it("matches a capitalized opf:Scheme attribute when updating", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf('<dc:identifier opf:Scheme="ISBN">0000000000</dc:identifier>'),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(xml).not.toContain("0000000000")
+  })
+})
+
+describe("OPF editing with refinement-typed identifiers", () => {
+  it("updates an identifier typed by an ONIX identifier-type refinement", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier id="book-id">0000000000</dc:identifier>' +
+          '<meta refines="#book-id" property="identifier-type" scheme="onix:codelist5">15</meta>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(xml).not.toContain("0000000000")
+    expect(readOpfMetadata(xml).identifiers).toHaveLength(1)
+  })
+
+  it("updates an identifier typed by a literal identifier-type refinement", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier id="book-id">0000000000</dc:identifier>' +
+          '<meta refines="#book-id" property="identifier-type">ISBN</meta>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(readOpfMetadata(xml).identifiers).toHaveLength(1)
+  })
+
+  it("removes the metadata refining an identifier it deletes", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
+          '<dc:identifier id="isbn-id" opf:scheme="ISBN">9783161484100</dc:identifier>' +
+          '<meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15</meta>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: undefined })
+
+    expect(readOpfIsbn(xml)).toBeUndefined()
+    expect(xml).not.toContain('refines="#isbn-id"')
+    expect(xml).toContain("urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809")
+  })
+
+  it("keeps the identifier the package points at when clearing the ISBN", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier id="pub-id" opf:scheme="ISBN">9783161484100</dc:identifier>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: undefined })
+
+    expect(xml).toContain('id="pub-id"')
+    expect(xml).toContain("9783161484100")
+  })
+})

--- a/packages/archive-metadata/src/opf/write.ts
+++ b/packages/archive-metadata/src/opf/write.ts
@@ -1,4 +1,10 @@
-import { readRecordAsText } from "@prose-reader/archive-reader"
+import {
+  parseOpf,
+  readRecordAsText,
+  resolveArchiveMetadata,
+  type OpfIdentifier,
+  type ResolvedMetadataIdentifier,
+} from "@prose-reader/archive-reader"
 import type { ArchiveFileRecord } from "../archive/types"
 import {
   type XmlDocument,
@@ -31,9 +37,6 @@ const IDENTIFIER_ELEMENT_NAME = "dc:identifier"
 
 const ISBN_SCHEME = "ISBN"
 
-/** Every spelling of the scheme attribute the read side accepts. */
-const SCHEME_ATTRIBUTES = ["opf:scheme", "opf:Scheme", "scheme"] as const
-
 /**
  * Apply a metadata patch to an existing OPF package document and
  * return the serialized XML body the caller should write back. The
@@ -54,6 +57,36 @@ export const buildPatchedOpfXml = async (
   return serializeOpfXml(xml, patch)
 }
 
+/**
+ * Which identifier the writer should touch is the reader's decision, not one
+ * this writer re-derives: `parseOpf` reports each element verbatim — including
+ * the `id` that addresses it — and `resolveArchiveMetadata` says what scheme
+ * the book ends up advertising for it, across every spelling of the scheme
+ * attribute and the EPUB 3 `identifier-type` refinements. Reading the document
+ * any other way is how a writer ends up editing an element the reader does not
+ * report, or appending a second one beside it.
+ *
+ * The two lists are index-aligned: the resolver maps over the parsed
+ * identifiers one to one.
+ */
+type ReaderIdentifier = {
+  readonly parsed: OpfIdentifier
+  readonly resolved: ResolvedMetadataIdentifier
+}
+
+const readerIdentifiers = (xml: string): ReadonlyArray<ReaderIdentifier> => {
+  const parsed = parseOpf(xml)
+  const resolved = resolveArchiveMetadata(parsed).identifiers ?? []
+
+  return parsed.identifiers.flatMap(function pairWithResolved(entry, index) {
+    const counterpart = resolved[index]
+
+    return counterpart === undefined
+      ? []
+      : [{ parsed: entry, resolved: counterpart }]
+  })
+}
+
 const serializeOpfXml = (xml: string, patch: OpfMetadataPatch): string => {
   const doc = parseXml(xml, OPF_LABEL)
   const root = doc.documentElement
@@ -68,7 +101,7 @@ const serializeOpfXml = (xml: string, patch: OpfMetadataPatch): string => {
     throw new Error("OPF document has no <metadata> element")
   }
 
-  upsertIsbnIdentifier(doc, root, metadata, patch.isbn)
+  upsertIsbnIdentifier(doc, metadata, readerIdentifiers(xml), patch.isbn)
 
   const serialized = serializeXml(doc)
 
@@ -100,145 +133,85 @@ const findChildByLocalName = (
 ): XmlElement | undefined => listChildrenByLocalName(parent, name)[0]
 
 /**
- * ONIX codelist 5 codes the read side maps to a scheme name, so an identifier
- * typed `<meta property="identifier-type" scheme="onix:codelist5">15</meta>`
- * is matched as the ISBN the reader reports rather than as the literal `15`.
+ * The element the reader read an identifier from. An `id` addresses it exactly;
+ * an identifier authored without one has only its position among the identifier
+ * elements, which is the order the parser reported it in.
  */
-const ONIX_IDENTIFIER_TYPES: Record<string, string> = {
-  "02": "ISBN",
-  "03": "GTIN",
-  "04": "UPC",
-  "05": "ISMN",
-  "06": "DOI",
-  "13": "LCCN",
-  "14": "GTIN",
-  "15": "ISBN",
-  "22": "URN",
-  "23": "OCLC",
-  "24": "ISBN",
-  "25": "ISMN",
-  "26": "DOI",
-  "34": "GTIN",
-  "35": "ARK",
-}
-
-const refiningMetas = (metadata: XmlElement, id: string): XmlElement[] =>
-  id === ""
-    ? []
-    : listChildrenByLocalName(metadata, "meta").filter(
-        function refinesElement(meta) {
-          return meta.getAttribute("refines")?.trim() === `#${id}`
-        },
-      )
-
-const identifierTypeMeta = (
+const findIdentifierElement = (
   metadata: XmlElement,
-  element: XmlElement,
-): XmlElement | undefined =>
-  refiningMetas(metadata, element.getAttribute("id")?.trim() ?? "").find(
-    function statesIdentifierType(meta) {
-      return meta.getAttribute("property")?.trim() === "identifier-type"
-    },
-  )
+  { parsed }: ReaderIdentifier,
+  index: number,
+): XmlElement | undefined => {
+  const elements = listChildrenByLocalName(metadata, "identifier")
 
-const metaIdentifierType = (meta: XmlElement): string => {
-  const value = meta.textContent?.trim() ?? ""
-  const isOnixCode =
-    meta.getAttribute("scheme")?.trim().toLowerCase() === "onix:codelist5"
-
-  return isOnixCode ? (ONIX_IDENTIFIER_TYPES[value] ?? value) : value
-}
-
-const attributeScheme = (element: XmlElement): string | undefined => {
-  for (const name of SCHEME_ATTRIBUTES) {
-    const value = element.getAttribute(name)?.trim()
-
-    if (value !== undefined && value !== "") return value
-  }
-
-  return undefined
-}
-
-/**
- * The scheme an element states, wherever it states it: EPUB 2 puts it on the
- * identifier, EPUB 3 refines it from a sibling `<meta>`.
- */
-const elementScheme = (metadata: XmlElement, element: XmlElement): string => {
-  const attribute = attributeScheme(element)
-
-  if (attribute !== undefined) return attribute
-
-  const meta = identifierTypeMeta(metadata, element)
-
-  return meta === undefined ? "" : metaIdentifierType(meta)
-}
-
-/**
- * Locate the `<dc:identifier>` the read side reports as the ISBN, if any —
- * matching where it states its scheme and how it spells it, so writes target
- * the node reads pick up instead of appending a second one beside it.
- */
-const findIsbnIdentifier = (metadata: XmlElement): XmlElement | undefined =>
-  listChildrenByLocalName(metadata, "identifier").find(
-    function carriesIsbnScheme(element) {
-      return elementScheme(metadata, element).toLowerCase() === "isbn"
-    },
-  )
-
-/**
- * The package's `unique-identifier` names a `dc:identifier` by id. Removing
- * that element would leave the reference dangling and the document invalid,
- * so it is the one identifier this writer will not delete.
- */
-const isUniqueIdentifierElement = (
-  root: XmlElement,
-  element: XmlElement,
-): boolean => {
-  const uniqueIdentifierId = root.getAttribute("unique-identifier")?.trim()
+  if (parsed.id === undefined) return elements[index]
 
   return (
-    uniqueIdentifierId !== undefined &&
-    uniqueIdentifierId !== "" &&
-    element.getAttribute("id")?.trim() === uniqueIdentifierId
+    elements.find(function carriesId(element) {
+      return element.getAttribute("id")?.trim() === parsed.id
+    }) ?? elements[index]
   )
 }
+
+const isbnIdentifierIndex = (
+  identifiers: ReadonlyArray<ReaderIdentifier>,
+): number =>
+  identifiers.findIndex(function resolvesAsIsbn({ resolved }) {
+    return resolved.scheme === ISBN_SCHEME
+  })
 
 /**
  * Removes an identifier along with the metadata refining it, which would
  * otherwise be left pointing at an id the package no longer has.
  */
-const removeIdentifier = (metadata: XmlElement, element: XmlElement): void => {
-  for (const meta of refiningMetas(
-    metadata,
-    element.getAttribute("id")?.trim() ?? "",
-  )) {
-    metadata.removeChild(meta)
+const removeIdentifier = (
+  metadata: XmlElement,
+  element: XmlElement,
+  refinedBy: ReadonlyArray<string>,
+): void => {
+  for (const meta of listChildrenByLocalName(metadata, "meta")) {
+    if (refinedBy.includes(meta.getAttribute("refines")?.trim() ?? "")) {
+      metadata.removeChild(meta)
+    }
   }
 
   metadata.removeChild(element)
 }
+
+const refinementTargets = ({ parsed }: ReaderIdentifier): string[] =>
+  parsed.id === undefined ? [] : [`#${parsed.id}`, parsed.id]
 
 // Untagged `<dc:identifier>` elements may be the publication UUID
 // referenced by `<package unique-identifier>`; only ISBN-tagged
 // identifiers are touched.
 const upsertIsbnIdentifier = (
   doc: XmlDocument,
-  root: XmlElement,
   metadata: XmlElement,
+  identifiers: ReadonlyArray<ReaderIdentifier>,
   isbn: string | undefined,
 ): void => {
-  const existing = findIsbnIdentifier(metadata)
+  const index = isbnIdentifierIndex(identifiers)
+  const existing = identifiers[index]
+  const element =
+    existing === undefined
+      ? undefined
+      : findIdentifierElement(metadata, existing, index)
 
   if (isbn === undefined || isbn === "") {
-    if (existing && !isUniqueIdentifierElement(root, existing)) {
-      removeIdentifier(metadata, existing)
+    /**
+     * The element `<package unique-identifier>` names is structural: removing
+     * it leaves the reference dangling. Untagging it would buy nothing either,
+     * since the reader infers ISBN from a bare ISBN value.
+     */
+    if (existing && element && existing.resolved.unique !== true) {
+      removeIdentifier(metadata, element, refinementTargets(existing))
     }
 
     return
   }
 
-  if (existing) {
-    existing.textContent = isbn
+  if (element) {
+    element.textContent = isbn
 
     return
   }

--- a/packages/archive-metadata/src/opf/write.ts
+++ b/packages/archive-metadata/src/opf/write.ts
@@ -23,6 +23,17 @@ export type OpfMetadataPatch = {
 
 const OPF_LABEL = "OPF"
 
+const DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
+
+const OPF_NAMESPACE = "http://www.idpf.org/2007/opf"
+
+const IDENTIFIER_ELEMENT_NAME = "dc:identifier"
+
+const ISBN_SCHEME = "ISBN"
+
+/** Every spelling of the scheme attribute the read side accepts. */
+const SCHEME_ATTRIBUTES = ["opf:scheme", "opf:Scheme", "scheme"] as const
+
 /**
  * Apply a metadata patch to an existing OPF package document and
  * return the serialized XML body the caller should write back. The
@@ -47,17 +58,17 @@ const serializeOpfXml = (xml: string, patch: OpfMetadataPatch): string => {
   const doc = parseXml(xml, OPF_LABEL)
   const root = doc.documentElement
 
-  if (root?.tagName !== "package") {
+  if (!root || localName(root.tagName) !== "package") {
     throw new Error("OPF root element is not <package>")
   }
 
-  const metadata = root.getElementsByTagName("metadata").item(0)
+  const metadata = findChildByLocalName(root, "metadata")
 
   if (!metadata) {
     throw new Error("OPF document has no <metadata> element")
   }
 
-  upsertIsbnIdentifier(doc, metadata, patch.isbn)
+  upsertIsbnIdentifier(doc, root, metadata, patch.isbn)
 
   const serialized = serializeXml(doc)
 
@@ -67,30 +78,144 @@ const serializeOpfXml = (xml: string, patch: OpfMetadataPatch): string => {
 }
 
 /**
- * Locate the `<dc:identifier>` carrying an ISBN scheme, if any. Both
- * `opf:scheme="ISBN"` and the bare `scheme="ISBN"` form are accepted,
- * with case-insensitive comparison — same rules the read side uses
- * when extracting the value, so writes target the same node reads
- * pick up.
+ * Elements are matched by local name, the same way the read side does, so a
+ * document that prefixes the OPF namespace — or leaves `<identifier>`
+ * unprefixed under a default one — stays one this writer can update rather
+ * than reject or duplicate into.
  */
-const findIsbnIdentifier = (parent: XmlElement): XmlElement | undefined => {
-  const identifiers = parent.getElementsByTagName("dc:identifier")
+const localName = (tagName: string): string =>
+  tagName.slice(tagName.lastIndexOf(":") + 1).toLowerCase()
 
-  for (let i = 0; i < identifiers.length; i += 1) {
-    const node = identifiers.item(i)
+const listChildrenByLocalName = (
+  parent: XmlElement,
+  name: string,
+): XmlElement[] =>
+  Array.from(parent.children).filter(function matchesLocalName(child) {
+    return localName(child.tagName) === name
+  })
 
-    if (!node) continue
+const findChildByLocalName = (
+  parent: XmlElement,
+  name: string,
+): XmlElement | undefined => listChildrenByLocalName(parent, name)[0]
 
-    const scheme = (
-      node.getAttribute("opf:scheme") ??
-      node.getAttribute("scheme") ??
-      ""
-    ).toLowerCase()
+/**
+ * ONIX codelist 5 codes the read side maps to a scheme name, so an identifier
+ * typed `<meta property="identifier-type" scheme="onix:codelist5">15</meta>`
+ * is matched as the ISBN the reader reports rather than as the literal `15`.
+ */
+const ONIX_IDENTIFIER_TYPES: Record<string, string> = {
+  "02": "ISBN",
+  "03": "GTIN",
+  "04": "UPC",
+  "05": "ISMN",
+  "06": "DOI",
+  "13": "LCCN",
+  "14": "GTIN",
+  "15": "ISBN",
+  "22": "URN",
+  "23": "OCLC",
+  "24": "ISBN",
+  "25": "ISMN",
+  "26": "DOI",
+  "34": "GTIN",
+  "35": "ARK",
+}
 
-    if (scheme === "isbn") return node
+const refiningMetas = (metadata: XmlElement, id: string): XmlElement[] =>
+  id === ""
+    ? []
+    : listChildrenByLocalName(metadata, "meta").filter(
+        function refinesElement(meta) {
+          return meta.getAttribute("refines")?.trim() === `#${id}`
+        },
+      )
+
+const identifierTypeMeta = (
+  metadata: XmlElement,
+  element: XmlElement,
+): XmlElement | undefined =>
+  refiningMetas(metadata, element.getAttribute("id")?.trim() ?? "").find(
+    function statesIdentifierType(meta) {
+      return meta.getAttribute("property")?.trim() === "identifier-type"
+    },
+  )
+
+const metaIdentifierType = (meta: XmlElement): string => {
+  const value = meta.textContent?.trim() ?? ""
+  const isOnixCode =
+    meta.getAttribute("scheme")?.trim().toLowerCase() === "onix:codelist5"
+
+  return isOnixCode ? (ONIX_IDENTIFIER_TYPES[value] ?? value) : value
+}
+
+const attributeScheme = (element: XmlElement): string | undefined => {
+  for (const name of SCHEME_ATTRIBUTES) {
+    const value = element.getAttribute(name)?.trim()
+
+    if (value !== undefined && value !== "") return value
   }
 
   return undefined
+}
+
+/**
+ * The scheme an element states, wherever it states it: EPUB 2 puts it on the
+ * identifier, EPUB 3 refines it from a sibling `<meta>`.
+ */
+const elementScheme = (metadata: XmlElement, element: XmlElement): string => {
+  const attribute = attributeScheme(element)
+
+  if (attribute !== undefined) return attribute
+
+  const meta = identifierTypeMeta(metadata, element)
+
+  return meta === undefined ? "" : metaIdentifierType(meta)
+}
+
+/**
+ * Locate the `<dc:identifier>` the read side reports as the ISBN, if any —
+ * matching where it states its scheme and how it spells it, so writes target
+ * the node reads pick up instead of appending a second one beside it.
+ */
+const findIsbnIdentifier = (metadata: XmlElement): XmlElement | undefined =>
+  listChildrenByLocalName(metadata, "identifier").find(
+    function carriesIsbnScheme(element) {
+      return elementScheme(metadata, element).toLowerCase() === "isbn"
+    },
+  )
+
+/**
+ * The package's `unique-identifier` names a `dc:identifier` by id. Removing
+ * that element would leave the reference dangling and the document invalid,
+ * so it is the one identifier this writer will not delete.
+ */
+const isUniqueIdentifierElement = (
+  root: XmlElement,
+  element: XmlElement,
+): boolean => {
+  const uniqueIdentifierId = root.getAttribute("unique-identifier")?.trim()
+
+  return (
+    uniqueIdentifierId !== undefined &&
+    uniqueIdentifierId !== "" &&
+    element.getAttribute("id")?.trim() === uniqueIdentifierId
+  )
+}
+
+/**
+ * Removes an identifier along with the metadata refining it, which would
+ * otherwise be left pointing at an id the package no longer has.
+ */
+const removeIdentifier = (metadata: XmlElement, element: XmlElement): void => {
+  for (const meta of refiningMetas(
+    metadata,
+    element.getAttribute("id")?.trim() ?? "",
+  )) {
+    metadata.removeChild(meta)
+  }
+
+  metadata.removeChild(element)
 }
 
 // Untagged `<dc:identifier>` elements may be the publication UUID
@@ -98,24 +223,34 @@ const findIsbnIdentifier = (parent: XmlElement): XmlElement | undefined => {
 // identifiers are touched.
 const upsertIsbnIdentifier = (
   doc: XmlDocument,
+  root: XmlElement,
   metadata: XmlElement,
   isbn: string | undefined,
 ): void => {
   const existing = findIsbnIdentifier(metadata)
 
   if (isbn === undefined || isbn === "") {
-    if (existing) metadata.removeChild(existing)
+    if (existing && !isUniqueIdentifierElement(root, existing)) {
+      removeIdentifier(metadata, existing)
+    }
 
     return
   }
 
   if (existing) {
     existing.textContent = isbn
+
     return
   }
 
-  const next = doc.createElement("dc:identifier")
-  next.setAttribute("opf:scheme", "ISBN")
+  /**
+   * Created and tagged through the namespace rather than by prefixed name: a
+   * package that uses the OPF namespace by default need not declare the legacy
+   * `opf` prefix, and an unbound one serializes into a document that no longer
+   * parses.
+   */
+  const next = doc.createElementNS(DC_NAMESPACE, IDENTIFIER_ELEMENT_NAME)
+  next.setAttributeNS(OPF_NAMESPACE, "opf:scheme", ISBN_SCHEME)
   next.textContent = isbn
   metadata.appendChild(next)
 }


### PR DESCRIPTION
## Problem

The OPF writer and the OPF reader disagreed about the same document in five ways. Each is reproducible against an OPF the reader handles fine, and each is fixed here against the writer's existing `isbn?: string` API — no behaviour change for callers.

| | Before | Result |
|---|---|---|
| 1 | A created `<dc:identifier>` was tagged `setAttribute("opf:scheme", …)` | Serializes to XML that **no longer parses** when the package never declares the `opf` prefix |
| 2 | Root matched as `tagName === "package"`, `<metadata>` via `getElementsByTagName` | A prefixed `<opf:package>` was **rejected outright** |
| 3 | Clearing the ISBN removed only the element | Left `<meta refines="#isbn-id">` pointing at nothing |
| 4 | Scheme read from attributes only | An EPUB 3 ISBN typed by an `identifier-type` refinement was never found → **duplicate ISBN appended**, carrying `xmlns=""` |
| 5 | Removed the ISBN element unconditionally | `<package unique-identifier="pub-id">` **left dangling** |

Bug 4 concretely, patching a document whose ISBN is typed by refinement:

```xml
<dc:identifier id="pub-id">9783161484100</dc:identifier>
<meta refines="#pub-id" property="identifier-type" scheme="onix:codelist5">15</meta>
<dc:identifier xmlns="" opf:scheme="ISBN">9780306406157</dc:identifier>   <!-- duplicate -->
```

## The fix

Every one of these is the same root cause: **the writer decided which element to edit by re-reading the DOM itself, instead of asking the reader.** So it does that now.

```ts
const parsed = parseOpf(xml)                      // each identifier verbatim, incl. its `id`
const resolved = resolveArchiveMetadata(parsed)   // the scheme the book advertises
```

`parseOpf` already handles prefixed packages, `<identifier>` left unprefixed under a default DC namespace, all three spellings of the scheme attribute, and `unique`. `resolveArchiveMetadata` already resolves EPUB 3 `identifier-type` refinements through the ONIX codelist 5 table. Pairing the two gives the writer every decision it had been making by hand, from the code that owns those decisions — so bugs 2, 3, 4 and 5 stop being possible rather than being separately patched, and the two sides cannot drift.

The first commit fixes the bugs with the logic written out by hand; the second replaces that with the delegation above. Kept as two commits because the first is where each bug and its test are legible.

What stays genuinely local to the writer:

- **Namespaced creation** — `createElementNS(DC_NAMESPACE, …)` and `setAttributeNS(OPF_NAMESPACE, "opf:scheme", …)`, so the output can be re-parsed (bug 1). The reader has no say here; it never writes.
- **Locating the DOM node**, since `parseOpf` returns no element handles: by `id` where the document gives one, falling back to position among the identifier elements otherwise — the only handle an anonymous identifier has, and the order the parser reported it in.
- **Not deleting the `unique-identifier` element.** It is structural, and untagging it instead would buy nothing since the reader infers `ISBN` from a bare ISBN value.

## Why this is separate

Extracted from #586, which replaces the single ISBN field with a list of scheme-tagged identifiers. These five are defects in the writer that exists today — different review criteria from the feature, and independently revertible. #586 is stacked on this branch.

Worth stating plainly: extracting this did **not** shrink #586 much (−89 insertions), because #586 replaces this writer's entry points rather than building on them. The value here is that five corruption bugs land and are revertible on their own.

## Testing

- **8 new cases, all verified to fail against the previous writer** — I ran them against it before fixing
- **15 existing cases pass unchanged**, so nothing current callers rely on moved
- `archive-metadata`: 101 tests pass; tsc and biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)