### PR TITLE
docs(agents): read prose-reader's guides before writing code against it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,40 @@
 - pnpm does not hoist, so every package must declare what it imports; do not rely on transitive dependencies being resolvable.
 - Dependency build scripts are opt-in via `allowBuilds` in `pnpm-workspace.yaml`; when pnpm reports newly ignored build scripts, add an explicit `true`/`false` entry there.
 
+### prose-reader: read its docs before writing code against it
+
+- **prose-reader and oboku have the same maintainer.** prose-reader is not a
+  third-party black box: its repository is available, its behaviour is
+  changeable, and a gap there is fixable rather than something to work around
+  locally.
+- `@prose-reader/*` is a documented library. Its guides live in the prose-reader
+  repo under `gitbook/<package>/` (e.g. `gitbook/archive-reader/`) and are the
+  source of truth for what each package owns, what its vocabulary means, and why
+  a field is shaped the way it is. Read them before writing code against it.
+- **The guides can be stale, wrong, or silent** — they are hand-written
+  alongside the code. When one does not answer the question, or contradicts what
+  you observe, read prose-reader's `src/`: it is typed, commented, and states
+  intent. Trust the source over the guide when they disagree, say so, and offer
+  to correct the guide upstream.
+- **Never reverse-engineer behaviour from `dist/`.** The published bundles are
+  minified: they tell you what the code does and nothing about what it intends.
+  Read `src/` in the repository instead — reaching for the built artifact when
+  the real source is available is what produced the duplication below.
+- **Treat "I am about to reimplement something archive-reader also does" as a
+  hard stop.** Identifier schemes and their crosswalks (ONIX, MARC), catalog URL
+  forms, container parsing, and metadata resolution all live upstream.
+  Duplicating them has been the recurring mistake in this repository.
+- **A field the resolved vocabulary omits is usually omitted deliberately.**
+  `metadata` is what the resolver believes; `sources` is the verbatim parser
+  output — what the book said. Container-specific detail lives in `sources`, so
+  check there and in the docs before concluding something is unavailable
+  upstream.
+- If knowledge genuinely belongs upstream and is not there yet, prefer a
+  prose-reader PR over a local copy, then upgrade oboku to the published version
+  in its own PR.
+- Smell test: if a test file uses a prose-reader helper to verify what the code
+  under test computes by hand, the code under test should be using that helper.
+
 ### Synology API docs
 
 - For Synology integrations, treat the public DSM Login Web API guide and File Station API guide as generic protocol references only.


### PR DESCRIPTION
## Why

Three times in recent work the answer turned out to be *"archive-reader already owns that"*:

- catalog URL templates, duplicated in `packages/archive-metadata/src/metadata/catalogUrl.ts` until it was deleted
- the identifier scheme vocabulary, duplicated as a local `KNOWN_IDENTIFIER_SCHEMES` record and normalizer
- the OPF identifier crosswalk in #603 — an ONIX codelist 5 table copied byte-for-byte into the writer, plus the scheme-attribute spellings and the `identifier-type` refinement walk, all of which `resolveArchiveMetadata` already does

The third is the instructive one. I reverse-engineered the ONIX table out of the minified `dist/index/index.js` bundle, while the sentence answering the actual question sat in `gitbook/archive-reader/resolved-metadata.md`:

> Parsed source data at `sources.opf.identifiers` also retains each element's XML `id`; normalized `metadata.identifiers` omits that internal anchor while keeping the semantic marker.

Field path, rationale, and the deliberate omission, in one line. A build artifact can tell you what code does; only the guides tell you what it intends — and intent is precisely the question that decides whether to implement something locally at all.

## What this adds

A section next to the existing "Synology API docs" rule, which is the same shape of guidance: where the source of truth for an external dependency lives.

- **The two repos share a maintainer**, so prose-reader is not a third-party black box — a gap there is fixable upstream rather than something to work around locally.
- **Read `gitbook/<package>/` first.**
- **The guides can be stale, wrong, or silent.** They are hand-written alongside the code, so when one does not answer the question — or contradicts what you observe — read prose-reader's `src/`, trust it over the guide, and offer to correct the guide upstream.
- **Never reverse-engineer from `dist/`.** The distinction that matters is `src/` versus `dist/`, not repo versus docs: reaching for a minified artifact when the real source is checked out is what produced the duplication above.
- **Treat "I'm about to reimplement something archive-reader does" as a hard stop.**
- **A field missing from the resolved vocabulary is usually deliberate**, with the raw value kept in `sources`.

Plus one smell test that would have caught #603 on its own: if a test file uses a prose-reader helper to verify what the code under test computes by hand, the code under test should be using that helper.

The "guides can be wrong" bullet has a live example already — that quoted line says `sources.opf.identifiers`, but the real path is `sources.opf.opf.identifiers`, since `sources.opf` is `{ opf, basePath }`. Worth a one-line fix upstream.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)