### PR TITLE
fix(archive-metadata): skip empty identifier elements when locating one to edit

### DIFF
--- a/packages/archive-metadata/src/opf/write.test.ts
+++ b/packages/archive-metadata/src/opf/write.test.ts
@@ -441,3 +441,25 @@ describe("OPF editing alongside empty identifier elements", () => {
     expect(xml).not.toContain("9783161484100")
   })
 })
+
+describe("OPF editing alongside identifiers the parser drops", () => {
+  it("updates the ISBN rather than an element holding only a nested element", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      '<?xml version="1.0" encoding="utf-8"?>' +
+        '<package xmlns="http://www.idpf.org/2007/opf"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:opf="http://www.idpf.org/2007/opf"' +
+        ' version="3.0" unique-identifier="pub-id">' +
+        "<metadata>" +
+        "<dc:identifier><span>ignored</span></dc:identifier>" +
+        '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>' +
+        "</metadata><manifest/><spine/></package>",
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(xml).not.toContain("0000000000")
+  })
+})

--- a/packages/archive-metadata/src/opf/write.test.ts
+++ b/packages/archive-metadata/src/opf/write.test.ts
@@ -399,3 +399,45 @@ describe("OPF editing with refinement-typed identifiers", () => {
     expect(xml).toContain("9783161484100")
   })
 })
+
+describe("OPF editing alongside empty identifier elements", () => {
+  it("updates the ISBN rather than an empty element sitting before it", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      '<?xml version="1.0" encoding="utf-8"?>' +
+        '<package xmlns="http://www.idpf.org/2007/opf"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:opf="http://www.idpf.org/2007/opf"' +
+        ' version="3.0" unique-identifier="pub-id">' +
+        "<metadata>" +
+        "<dc:identifier></dc:identifier>" +
+        '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>' +
+        "</metadata><manifest/><spine/></package>",
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(xml).not.toContain("0000000000")
+  })
+
+  it("removes the ISBN rather than an empty element sitting before it", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      '<?xml version="1.0" encoding="utf-8"?>' +
+        '<package xmlns="http://www.idpf.org/2007/opf"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' xmlns:opf="http://www.idpf.org/2007/opf"' +
+        ' version="3.0" unique-identifier="pub-id">' +
+        "<metadata>" +
+        "<dc:identifier></dc:identifier>" +
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>' +
+        "</metadata><manifest/><spine/></package>",
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { isbn: undefined })
+
+    expect(readOpfIsbn(xml)).toBeUndefined()
+    expect(xml).not.toContain("9783161484100")
+  })
+})

--- a/packages/archive-metadata/src/opf/write.ts
+++ b/packages/archive-metadata/src/opf/write.ts
@@ -133,14 +133,33 @@ const findChildByLocalName = (
 ): XmlElement | undefined => listChildrenByLocalName(parent, name)[0]
 
 /**
- * The identifier elements the parser reports, in its order. Elements with no
- * value are skipped because the parser drops them, and an authored empty
- * `<dc:identifier>` would otherwise shift every position after it.
+ * An element's own text, excluding any nested element's — the value the parser
+ * reads. `textContent` would fold descendants in, and disagreeing with the
+ * parser about which elements have a value is what shifts the positions below.
+ */
+const directText = (element: XmlElement): string =>
+  Array.from(element.childNodes)
+    .filter(function isTextual(node) {
+      return (
+        node.nodeType === Node.TEXT_NODE ||
+        node.nodeType === Node.CDATA_SECTION_NODE
+      )
+    })
+    .map(function nodeText(node) {
+      return node.nodeValue ?? ""
+    })
+    .join("")
+
+/**
+ * The identifier elements the parser reports, in its order. Valueless elements
+ * are skipped because the parser drops them, and one authored empty — or
+ * holding only a nested element — would otherwise shift every position after
+ * it.
  */
 const identifierElements = (metadata: XmlElement): XmlElement[] =>
   listChildrenByLocalName(metadata, "identifier").filter(
     function statesAValue(element) {
-      return (element.textContent?.trim() ?? "") !== ""
+      return directText(element).trim() !== ""
     },
   )
 

--- a/packages/archive-metadata/src/opf/write.ts
+++ b/packages/archive-metadata/src/opf/write.ts
@@ -133,6 +133,18 @@ const findChildByLocalName = (
 ): XmlElement | undefined => listChildrenByLocalName(parent, name)[0]
 
 /**
+ * The identifier elements the parser reports, in its order. Elements with no
+ * value are skipped because the parser drops them, and an authored empty
+ * `<dc:identifier>` would otherwise shift every position after it.
+ */
+const identifierElements = (metadata: XmlElement): XmlElement[] =>
+  listChildrenByLocalName(metadata, "identifier").filter(
+    function statesAValue(element) {
+      return (element.textContent?.trim() ?? "") !== ""
+    },
+  )
+
+/**
  * The element the reader read an identifier from. An `id` addresses it exactly;
  * an identifier authored without one has only its position among the identifier
  * elements, which is the order the parser reported it in.
@@ -142,7 +154,7 @@ const findIdentifierElement = (
   { parsed }: ReaderIdentifier,
   index: number,
 ): XmlElement | undefined => {
-  const elements = listChildrenByLocalName(metadata, "identifier")
+  const elements = identifierElements(metadata)
 
   if (parsed.id === undefined) return elements[index]
 


### PR DESCRIPTION
## The bug

A regression I introduced in #603. `parseOpf` reports every **non-empty** `dc:identifier` — the guide says so and I verified it: four identifier elements in the DOM, two reported. The writer paired the reader's identifiers against *all* identifier elements, so an authored empty one shifts every position after it.

Given:

```xml
<metadata>
  <dc:identifier></dc:identifier>
  <dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>
</metadata>
```

patching with `9783161484100` produced:

```xml
<dc:identifier>9783161484100</dc:identifier>
<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>
```

Two identifiers where there should be one, and since the reader infers `ISBN` from a bare ISBN value, both read as ISBNs — the stale one still wearing the scheme tag. Clearing the ISBN had the mirror-image failure: it removed the empty element and left the real ISBN.

Only reachable for an identifier the document gives no `id`; an `id` addresses its element exactly, which is why the existing suite didn't catch it.

## The fix

Pair against the elements the parser actually reports, by skipping ones with no value — a one-line filter with the invariant named in a comment, since nothing in the type system enforces it.

## Testing

Two regression cases, both verified to fail before the fix: the update path and the removal path. 103 tests pass in the package; tsc and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)