### PR TITLE
feat(archive-metadata): patch identifiers as a set rather than one ISBN field

### DIFF
--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.test.tsx
@@ -43,7 +43,7 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
     const actions: WebArchiveUpdateAction[] = [
       {
         kind: "patch-metadata",
-        patch: { isbn: "9781234567897" },
+        patch: { identifiers: [{ scheme: "ISBN", value: "9781234567897" }] },
         targets: { comicInfo: true, opf: true },
       },
       {
@@ -93,7 +93,7 @@ describe("confirmApplyLocalUpdate", function testConfirmApplyLocalUpdate() {
     const actions: WebArchiveUpdateAction[] = [
       {
         kind: "patch-metadata",
-        patch: { isbn: undefined },
+        patch: { identifiers: [] },
         targets: { comicInfo: true },
       },
       {

--- a/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
+++ b/apps/web/src/books/optimize/apply/confirmApplyLocalUpdate.tsx
@@ -3,6 +3,7 @@ import {
   PRESERVABLE_IMAGE_FORMAT_NAMES,
   type WebArchiveUpdateAction,
 } from "@oboku/archive-metadata/web"
+import { isIsbnBearingScheme } from "@prose-reader/archive-reader"
 import { FiberManualRecord } from "@mui/icons-material"
 import {
   List,
@@ -63,13 +64,19 @@ function MetadataUpdateItems({
   if (action.targets.comicInfo) targets.push(CONTAINER_LABELS.comicInfo)
   if (action.targets.opf) targets.push(CONTAINER_LABELS.opf)
 
-  return action.patch.isbn === undefined ? (
+  const isbn = action.patch.identifiers.find(function announcesIsbn({
+    scheme,
+  }) {
+    return isIsbnBearingScheme(scheme)
+  })?.value
+
+  return isbn === undefined ? (
     <UpdateListItem>
       Remove the ISBN from <MetadataTargetChips targets={targets} />.
     </UpdateListItem>
   ) : (
     <UpdateListItem>
-      Set the ISBN to <KeyChip label={action.patch.isbn} /> in{" "}
+      Set the ISBN to <KeyChip label={isbn} /> in{" "}
       <MetadataTargetChips targets={targets} />.
     </UpdateListItem>
   )

--- a/apps/web/src/books/optimize/metadata/targets.test.ts
+++ b/apps/web/src/books/optimize/metadata/targets.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest"
 import { CONTAINER_XML, comicInfo, inspect, opf } from "./inspection.fixture"
-import { hasWritableMetadataTarget, resolveMetadataTargets } from "./targets"
+import {
+  hasWritableMetadataTarget,
+  resolveArchiveMetadataPatchPlan,
+  resolveMetadataTargets,
+} from "./targets"
 
 const UNPARSEABLE = "<root><child></wrong></root>"
 
@@ -102,5 +106,93 @@ describe("resolveMetadataTargets", () => {
       comicInfo: false,
       opf: false,
     })
+  })
+})
+
+describe("resolveArchiveMetadataPatchPlan", () => {
+  it("carries the identifiers it is not editing through the patch", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
+          '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>' +
+          '<dc:identifier opf:scheme="DOI">10.1000/182</dc:identifier>',
+      ),
+    })
+
+    const { patch } = resolveArchiveMetadataPatchPlan(
+      { isbn: "9783161484100" },
+      inspection,
+    )
+
+    expect(patch.identifiers).toEqual([
+      {
+        scheme: "Unknown",
+        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
+        unique: true,
+      },
+      { scheme: "ISBN", value: "9783161484100", unique: false },
+      { scheme: "DOI", value: "10.1000/182", unique: false },
+    ])
+  })
+
+  it("appends an ISBN a book announced none of", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>',
+      ),
+    })
+
+    const { patch } = resolveArchiveMetadataPatchPlan(
+      { isbn: "9783161484100" },
+      inspection,
+    )
+
+    expect(patch.identifiers).toEqual([
+      {
+        scheme: "Unknown",
+        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
+        unique: true,
+      },
+      { scheme: "ISBN", value: "9783161484100" },
+    ])
+  })
+
+  it("drops only the ISBN when the field is cleared", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
+          '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
+      ),
+    })
+
+    const { patch } = resolveArchiveMetadataPatchPlan({ isbn: "" }, inspection)
+
+    expect(patch.identifiers).toEqual([
+      {
+        scheme: "Unknown",
+        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
+        unique: true,
+      },
+    ])
+  })
+
+  it("edits a ComicInfo GTIN as the ISBN it announces", async () => {
+    const inspection = await inspect({
+      "ComicInfo.xml": comicInfo("<GTIN>0000000000</GTIN>"),
+      "page-001.jpg": "binary",
+    })
+
+    const { patch, targets } = resolveArchiveMetadataPatchPlan(
+      { isbn: "9783161484100" },
+      inspection,
+    )
+
+    expect(patch.identifiers).toEqual([
+      { scheme: "GTIN", value: "9783161484100", unique: false },
+    ])
+    expect(targets).toEqual({ comicInfo: true, opf: false })
   })
 })

--- a/apps/web/src/books/optimize/metadata/targets.test.ts
+++ b/apps/web/src/books/optimize/metadata/targets.test.ts
@@ -196,3 +196,46 @@ describe("resolveArchiveMetadataPatchPlan", () => {
     expect(targets).toEqual({ comicInfo: true, opf: false })
   })
 })
+
+describe("resolveArchiveMetadataPatchPlan, an ISBN both containers announce", () => {
+  const bothAnnounce = () =>
+    inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
+          '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
+      ),
+      "ComicInfo.xml": comicInfo("<GTIN>9783161484100</GTIN>"),
+    })
+
+  it("leaves the previous ISBN behind under no scheme", async () => {
+    const { patch } = resolveArchiveMetadataPatchPlan(
+      { isbn: "9780306406157" },
+      await bothAnnounce(),
+    )
+
+    expect(patch.identifiers).toEqual([
+      {
+        scheme: "Unknown",
+        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
+        unique: true,
+      },
+      { scheme: "ISBN", value: "9780306406157", unique: false },
+    ])
+  })
+
+  it("clears every entry announcing it", async () => {
+    const { patch } = resolveArchiveMetadataPatchPlan(
+      { isbn: "" },
+      await bothAnnounce(),
+    )
+
+    expect(patch.identifiers).toEqual([
+      {
+        scheme: "Unknown",
+        value: "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809",
+        unique: true,
+      },
+    ])
+  })
+})

--- a/apps/web/src/books/optimize/metadata/targets.ts
+++ b/apps/web/src/books/optimize/metadata/targets.ts
@@ -1,8 +1,12 @@
 import type {
+  ArchiveMetadataIdentifier,
   ArchiveMetadataPatch,
   ArchiveMetadataTargets,
 } from "@oboku/archive-metadata/web"
-import { identifierValue } from "@prose-reader/archive-reader"
+import {
+  identifierValue,
+  isIsbnBearingScheme,
+} from "@prose-reader/archive-reader"
 import type { FileInspection } from "../useFileInspection"
 import type { MetadataFixerFormValues } from "./types"
 
@@ -41,6 +45,41 @@ export const resolveMetadataFixerFormValues = (
     identifierValue(inspection.resolvedArchive.metadata.identifiers, "ISBN") ??
     "",
 })
+
+/**
+ * The identifiers the archive should end up carrying: the ones it already has,
+ * with the edited ISBN swapped into whichever of them announced one — appended
+ * when none did, dropped when the field was cleared.
+ *
+ * The patch is the complete set rather than a delta, so every identifier the
+ * book carries has to be listed for it to survive the write. Only the ISBN is
+ * editable here; the rest are passed through as read.
+ */
+const patchIdentifiers = (
+  inspection: FileInspection,
+  isbn: string | undefined,
+): ArchiveMetadataIdentifier[] => {
+  const identifiers = (
+    inspection.resolvedArchive.metadata.identifiers ?? []
+  ).map(function toPatchIdentifier({ scheme, value, unique }) {
+    return { scheme, value, unique: unique === true }
+  })
+  const isbnIndex = identifiers.findIndex(function announcesIsbn({ scheme }) {
+    return isIsbnBearingScheme(scheme)
+  })
+
+  if (isbn === undefined) {
+    return identifiers.filter(function isNotTheEditedIsbn(_, index) {
+      return index !== isbnIndex
+    })
+  }
+
+  if (isbnIndex === -1) return [...identifiers, { scheme: "ISBN", value: isbn }]
+
+  return identifiers.map(function withEditedValue(identifier, index) {
+    return index === isbnIndex ? { ...identifier, value: isbn } : identifier
+  })
+}
 
 /**
  * The containers a save should write.
@@ -87,6 +126,8 @@ export const resolveArchiveMetadataPatchPlan = (
   values: MetadataFixerFormValues,
   inspection: FileInspection,
 ): ArchiveMetadataPatchPlan => ({
-  patch: { isbn: normalizeFormIsbn(values.isbn) },
+  patch: {
+    identifiers: patchIdentifiers(inspection, normalizeFormIsbn(values.isbn)),
+  },
   targets: resolveMetadataTargets(inspection),
 })

--- a/apps/web/src/books/optimize/metadata/targets.ts
+++ b/apps/web/src/books/optimize/metadata/targets.ts
@@ -48,13 +48,20 @@ export const resolveMetadataFixerFormValues = (
 
 /**
  * The identifiers the archive should end up carrying: the ones it already has,
- * with the edited ISBN swapped into whichever of them announced one — appended
- * when none did, dropped when the field was cleared.
+ * with the edited ISBN in place of every one of them that announced an ISBN.
+ *
+ * More than one usually does — a book whose OPF and ComicInfo both carry it is
+ * read as an `ISBN` and a `GTIN` of the same value — and they are one fact, so
+ * the edit replaces the first and drops the rest. Keeping the others would
+ * leave the previous ISBN behind under the other scheme.
  *
  * The patch is the complete set rather than a delta, so every identifier the
  * book carries has to be listed for it to survive the write. Only the ISBN is
  * editable here; the rest are passed through as read.
  */
+const announcesIsbn = ({ scheme }: ArchiveMetadataIdentifier): boolean =>
+  isIsbnBearingScheme(scheme)
+
 const patchIdentifiers = (
   inspection: FileInspection,
   isbn: string | undefined,
@@ -64,21 +71,20 @@ const patchIdentifiers = (
   ).map(function toPatchIdentifier({ scheme, value, unique }) {
     return { scheme, value, unique: unique === true }
   })
-  const isbnIndex = identifiers.findIndex(function announcesIsbn({ scheme }) {
-    return isIsbnBearingScheme(scheme)
-  })
+  const editedIndex = identifiers.findIndex(announcesIsbn)
 
-  if (isbn === undefined) {
-    return identifiers.filter(function isNotTheEditedIsbn(_, index) {
-      return index !== isbnIndex
-    })
-  }
+  const carried = identifiers.flatMap(
+    function keepOrReplace(identifier, index) {
+      if (!announcesIsbn(identifier)) return [identifier]
+      if (index !== editedIndex || isbn === undefined) return []
 
-  if (isbnIndex === -1) return [...identifiers, { scheme: "ISBN", value: isbn }]
+      return [{ ...identifier, value: isbn }]
+    },
+  )
 
-  return identifiers.map(function withEditedValue(identifier, index) {
-    return index === isbnIndex ? { ...identifier, value: isbn } : identifier
-  })
+  return editedIndex === -1 && isbn !== undefined
+    ? [...carried, { scheme: "ISBN", value: isbn }]
+    : carried
 }
 
 /**

--- a/packages/archive-metadata/src/comicInfo/index.test.ts
+++ b/packages/archive-metadata/src/comicInfo/index.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest"
 import {
   arrayBufferFileAccessors,
+  catalogIdentifierFromUrl,
   createArchive,
   getArchiveHasComicInfo,
   identifierValue,
@@ -9,7 +10,11 @@ import {
   resolveArchiveMetadata,
 } from "@prose-reader/archive-reader"
 import type { Archive, ArchiveRecord } from "../archive/types"
-import { COMIC_INFO_FILENAME, buildPatchedComicInfoXml } from "./index"
+import {
+  COMIC_INFO_FILENAME,
+  buildPatchedComicInfoXml,
+  isComicInfoWritableIdentifierScheme,
+} from "./index"
 
 const basename = (uri: string): string =>
   uri.split("/").filter(Boolean).pop() ?? uri
@@ -131,7 +136,7 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     const archive = makeArchive({ "page-001.jpg": "binary" })
 
     const xml = await buildPatchedComicInfoXml(archive, {
-      isbn: "9783161484100",
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     expect(xml.startsWith("<?xml")).toBe(true)
@@ -144,10 +149,10 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     expect(readComicInfoIsbn(xml)).toBe("9783161484100")
   })
 
-  it("emits no GTIN element when synthesising with an undefined ISBN", async () => {
+  it("emits no GTIN element when synthesising without any identifier", async () => {
     const archive = makeArchive({ "page-001.jpg": "binary" })
 
-    const xml = await buildPatchedComicInfoXml(archive, { isbn: undefined })
+    const xml = await buildPatchedComicInfoXml(archive, { identifiers: [] })
 
     expect(xml).not.toContain("<GTIN")
     expect(readComicInfoIsbn(xml)).toBeUndefined()
@@ -164,7 +169,7 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     })
 
     const xml = await buildPatchedComicInfoXml(archive, {
-      isbn: "9783161484100",
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     expect(xml).toContain("<Title>Sample</Title>")
@@ -182,7 +187,7 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     })
 
     const xml = await buildPatchedComicInfoXml(archive, {
-      isbn: "9783161484100",
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     const matches = xml.match(/<GTIN>/g) ?? []
@@ -191,14 +196,149 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     expect(xml).not.toContain("<GTIN>0000000000</GTIN>")
   })
 
-  it("removes the GTIN element when the patch clears it", async () => {
+  it("stores a GTIN-scheme identifier in the same element as an ISBN", async () => {
+    const archive = makeArchive({ "page-001.jpg": "binary" })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [{ scheme: "GTIN", value: "9783161484100" }],
+    })
+
+    expect(xml).toContain("<GTIN>9783161484100</GTIN>")
+  })
+
+  it("stores URL identifiers as a space-separated Web element", async () => {
+    const archive = makeArchive({ "page-001.jpg": "binary" })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [
+        { scheme: "URL", value: "https://example.com/a" },
+        { scheme: "URL", value: "https://example.com/b" },
+      ],
+    })
+
+    expect(xml).toContain(
+      "<Web>https://example.com/a https://example.com/b</Web>",
+    )
+  })
+
+  it("removes the Web element when no URL identifier remains", async () => {
+    const archive = makeArchive({
+      "ComicInfo.xml": minimalComicInfo("<Web>https://example.com/a</Web>"),
+    })
+
+    const xml = await buildPatchedComicInfoXml(archive, { identifiers: [] })
+
+    expect(xml).not.toContain("<Web")
+  })
+
+  it("stores a catalog identifier as its official Web link", async () => {
+    const archive = makeArchive({ "page-001.jpg": "binary" })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [
+        { scheme: "GoogleBooks", value: "zyTCAlFPjgYC" },
+        { scheme: "ProjectGutenberg", value: "2701" },
+      ],
+    })
+
+    expect(isComicInfoWritableIdentifierScheme("GoogleBooks")).toBe(true)
+    expect(xml).toContain(
+      "<Web>https://books.google.com/books?id=zyTCAlFPjgYC " +
+        "https://www.gutenberg.org/ebooks/2701</Web>",
+    )
+  })
+
+  it("keeps plain links alongside the catalog ones", async () => {
+    const archive = makeArchive({ "page-001.jpg": "binary" })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [
+        { scheme: "URL", value: "https://example.com/a" },
+        { scheme: "GoogleBooks", value: "zyTCAlFPjgYC" },
+      ],
+    })
+
+    expect(xml).toContain(
+      "<Web>https://example.com/a " +
+        "https://books.google.com/books?id=zyTCAlFPjgYC</Web>",
+    )
+  })
+
+  it("stores a DOI and an Open Library key as their resolver links", async () => {
+    const archive = makeArchive({ "page-001.jpg": "binary" })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [
+        { scheme: "DOI", value: "10.1000/182" },
+        { scheme: "OpenLibrary", value: "/books/OL7353617M" },
+      ],
+    })
+
+    expect(xml).toContain(
+      "<Web>https://doi.org/10.1000/182 " +
+        "https://openlibrary.org/books/OL7353617M</Web>",
+    )
+  })
+
+  it("accepts a bare catalog id, addressing it the way the catalog does", async () => {
+    const archive = makeArchive({ "page-001.jpg": "binary" })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [{ scheme: "OpenLibrary", value: "OL7353617M" }],
+    })
+
+    expect(xml).toContain("<Web>https://openlibrary.org/books/OL7353617M</Web>")
+  })
+
+  it("has nowhere to store a scheme with neither a GTIN nor a link form", async () => {
+    const archive = makeArchive({ "page-001.jpg": "binary" })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [{ scheme: "AcmeCatalog", value: "acme-42" }],
+    })
+
+    expect(isComicInfoWritableIdentifierScheme("AcmeCatalog")).toBe(false)
+    expect(xml).not.toContain("acme-42")
+  })
+
+  it("will not write a value its catalog cannot address", async () => {
+    const archive = makeArchive({ "page-001.jpg": "binary" })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [{ scheme: "ProjectGutenberg", value: "not-a-number" }],
+    })
+
+    expect(xml).not.toContain("not-a-number")
+  })
+
+  it("round-trips a catalog identifier through the link the reader parses", async () => {
+    const archive = makeArchive({ "page-001.jpg": "binary" })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [{ scheme: "GoogleBooks", value: "zyTCAlFPjgYC" }],
+    })
+    const [webIdentifier] =
+      resolveArchiveMetadata(parseComicInfo(xml)).identifiers ?? []
+
+    expect(webIdentifier).toEqual({
+      value: "https://books.google.com/books?id=zyTCAlFPjgYC",
+      scheme: "URL",
+    })
+    expect(
+      webIdentifier && catalogIdentifierFromUrl(webIdentifier.value),
+    ).toEqual({ value: "zyTCAlFPjgYC", scheme: "GoogleBooks" })
+  })
+
+  it("removes the GTIN element when the patch drops every ISBN-bearing identifier", async () => {
     const archive = makeArchive({
       "ComicInfo.xml": minimalComicInfo(
         "<Title>Sample</Title><GTIN>9783161484100</GTIN>",
       ),
     })
 
-    const xml = await buildPatchedComicInfoXml(archive, { isbn: undefined })
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [{ scheme: "DOI", value: "10.1000/182" }],
+    })
 
     expect(xml).not.toContain("<GTIN")
     expect(xml).toContain("<Title>Sample</Title>")
@@ -211,7 +351,7 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     })
 
     const xml = await buildPatchedComicInfoXml(archive, {
-      isbn: "9783161484100",
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     expect(xml).toContain("<Title>Sample</Title>")
@@ -224,7 +364,7 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     })
 
     const xml = await buildPatchedComicInfoXml(archive, {
-      isbn: "9783161484100",
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     expect(xml.startsWith("<?xml")).toBe(true)
@@ -241,7 +381,9 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     })
 
     await expect(
-      buildPatchedComicInfoXml(archive, { isbn: "9783161484100" }),
+      buildPatchedComicInfoXml(archive, {
+        identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+      }),
     ).rejects.toThrow(/root element is not <ComicInfo>/i)
   })
 
@@ -251,7 +393,7 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     })
 
     const xml = await buildPatchedComicInfoXml(archive, {
-      isbn: "9783161484100",
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     expect(xml.startsWith("<?xml")).toBe(true)

--- a/packages/archive-metadata/src/comicInfo/index.ts
+++ b/packages/archive-metadata/src/comicInfo/index.ts
@@ -1,9 +1,16 @@
 import {
+  catalogUrlFromIdentifier,
   COMIC_INFO_FILENAME as PROSE_COMIC_INFO_FILENAME,
   getArchiveHasComicInfo,
+  isIsbnBearingScheme,
+  isMetadataCatalogScheme,
+  normalizeIdentifierScheme,
   readRecordAsText,
+  type MetadataIdentifierScheme,
 } from "@prose-reader/archive-reader"
 import type { Archive } from "../archive/types"
+import type { ArchiveMetadataIdentifier } from "../metadata/write"
+import { URL_IDENTIFIER_SCHEME } from "../metadata/identifiers"
 import {
   type XmlDocument,
   parseXml,
@@ -12,7 +19,7 @@ import {
 } from "../utils/dom"
 
 type ComicInfoMetadataPatch = {
-  isbn?: string | undefined
+  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>
 }
 
 export { PROSE_COMIC_INFO_FILENAME as COMIC_INFO_FILENAME }
@@ -23,6 +30,20 @@ const COMIC_INFO_NAMESPACE_ATTRS = {
   xmlns_xsi: "http://www.w3.org/2001/XMLSchema-instance",
   xmlns_xsd: "http://www.w3.org/2001/XMLSchema",
 }
+
+/**
+ * Schemes this writer can map onto a ComicInfo field: ISBN/GTIN-bearing ones
+ * become `<GTIN>`, and `<Web>` takes both plain links and the catalogs that
+ * have an official URL form. Consumers should check this before offering
+ * ComicInfo as a target, since the writer silently has nothing to write for
+ * the schemes it rejects.
+ */
+export const isComicInfoWritableIdentifierScheme = (
+  scheme: MetadataIdentifierScheme,
+): boolean =>
+  isIsbnBearingScheme(scheme) ||
+  normalizeIdentifierScheme(scheme) === URL_IDENTIFIER_SCHEME ||
+  isMetadataCatalogScheme(scheme)
 
 /**
  * Produce the new ComicInfo.xml body for a patched archive. Handles
@@ -59,9 +80,34 @@ const tryParseExistingComicInfo = (xml: string): XmlDocument | undefined => {
   }
 }
 
+const gtinValue = (
+  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>,
+): string | undefined =>
+  identifiers.find(function isGtinBearing({ scheme }) {
+    return isIsbnBearingScheme(scheme)
+  })?.value
+
+const webValue = (
+  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>,
+): string | undefined => {
+  const urls = identifiers.flatMap(function toWebUrl(identifier) {
+    if (
+      normalizeIdentifierScheme(identifier.scheme) === URL_IDENTIFIER_SCHEME
+    ) {
+      return [identifier.value]
+    }
+
+    const catalogUrl = catalogUrlFromIdentifier(identifier)
+
+    return catalogUrl === undefined ? [] : [catalogUrl]
+  })
+
+  return urls.length > 0 ? urls.join(" ") : undefined
+}
+
 const serializeComicInfoXml = (
   existingXml: string | undefined | null,
-  patch: ComicInfoMetadataPatch,
+  { identifiers }: ComicInfoMetadataPatch,
 ): string => {
   const parsedExisting = existingXml
     ? tryParseExistingComicInfo(existingXml)
@@ -74,7 +120,8 @@ const serializeComicInfoXml = (
     throw new Error("ComicInfo.xml root element is not <ComicInfo>")
   }
 
-  upsertChildElement(doc, root, "GTIN", patch.isbn)
+  upsertChildElement(doc, root, "GTIN", gtinValue(identifiers))
+  upsertChildElement(doc, root, "Web", webValue(identifiers))
 
   const serialized = serializeXml(doc)
 

--- a/packages/archive-metadata/src/common.ts
+++ b/packages/archive-metadata/src/common.ts
@@ -6,12 +6,18 @@ export type {
 export { isFileRecord } from "./archive/types"
 
 export type {
+  ArchiveMetadataIdentifier,
   ArchiveMetadataPatch,
   ArchiveMetadataTargets,
   ArchivePatch,
   ArchivePatchedEntry,
 } from "./metadata/write"
 export { patchArchiveMetadata } from "./metadata/write"
+export { isComicInfoWritableIdentifierScheme } from "./comicInfo"
+export {
+  UNTAGGED_IDENTIFIER_SCHEME,
+  URL_IDENTIFIER_SCHEME,
+} from "./metadata/identifiers"
 
 export type { PatchMetadataAction } from "./update/actions"
 export type {

--- a/packages/archive-metadata/src/metadata/identifiers.ts
+++ b/packages/archive-metadata/src/metadata/identifiers.ts
@@ -1,0 +1,20 @@
+import {
+  normalizeIdentifierScheme,
+  type MetadataIdentifierScheme,
+} from "@prose-reader/archive-reader"
+
+/**
+ * Scheme meaning "this identifier carries no scheme at all". The read side
+ * reports it for an untagged identifier, so writing it back as a missing
+ * scheme attribute is what keeps read → edit → write → read stable.
+ */
+export const UNTAGGED_IDENTIFIER_SCHEME = "Unknown"
+
+/** Scheme of an identifier that is itself a link. */
+export const URL_IDENTIFIER_SCHEME = "URL"
+
+export const isUntaggedIdentifierScheme = (
+  scheme: MetadataIdentifierScheme,
+): boolean =>
+  normalizeIdentifierScheme(scheme) === UNTAGGED_IDENTIFIER_SCHEME ||
+  scheme.trim() === ""

--- a/packages/archive-metadata/src/metadata/write.test.ts
+++ b/packages/archive-metadata/src/metadata/write.test.ts
@@ -48,7 +48,9 @@ const epub = () =>
     close: () => Promise.resolve(),
   })
 
-const ISBN_PATCH = { isbn: "9783161484100" }
+const ISBN_PATCH = {
+  identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+}
 
 describe("patchArchiveMetadata", () => {
   it("refuses a patch with no container to write it into", async () => {

--- a/packages/archive-metadata/src/metadata/write.ts
+++ b/packages/archive-metadata/src/metadata/write.ts
@@ -1,19 +1,39 @@
 import {
   getArchiveHasComicInfo,
   getArchiveOpfInfo,
+  type MetadataIdentifierScheme,
 } from "@prose-reader/archive-reader"
 import type { Archive } from "../archive/types"
 import { COMIC_INFO_FILENAME, buildPatchedComicInfoXml } from "../comicInfo"
 import { buildPatchedOpfXml } from "../opf/write"
 
 /**
+ * One identifier an archive should carry after the patch.
+ *
+ * `scheme` accepts any string: the containers hold arbitrary schemes and
+ * the reader reports them verbatim. Known schemes are matched
+ * case-insensitively, and `"Unknown"` means "carry no scheme".
+ *
+ * `unique` marks the identifier the OPF's `<package unique-identifier>`
+ * points at. That element is structural — the writer only ever rewrites it
+ * through this entry and never removes it, so a book keeps a resolvable
+ * unique identifier whatever the caller does with the rest of the list.
+ */
+export type ArchiveMetadataIdentifier = {
+  readonly scheme: MetadataIdentifierScheme
+  readonly value: string
+  readonly unique?: boolean
+}
+
+/**
  * Fields an archive patch may set. Expand in lockstep when a new field
  * becomes writable in at least one container.
  *
- * Today only `isbn` is writable.
+ * `identifiers` is the complete set the archive should end up with, not a
+ * delta: an identifier the containers hold but the list omits is removed.
  */
 export type ArchiveMetadataPatch = {
-  isbn?: string | undefined
+  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>
 }
 
 /**
@@ -59,6 +79,9 @@ export type ArchivePatch = {
  *  - `targets.comicInfo` → patch the existing `ComicInfo.xml` if any,
  *    otherwise synthesize a minimal one. This always succeeds and is
  *    the safe default for archives that carry no embedded metadata.
+ *    Identifiers are mapped onto `<GTIN>` and `<Web>`, so ones on a
+ *    scheme neither field represents are not written for this target
+ *    — see `isComicInfoWritableIdentifierScheme` to check up front.
  *  - `targets.opf` → patch the existing OPF package document. Throws
  *    when the archive has no OPF: synthesizing one would turn a CBZ
  *    into an EPUB, which is well outside this writer's scope.
@@ -86,7 +109,7 @@ export const patchArchiveMetadata = async (
   const entries: ArchivePatchedEntry[] = []
 
   if (targets.comicInfo) {
-    const xml = await buildPatchedComicInfoXml(archive, { isbn: patch.isbn })
+    const xml = await buildPatchedComicInfoXml(archive, patch)
     const existingComicInfo = getArchiveHasComicInfo(archive)
     entries.push({ path: existingComicInfo?.uri ?? COMIC_INFO_FILENAME, xml })
   }
@@ -100,7 +123,7 @@ export const patchArchiveMetadata = async (
       )
     }
 
-    const xml = await buildPatchedOpfXml(opfEntry, { isbn: patch.isbn })
+    const xml = await buildPatchedOpfXml(opfEntry, patch)
     entries.push({ path: opfEntry.uri, xml })
   }
 

--- a/packages/archive-metadata/src/opf/write.test.ts
+++ b/packages/archive-metadata/src/opf/write.test.ts
@@ -654,3 +654,63 @@ describe("OPF editing under an aliased namespace prefix", () => {
     ])
   })
 })
+
+describe("OPF editing an identifier that states no scheme", () => {
+  it("edits the element whose value the reader reads as an ISBN", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        `<dc:identifier id="pub-id">${UUID_IDENTIFIER}</dc:identifier>` +
+          '<dc:identifier id="isbn-id">9783161484100</dc:identifier>' +
+          '<meta refines="#isbn-id" property="display-seq">1</meta>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [
+        { scheme: "Unknown", value: UUID_IDENTIFIER, unique: true },
+        { scheme: "ISBN", value: "9780306406157" },
+      ],
+    })
+
+    expect(readOpfIsbn(xml)).toBe("9780306406157")
+    expect(xml).toContain('id="isbn-id"')
+    expect(xml).toContain('refines="#isbn-id"')
+    expect(readOpfIdentifiers(xml)).toHaveLength(2)
+  })
+
+  it("leaves an element whose value announces nothing untagged", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf('<dc:identifier id="catalog-id">catalog-42</dc:identifier>'),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "Unknown", value: "catalog-99" }],
+    })
+
+    expect(xml).toContain('id="catalog-id"')
+    expect(xml).not.toContain("scheme=")
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "catalog-99", scheme: "Unknown" },
+    ])
+  })
+
+  it("does not hand a bare UUID to a patched ISBN", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(`<dc:identifier id="uuid-id">${UUID_IDENTIFIER}</dc:identifier>`),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [
+        { scheme: "Unknown", value: UUID_IDENTIFIER },
+        { scheme: "ISBN", value: "9783161484100" },
+      ],
+    })
+
+    expect(xml).toContain(UUID_IDENTIFIER)
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(readOpfIdentifiers(xml)).toHaveLength(2)
+  })
+})

--- a/packages/archive-metadata/src/opf/write.test.ts
+++ b/packages/archive-metadata/src/opf/write.test.ts
@@ -5,6 +5,7 @@ import {
   identifierValue,
   parseOpf,
   resolveArchiveMetadata,
+  type ResolvedMetadataIdentifier,
 } from "@prose-reader/archive-reader"
 import type { ArchiveFileRecord } from "../archive/types"
 import { buildPatchedOpfXml } from "./write"
@@ -39,25 +40,34 @@ const makeEntry = (uri: string, body: string): ArchiveFileRecord => ({
   ...arrayBufferFileAccessors(() => Promise.resolve(toArrayBuffer(body))),
 })
 
+const UUID_IDENTIFIER = "urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809"
+
 const readOpfMetadata = (xml: string) => resolveArchiveMetadata(parseOpf(xml))
 
 const readOpfIsbn = (xml: string): string | undefined =>
   identifierValue(readOpfMetadata(xml).identifiers, "ISBN")
+
+const readOpfIdentifiers = (
+  xml: string,
+): ReadonlyArray<ResolvedMetadataIdentifier> =>
+  readOpfMetadata(xml).identifiers ?? []
 
 describe("OPF editing (buildPatchedOpfXml)", () => {
   it('inserts a new opf:scheme="ISBN" identifier when the metadata had none', async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
+        `<dc:identifier id="pub-id">${UUID_IDENTIFIER}</dc:identifier>` +
           "<dc:title>Sample</dc:title>",
       ),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIsbn(xml)).toBe("9783161484100")
-    expect(xml).toContain("urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809")
+    expect(xml).toContain(UUID_IDENTIFIER)
     expect(xml).toContain("<dc:title>Sample</dc:title>")
   })
 
@@ -65,12 +75,14 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
+        `<dc:identifier id="pub-id">${UUID_IDENTIFIER}</dc:identifier>` +
           '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>',
       ),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIsbn(xml)).toBe("9783161484100")
     expect(xml).not.toContain("0000000000")
@@ -82,79 +94,272 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
       opf('<dc:identifier opf:scheme="isbn">0000000000</dc:identifier>'),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIsbn(xml)).toBe("9783161484100")
     expect(xml).not.toContain("0000000000")
   })
 
-  it('matches a bare scheme="ISBN" attribute when updating', async () => {
+  it('reuses a bare scheme="ISBN" attribute rather than switching spelling', async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf('<dc:identifier scheme="ISBN">0000000000</dc:identifier>'),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(xml).toContain('scheme="ISBN"')
+    expect(xml).not.toContain("opf:scheme")
     expect(xml).not.toContain("0000000000")
   })
 
-  it("never touches a UUID identifier carrying the unique-identifier id", async () => {
+  it("writes an identifier on any scheme the caller asks for", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
-      opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>',
-      ),
+      opf("<dc:title>Sample</dc:title>"),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [
+        { scheme: "ISBN", value: "9783161484100" },
+        { scheme: "GoogleBooks", value: "zyTCAlFPjgYC" },
+        { scheme: "AcmeCatalog", value: "acme-42" },
+      ],
+    })
 
-    expect(xml).toContain("urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809")
-    expect(xml).toContain('id="pub-id"')
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "9783161484100", scheme: "ISBN" },
+      { value: "zyTCAlFPjgYC", scheme: "GoogleBooks" },
+      { value: "acme-42", scheme: "AcmeCatalog" },
+    ])
   })
 
-  it("removes the ISBN identifier when the patch clears it with undefined", async () => {
+  it("normalizes a known scheme to its canonical casing", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
-      opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
-          '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
-      ),
+      opf("<dc:title>Sample</dc:title>"),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: undefined })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "googlebooks", value: "zyTCAlFPjgYC" }],
+    })
 
-    expect(readOpfIsbn(xml)).toBeUndefined()
-    expect(xml).toContain("urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809")
+    expect(xml).toContain('opf:scheme="GoogleBooks"')
   })
 
-  it("removes the ISBN identifier when the patch clears it with an empty string", async () => {
+  it("writes an untagged identifier when the scheme is Unknown", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf('<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>'),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "Unknown", value: "custom-id" }],
+    })
 
-    expect(readOpfIsbn(xml)).toBeUndefined()
+    expect(xml).toContain("<dc:identifier>custom-id</dc:identifier>")
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "custom-id", scheme: "Unknown" },
+    ])
   })
 
-  it("does nothing when clearing an already-absent ISBN", async () => {
+  it("removes the identifiers the patch leaves out", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>',
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>' +
+          '<dc:identifier opf:scheme="DOI">10.1000/182</dc:identifier>',
       ),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: undefined })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "DOI", value: "10.1000/182" }],
+    })
 
-    expect(readOpfIsbn(xml)).toBeUndefined()
-    expect(xml).toContain("urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809")
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "10.1000/182", scheme: "DOI" },
+    ])
+    expect(xml).not.toContain("9783161484100")
   })
 
-  it("preserves unrelated metadata fields when inserting an ISBN", async () => {
+  it("removes every identifier when the patch carries none", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf('<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>'),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, { identifiers: [] })
+
+    expect(readOpfIdentifiers(xml)).toEqual([])
+  })
+
+  it("keeps several identifiers sharing one scheme", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf('<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>'),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [
+        { scheme: "ISBN", value: "9783161484100" },
+        { scheme: "ISBN", value: "9780306406157" },
+      ],
+    })
+
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "9783161484100", scheme: "ISBN" },
+      { value: "9780306406157", scheme: "ISBN" },
+    ])
+  })
+
+  it("reuses the element of a scheme so refining metadata keeps resolving", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier id="isbn-id" opf:scheme="ISBN">0000000000</dc:identifier>' +
+          '<meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15</meta>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
+
+    expect(xml).toContain('id="isbn-id"')
+    expect(xml).toContain('refines="#isbn-id"')
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+  })
+
+  it("binds the scheme attribute when the package omits the opf prefix", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      '<?xml version="1.0" encoding="utf-8"?>' +
+        '<package xmlns="http://www.idpf.org/2007/opf"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' version="3.0" unique-identifier="pub-id">' +
+        `<metadata><dc:identifier id="pub-id">${UUID_IDENTIFIER}</dc:identifier></metadata>` +
+        "<manifest/><spine/>" +
+        "</package>",
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [
+        { scheme: "Unknown", value: UUID_IDENTIFIER, unique: true },
+        { scheme: "ISBN", value: "9783161484100" },
+      ],
+    })
+
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    // Re-patching parses the output again, which a document carrying an
+    // unbound prefix would fail.
+    const repatched = await buildPatchedOpfXml(
+      makeEntry("OEBPS/content.opf", xml),
+      { identifiers: readOpfIdentifiers(xml) },
+    )
+
+    expect(readOpfIsbn(repatched)).toBe("9783161484100")
+  })
+
+  it("matches an identifier typed only by a refining meta", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier id="gb">zyTCAlFPjgYC</dc:identifier>' +
+          '<meta refines="#gb" property="identifier-type">GoogleBooks</meta>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "GoogleBooks", value: "otherVolumeId" }],
+    })
+
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "otherVolumeId", scheme: "GoogleBooks" },
+    ])
+    expect(xml).toContain('id="gb"')
+    expect(xml).toContain('refines="#gb"')
+  })
+
+  it("matches an identifier typed by an ONIX identifier-type code", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier id="isbn">0000000000</dc:identifier>' +
+          '<meta refines="#isbn" property="identifier-type" scheme="onix:codelist5">15</meta>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
+
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "9783161484100", scheme: "ISBN" },
+    ])
+    expect(xml).toContain('id="isbn"')
+  })
+
+  it("removes the metadata refining an identifier it deletes", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>' +
+          '<dc:identifier id="doomed" opf:scheme="DOI">10.1000/182</dc:identifier>' +
+          '<meta refines="#doomed" property="identifier-type">DOI</meta>' +
+          '<meta refines="#doomed" property="display-seq">2</meta>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
+
+    expect(xml).not.toContain("10.1000/182")
+    expect(xml).not.toContain('refines="#doomed"')
+  })
+
+  it("never removes the unique-identifier element the patch leaves out", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(`<dc:identifier id="pub-id">${UUID_IDENTIFIER}</dc:identifier>`),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
+
+    expect(xml).toContain(UUID_IDENTIFIER)
+    expect(xml).toContain('id="pub-id"')
+  })
+
+  it("rewrites the unique-identifier element through the entry marked unique", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier id="pub-id" opf:scheme="ISBN">0000000000</dc:identifier>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [
+        { scheme: "ISBN", value: "9783161484100", unique: true },
+        { scheme: "GoogleBooks", value: "zyTCAlFPjgYC" },
+      ],
+    })
+
+    expect(xml).toContain('id="pub-id"')
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "9783161484100", scheme: "ISBN", unique: true },
+      { value: "zyTCAlFPjgYC", scheme: "GoogleBooks" },
+    ])
+  })
+
+  it("preserves unrelated metadata fields when inserting an identifier", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf(
@@ -165,7 +370,9 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
       ),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfMetadata(xml)).toMatchObject({
       titles: [{ value: "Norwegian Wood" }],
@@ -176,7 +383,7 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
     expect(readOpfIsbn(xml)).toBe("9783161484100")
   })
 
-  it("preserves manifest and spine when inserting an ISBN", async () => {
+  it("preserves manifest and spine when inserting an identifier", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf("<dc:title>Sample</dc:title>", {
@@ -187,7 +394,9 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
       }),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIsbn(xml)).toBe("9783161484100")
     expect(xml).toContain(
@@ -209,7 +418,9 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
         "</package>",
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(xml.startsWith("<?xml")).toBe(true)
   })
@@ -221,7 +432,9 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
     )
 
     await expect(
-      buildPatchedOpfXml(entry, { isbn: "9783161484100" }),
+      buildPatchedOpfXml(entry, {
+        identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+      }),
     ).rejects.toThrow(/root element is not <package>/i)
   })
 
@@ -238,7 +451,9 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
     )
 
     await expect(
-      buildPatchedOpfXml(entry, { isbn: "9783161484100" }),
+      buildPatchedOpfXml(entry, {
+        identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+      }),
     ).rejects.toThrow(/has no <metadata> element/i)
   })
 
@@ -246,48 +461,37 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
     const entry = makeEntry("OEBPS/content.opf", "<package><metadata>")
 
     await expect(
-      buildPatchedOpfXml(entry, { isbn: "9783161484100" }),
+      buildPatchedOpfXml(entry, {
+        identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+      }),
     ).rejects.toThrow(/OPF is malformed/i)
   })
 
-  it("round-trips: the patched output parses back to the patched ISBN", async () => {
+  it("round-trips: patching the output again is a no-op", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
-      opf("<dc:title>Sample</dc:title>"),
+      opf(`<dc:identifier id="pub-id">${UUID_IDENTIFIER}</dc:identifier>`),
+    )
+    const identifiers = [
+      { scheme: "Unknown", value: UUID_IDENTIFIER, unique: true },
+      { scheme: "GoogleBooks", value: "zyTCAlFPjgYC" },
+    ]
+
+    const xml = await buildPatchedOpfXml(entry, { identifiers })
+    const repatched = await buildPatchedOpfXml(
+      makeEntry("OEBPS/content.opf", xml),
+      { identifiers: readOpfIdentifiers(xml) },
     )
 
-    const xml = await buildPatchedOpfXml(entry, {
-      isbn: "9783161484100",
-    })
-
-    expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(readOpfIdentifiers(repatched)).toEqual(readOpfIdentifiers(xml))
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: UUID_IDENTIFIER, scheme: "Unknown", unique: true },
+      { value: "zyTCAlFPjgYC", scheme: "GoogleBooks" },
+    ])
   })
 })
 
 describe("OPF editing across container spellings", () => {
-  const reparse = (xml: string): Document => {
-    const doc = new DOMParser().parseFromString(xml, "application/xml")
-    const error = doc.getElementsByTagName("parsererror").item(0)
-
-    if (error) throw new Error(`malformed: ${error.textContent}`)
-
-    return doc
-  }
-
-  it("binds the namespaces of an identifier it creates", async () => {
-    const entry = makeEntry(
-      "OEBPS/content.opf",
-      '<?xml version="1.0" encoding="utf-8"?>' +
-        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id">' +
-        "<metadata/><manifest/><spine/></package>",
-    )
-
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
-
-    expect(() => reparse(xml)).not.toThrow()
-    expect(readOpfIsbn(xml)).toBe("9783161484100")
-  })
-
   it("patches a package that prefixes the OPF namespace", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
@@ -299,7 +503,9 @@ describe("OPF editing across container spellings", () => {
         "<opf:manifest/><opf:spine/></opf:package>",
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIsbn(xml)).toBe("9783161484100")
     expect(xml).toContain("<dc:title>Sample</dc:title>")
@@ -317,27 +523,53 @@ describe("OPF editing across container spellings", () => {
         "</metadata><manifest/><spine/></package>",
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(readOpfIdentifiers(xml)).toHaveLength(1)
     expect(xml).not.toContain("0000000000")
   })
 
-  it("matches a capitalized opf:Scheme attribute when updating", async () => {
+  it("reuses a capitalized opf:Scheme attribute rather than switching spelling", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf('<dc:identifier opf:Scheme="ISBN">0000000000</dc:identifier>'),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIsbn(xml)).toBe("9783161484100")
+    expect(readOpfIdentifiers(xml)).toHaveLength(1)
+    expect(xml).toContain("opf:Scheme")
     expect(xml).not.toContain("0000000000")
   })
 })
 
-describe("OPF editing with refinement-typed identifiers", () => {
-  it("updates an identifier typed by an ONIX identifier-type refinement", async () => {
+describe("OPF editing alongside a valueless identifier element", () => {
+  it("reconciles onto the tagged element and drops the empty one", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        "<dc:identifier></dc:identifier>" +
+          '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
+
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "9783161484100", scheme: "ISBN" },
+    ])
+    expect(xml).not.toContain("0000000000")
+  })
+
+  it("keeps a scheme stated by an ONIX refinement on the element it refines", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf(
@@ -346,120 +578,79 @@ describe("OPF editing with refinement-typed identifiers", () => {
       ),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIsbn(xml)).toBe("9783161484100")
-    expect(xml).not.toContain("0000000000")
-    expect(readOpfMetadata(xml).identifiers).toHaveLength(1)
-  })
-
-  it("updates an identifier typed by a literal identifier-type refinement", async () => {
-    const entry = makeEntry(
-      "OEBPS/content.opf",
-      opf(
-        '<dc:identifier id="book-id">0000000000</dc:identifier>' +
-          '<meta refines="#book-id" property="identifier-type">ISBN</meta>',
-      ),
-    )
-
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
-
-    expect(readOpfIsbn(xml)).toBe("9783161484100")
-    expect(readOpfMetadata(xml).identifiers).toHaveLength(1)
-  })
-
-  it("removes the metadata refining an identifier it deletes", async () => {
-    const entry = makeEntry(
-      "OEBPS/content.opf",
-      opf(
-        '<dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809</dc:identifier>' +
-          '<dc:identifier id="isbn-id" opf:scheme="ISBN">9783161484100</dc:identifier>' +
-          '<meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15</meta>',
-      ),
-    )
-
-    const xml = await buildPatchedOpfXml(entry, { isbn: undefined })
-
-    expect(readOpfIsbn(xml)).toBeUndefined()
-    expect(xml).not.toContain('refines="#isbn-id"')
-    expect(xml).toContain("urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809")
-  })
-
-  it("keeps the identifier the package points at when clearing the ISBN", async () => {
-    const entry = makeEntry(
-      "OEBPS/content.opf",
-      opf(
-        '<dc:identifier id="pub-id" opf:scheme="ISBN">9783161484100</dc:identifier>',
-      ),
-    )
-
-    const xml = await buildPatchedOpfXml(entry, { isbn: undefined })
-
-    expect(xml).toContain('id="pub-id"')
-    expect(xml).toContain("9783161484100")
+    expect(readOpfIdentifiers(xml)).toHaveLength(1)
+    expect(xml).toContain('id="book-id"')
+    expect(xml).toContain('refines="#book-id"')
   })
 })
 
-describe("OPF editing alongside empty identifier elements", () => {
-  it("updates the ISBN rather than an empty element sitting before it", async () => {
+describe("OPF editing under an aliased namespace prefix", () => {
+  const aliased = (metadata: string) =>
+    '<?xml version="1.0" encoding="utf-8"?>' +
+    '<package xmlns="http://www.idpf.org/2007/opf"' +
+    ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+    ' xmlns:pkg="http://www.idpf.org/2007/opf"' +
+    ' version="3.0" unique-identifier="pub-id">' +
+    `<metadata>${metadata}</metadata><manifest/><spine/></package>`
+
+  it("rewrites the aliased element rather than adding one beside it", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
-      '<?xml version="1.0" encoding="utf-8"?>' +
-        '<package xmlns="http://www.idpf.org/2007/opf"' +
-        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-        ' xmlns:opf="http://www.idpf.org/2007/opf"' +
-        ' version="3.0" unique-identifier="pub-id">' +
-        "<metadata>" +
-        "<dc:identifier></dc:identifier>" +
-        '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>' +
-        "</metadata><manifest/><spine/></package>",
+      aliased(
+        '<dc:identifier id="isbn-id" pkg:scheme="ISBN">9783161484100</dc:identifier>' +
+          '<meta refines="#isbn-id" property="display-seq">1</meta>',
+      ),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9780306406157" }],
+    })
 
-    expect(readOpfIsbn(xml)).toBe("9783161484100")
-    expect(xml).not.toContain("0000000000")
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "9780306406157", scheme: "ISBN" },
+    ])
+    expect(xml).toContain('id="isbn-id"')
+    expect(xml).toContain('refines="#isbn-id"')
+    expect(xml.match(/scheme="/g)).toHaveLength(1)
   })
 
-  it("removes the ISBN rather than an empty element sitting before it", async () => {
+  it("clears an aliased scheme when the identifier becomes untagged", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
-      '<?xml version="1.0" encoding="utf-8"?>' +
-        '<package xmlns="http://www.idpf.org/2007/opf"' +
-        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-        ' xmlns:opf="http://www.idpf.org/2007/opf"' +
-        ' version="3.0" unique-identifier="pub-id">' +
-        "<metadata>" +
-        "<dc:identifier></dc:identifier>" +
-        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>' +
-        "</metadata><manifest/><spine/></package>",
+      aliased('<dc:identifier pkg:scheme="ISBN">9783161484100</dc:identifier>'),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: undefined })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "Unknown", value: "catalog-42" }],
+    })
 
-    expect(readOpfIsbn(xml)).toBeUndefined()
-    expect(xml).not.toContain("9783161484100")
+    expect(xml).not.toContain("scheme=")
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "catalog-42", scheme: "Unknown" },
+    ])
   })
-})
 
-describe("OPF editing alongside identifiers the parser drops", () => {
-  it("updates the ISBN rather than an element holding only a nested element", async () => {
+  it("writes a non-inferrable scheme a package with no opf prefix reads back", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       '<?xml version="1.0" encoding="utf-8"?>' +
         '<package xmlns="http://www.idpf.org/2007/opf"' +
         ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
-        ' xmlns:opf="http://www.idpf.org/2007/opf"' +
         ' version="3.0" unique-identifier="pub-id">' +
-        "<metadata>" +
-        "<dc:identifier><span>ignored</span></dc:identifier>" +
-        '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>' +
-        "</metadata><manifest/><spine/></package>",
+        "<metadata/><manifest/><spine/></package>",
     )
 
-    const xml = await buildPatchedOpfXml(entry, { isbn: "9783161484100" })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "GoogleBooks", value: "zyTCAlFPjgYC" }],
+    })
 
-    expect(readOpfIsbn(xml)).toBe("9783161484100")
-    expect(xml).not.toContain("0000000000")
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "zyTCAlFPjgYC", scheme: "GoogleBooks" },
+    ])
   })
 })

--- a/packages/archive-metadata/src/opf/write.ts
+++ b/packages/archive-metadata/src/opf/write.ts
@@ -1,4 +1,5 @@
 import {
+  inferIdentifierScheme,
   normalizeIdentifierScheme,
   OPF_IDENTIFIER_SCHEME_ATTRIBUTES,
   OPF_IDENTIFIER_SCHEME_LOCAL_NAMES,
@@ -170,12 +171,18 @@ const schemeSink = (
   return meta === undefined ? undefined : { kind: "refinement", meta }
 }
 
+/**
+ * The scheme an element is read as, which for one that states none is the one
+ * its value announces — the reader infers a bare Bookland number as an `ISBN`,
+ * so an element holding one has to match a patched `ISBN` rather than look
+ * untagged and be replaced.
+ */
 const elementScheme = (metadata: XmlElement, element: XmlElement): string => {
   const sink = schemeSink(metadata, element)
 
   switch (sink?.kind) {
     case undefined:
-      return ""
+      return inferIdentifierScheme(element.textContent ?? "")
     case "namespaced":
       return element.getAttributeNS(OPF_NAMESPACE, sink.localName)?.trim() ?? ""
     case "attribute":

--- a/packages/archive-metadata/src/opf/write.ts
+++ b/packages/archive-metadata/src/opf/write.ts
@@ -1,11 +1,14 @@
 import {
-  parseOpf,
+  normalizeIdentifierScheme,
+  OPF_IDENTIFIER_SCHEME_ATTRIBUTES,
+  OPF_IDENTIFIER_SCHEME_LOCAL_NAMES,
+  OPF_NAMESPACE,
+  opfIdentifierTypeScheme,
   readRecordAsText,
-  resolveArchiveMetadata,
-  type OpfIdentifier,
-  type ResolvedMetadataIdentifier,
 } from "@prose-reader/archive-reader"
 import type { ArchiveFileRecord } from "../archive/types"
+import type { ArchiveMetadataIdentifier } from "../metadata/write"
+import { isUntaggedIdentifierScheme } from "../metadata/identifiers"
 import {
   type XmlDocument,
   type XmlElement,
@@ -19,23 +22,19 @@ import {
  * a round-trip contract (read → mutate → re-read returns the same
  * value) we need to keep working across EPUB producers.
  *
- * Today only `isbn` is writable. Adding a new field means deciding
- * which OPF element it maps to *and* updating the ISBN-style
- * "find existing or create" logic for that element.
+ * Today only `identifiers` is writable. Adding a new field means
+ * deciding which OPF element it maps to *and* giving it the same
+ * "find existing or create" reconciliation identifiers get.
  */
 export type OpfMetadataPatch = {
-  isbn?: string | undefined
+  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>
 }
 
 const OPF_LABEL = "OPF"
 
 const DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
 
-const OPF_NAMESPACE = "http://www.idpf.org/2007/opf"
-
 const IDENTIFIER_ELEMENT_NAME = "dc:identifier"
-
-const ISBN_SCHEME = "ISBN"
 
 /**
  * Apply a metadata patch to an existing OPF package document and
@@ -57,36 +56,6 @@ export const buildPatchedOpfXml = async (
   return serializeOpfXml(xml, patch)
 }
 
-/**
- * Which identifier the writer should touch is the reader's decision, not one
- * this writer re-derives: `parseOpf` reports each element verbatim — including
- * the `id` that addresses it — and `resolveArchiveMetadata` says what scheme
- * the book ends up advertising for it, across every spelling of the scheme
- * attribute and the EPUB 3 `identifier-type` refinements. Reading the document
- * any other way is how a writer ends up editing an element the reader does not
- * report, or appending a second one beside it.
- *
- * The two lists are index-aligned: the resolver maps over the parsed
- * identifiers one to one.
- */
-type ReaderIdentifier = {
-  readonly parsed: OpfIdentifier
-  readonly resolved: ResolvedMetadataIdentifier
-}
-
-const readerIdentifiers = (xml: string): ReadonlyArray<ReaderIdentifier> => {
-  const parsed = parseOpf(xml)
-  const resolved = resolveArchiveMetadata(parsed).identifiers ?? []
-
-  return parsed.identifiers.flatMap(function pairWithResolved(entry, index) {
-    const counterpart = resolved[index]
-
-    return counterpart === undefined
-      ? []
-      : [{ parsed: entry, resolved: counterpart }]
-  })
-}
-
 const serializeOpfXml = (xml: string, patch: OpfMetadataPatch): string => {
   const doc = parseXml(xml, OPF_LABEL)
   const root = doc.documentElement
@@ -101,7 +70,7 @@ const serializeOpfXml = (xml: string, patch: OpfMetadataPatch): string => {
     throw new Error("OPF document has no <metadata> element")
   }
 
-  upsertIsbnIdentifier(doc, metadata, readerIdentifiers(xml), patch.isbn)
+  reconcileIdentifiers(doc, root, metadata, patch.identifiers)
 
   const serialized = serializeXml(doc)
 
@@ -113,7 +82,7 @@ const serializeOpfXml = (xml: string, patch: OpfMetadataPatch): string => {
 /**
  * Elements are matched by local name, the same way the read side does, so a
  * document that prefixes the OPF namespace — or leaves `<identifier>`
- * unprefixed under a default one — stays one this writer can update rather
+ * unprefixed under a default one — stays one this writer can reconcile rather
  * than reject or duplicate into.
  */
 const localName = (tagName: string): string =>
@@ -133,128 +102,245 @@ const findChildByLocalName = (
 ): XmlElement | undefined => listChildrenByLocalName(parent, name)[0]
 
 /**
- * An element's own text, excluding any nested element's — the value the parser
- * reads. `textContent` would fold descendants in, and disagreeing with the
- * parser about which elements have a value is what shifts the positions below.
+ * Where an element's scheme is stated. EPUB 2 puts it on the identifier, EPUB 3
+ * refines it from a sibling `<meta>` — a rewrite keeps whichever the document
+ * chose, so the two never end up contradicting each other.
  */
-const directText = (element: XmlElement): string =>
-  Array.from(element.childNodes)
-    .filter(function isTextual(node) {
-      return (
-        node.nodeType === Node.TEXT_NODE ||
-        node.nodeType === Node.CDATA_SECTION_NODE
-      )
-    })
-    .map(function nodeText(node) {
-      return node.nodeValue ?? ""
-    })
-    .join("")
+type SchemeSink =
+  | { readonly kind: "namespaced"; readonly localName: string }
+  | { readonly kind: "attribute"; readonly name: string }
+  | { readonly kind: "refinement"; readonly meta: XmlElement }
 
-/**
- * The identifier elements the parser reports, in its order. Valueless elements
- * are skipped because the parser drops them, and one authored empty — or
- * holding only a nested element — would otherwise shift every position after
- * it.
- */
-const identifierElements = (metadata: XmlElement): XmlElement[] =>
-  listChildrenByLocalName(metadata, "identifier").filter(
-    function statesAValue(element) {
-      return directText(element).trim() !== ""
+const refiningMetas = (metadata: XmlElement, id: string): XmlElement[] =>
+  id === ""
+    ? []
+    : listChildrenByLocalName(metadata, "meta").filter(
+        function refinesElement(meta) {
+          return meta.getAttribute("refines")?.trim() === `#${id}`
+        },
+      )
+
+const identifierTypeMeta = (
+  metadata: XmlElement,
+  element: XmlElement,
+): XmlElement | undefined =>
+  refiningMetas(metadata, element.getAttribute("id")?.trim() ?? "").find(
+    function statesIdentifierType(meta) {
+      return meta.getAttribute("property")?.trim() === "identifier-type"
     },
   )
 
+const metaIdentifierType = (meta: XmlElement): string =>
+  opfIdentifierTypeScheme({
+    value: meta.textContent ?? "",
+    scheme: meta.getAttribute("scheme") ?? "",
+  }) ?? ""
+
 /**
- * The element the reader read an identifier from. An `id` addresses it exactly;
- * an identifier authored without one has only its position among the identifier
- * elements, which is the order the parser reported it in.
+ * Where an element already states its scheme, preferring the namespace over the
+ * spelling: a package may bind the OPF namespace to any prefix, and a rewrite
+ * has to land on the attribute the reader read rather than beside it.
+ *
+ * The literal `opf:`-prefixed names are still tried, for a package that uses
+ * the prefix without declaring it — invalid, but the read side tolerates it, so
+ * the write side has to find the same attribute.
  */
-const findIdentifierElement = (
+const schemeSink = (
   metadata: XmlElement,
-  { parsed }: ReaderIdentifier,
-  index: number,
-): XmlElement | undefined => {
-  const elements = identifierElements(metadata)
-
-  if (parsed.id === undefined) return elements[index]
-
-  return (
-    elements.find(function carriesId(element) {
-      return element.getAttribute("id")?.trim() === parsed.id
-    }) ?? elements[index]
+  element: XmlElement,
+): SchemeSink | undefined => {
+  const localName = OPF_IDENTIFIER_SCHEME_LOCAL_NAMES.find(
+    function isCarriedInNamespace(name) {
+      return (element.getAttributeNS(OPF_NAMESPACE, name)?.trim() ?? "") !== ""
+    },
   )
+
+  if (localName !== undefined) return { kind: "namespaced", localName }
+
+  const attribute = OPF_IDENTIFIER_SCHEME_ATTRIBUTES.find(
+    function isCarriedLiterally(name) {
+      return (element.getAttribute(name)?.trim() ?? "") !== ""
+    },
+  )
+
+  if (attribute !== undefined) return { kind: "attribute", name: attribute }
+
+  const meta = identifierTypeMeta(metadata, element)
+
+  return meta === undefined ? undefined : { kind: "refinement", meta }
 }
 
-const isbnIdentifierIndex = (
-  identifiers: ReadonlyArray<ReaderIdentifier>,
-): number =>
-  identifiers.findIndex(function resolvesAsIsbn({ resolved }) {
-    return resolved.scheme === ISBN_SCHEME
-  })
+const elementScheme = (metadata: XmlElement, element: XmlElement): string => {
+  const sink = schemeSink(metadata, element)
+
+  switch (sink?.kind) {
+    case undefined:
+      return ""
+    case "namespaced":
+      return element.getAttributeNS(OPF_NAMESPACE, sink.localName)?.trim() ?? ""
+    case "attribute":
+      return element.getAttribute(sink.name)?.trim() ?? ""
+    case "refinement":
+      return metaIdentifierType(sink.meta)
+  }
+}
+
+const schemeKey = (scheme: string): string =>
+  isUntaggedIdentifierScheme(scheme) ? "" : scheme.trim().toLowerCase()
+
+const clearScheme = (metadata: XmlElement, element: XmlElement): void => {
+  for (const localName of OPF_IDENTIFIER_SCHEME_LOCAL_NAMES) {
+    element.removeAttributeNS(OPF_NAMESPACE, localName)
+    element.removeAttribute(localName)
+  }
+
+  for (const attribute of OPF_IDENTIFIER_SCHEME_ATTRIBUTES) {
+    element.removeAttribute(attribute)
+  }
+
+  const meta = identifierTypeMeta(metadata, element)
+
+  if (meta) metadata.removeChild(meta)
+}
+
+const writeIdentifier = (
+  metadata: XmlElement,
+  element: XmlElement,
+  { scheme, value }: ArchiveMetadataIdentifier,
+): void => {
+  element.textContent = value
+
+  if (isUntaggedIdentifierScheme(scheme)) {
+    clearScheme(metadata, element)
+
+    return
+  }
+
+  const normalized = normalizeIdentifierScheme(scheme)
+  const sink = schemeSink(metadata, element)
+
+  switch (sink?.kind) {
+    case "refinement":
+      sink.meta.textContent = normalized
+      sink.meta.removeAttribute("scheme")
+
+      return
+    /**
+     * Addressed by namespace and local name, which rewrites the value of the
+     * attribute already there and leaves whichever prefix the package chose
+     * for it alone.
+     */
+    case "namespaced":
+      element.setAttributeNS(OPF_NAMESPACE, sink.localName, normalized)
+
+      return
+    case "attribute":
+      element.setAttribute(sink.name, normalized)
+
+      return
+    /**
+     * Bound rather than set as a plain `opf:scheme` name: a package that uses
+     * the OPF namespace by default need not declare the legacy prefix, and an
+     * unbound one serializes into a document that no longer parses.
+     */
+    case undefined:
+      element.setAttributeNS(OPF_NAMESPACE, "opf:scheme", normalized)
+
+      return
+  }
+}
 
 /**
  * Removes an identifier along with the metadata refining it, which would
  * otherwise be left pointing at an id the package no longer has.
  */
-const removeIdentifier = (
-  metadata: XmlElement,
-  element: XmlElement,
-  refinedBy: ReadonlyArray<string>,
-): void => {
-  for (const meta of listChildrenByLocalName(metadata, "meta")) {
-    if (refinedBy.includes(meta.getAttribute("refines")?.trim() ?? "")) {
-      metadata.removeChild(meta)
-    }
+const removeIdentifier = (metadata: XmlElement, element: XmlElement): void => {
+  for (const meta of refiningMetas(
+    metadata,
+    element.getAttribute("id")?.trim() ?? "",
+  )) {
+    metadata.removeChild(meta)
   }
 
   metadata.removeChild(element)
 }
 
-const refinementTargets = ({ parsed }: ReaderIdentifier): string[] =>
-  parsed.id === undefined ? [] : [`#${parsed.id}`, parsed.id]
-
-// Untagged `<dc:identifier>` elements may be the publication UUID
-// referenced by `<package unique-identifier>`; only ISBN-tagged
-// identifiers are touched.
-const upsertIsbnIdentifier = (
-  doc: XmlDocument,
+const groupBySchemeKey = (
   metadata: XmlElement,
-  identifiers: ReadonlyArray<ReaderIdentifier>,
-  isbn: string | undefined,
+  elements: ReadonlyArray<XmlElement>,
+): Map<string, XmlElement[]> => {
+  const groups = new Map<string, XmlElement[]>()
+
+  for (const element of elements) {
+    const key = schemeKey(elementScheme(metadata, element))
+    const group = groups.get(key)
+
+    if (group) group.push(element)
+    else groups.set(key, [element])
+  }
+
+  return groups
+}
+
+const findUniqueIdentifierElement = (
+  root: XmlElement,
+  elements: ReadonlyArray<XmlElement>,
+): XmlElement | undefined => {
+  const uniqueIdentifierId = root.getAttribute("unique-identifier")?.trim()
+
+  if (uniqueIdentifierId === undefined || uniqueIdentifierId === "") {
+    return undefined
+  }
+
+  return elements.find(function carriesUniqueIdentifierId(element) {
+    return element.getAttribute("id")?.trim() === uniqueIdentifierId
+  })
+}
+
+/**
+ * Rewrites the document's identifiers so it ends up carrying exactly the
+ * patched set, reusing the existing element of a scheme rather than replacing
+ * it — an element may be the target of `<meta refines>` entries, and its `id`
+ * has to survive an edit for those to keep resolving.
+ */
+const reconcileIdentifiers = (
+  doc: XmlDocument,
+  root: XmlElement,
+  metadata: XmlElement,
+  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>,
 ): void => {
-  const index = isbnIdentifierIndex(identifiers)
-  const existing = identifiers[index]
-  const element =
-    existing === undefined
-      ? undefined
-      : findIdentifierElement(metadata, existing, index)
+  const elements = listChildrenByLocalName(metadata, "identifier")
+  const uniqueElement = findUniqueIdentifierElement(root, elements)
+  const uniqueIdentifier = identifiers.find(function isPinnedToUniqueElement({
+    unique,
+  }) {
+    return unique === true
+  })
 
-  if (isbn === undefined || isbn === "") {
-    /**
-     * The element `<package unique-identifier>` names is structural: removing
-     * it leaves the reference dangling. Untagging it would buy nothing either,
-     * since the reader infers ISBN from a bare ISBN value.
-     */
-    if (existing && element && existing.resolved.unique !== true) {
-      removeIdentifier(metadata, element, refinementTargets(existing))
-    }
-
-    return
+  if (uniqueElement && uniqueIdentifier) {
+    writeIdentifier(metadata, uniqueElement, uniqueIdentifier)
   }
 
-  if (element) {
-    element.textContent = isbn
+  const reusable = groupBySchemeKey(
+    metadata,
+    elements.filter(function isReconcilable(element) {
+      return element !== uniqueElement
+    }),
+  )
 
-    return
+  for (const identifier of identifiers) {
+    if (identifier === uniqueIdentifier && uniqueElement) continue
+
+    const element =
+      reusable.get(schemeKey(identifier.scheme))?.shift() ??
+      metadata.appendChild(
+        doc.createElementNS(DC_NAMESPACE, IDENTIFIER_ELEMENT_NAME),
+      )
+
+    writeIdentifier(metadata, element, identifier)
   }
 
-  /**
-   * Created and tagged through the namespace rather than by prefixed name: a
-   * package that uses the OPF namespace by default need not declare the legacy
-   * `opf` prefix, and an unbound one serializes into a document that no longer
-   * parses.
-   */
-  const next = doc.createElementNS(DC_NAMESPACE, IDENTIFIER_ELEMENT_NAME)
-  next.setAttributeNS(OPF_NAMESPACE, "opf:scheme", ISBN_SCHEME)
-  next.textContent = isbn
-  metadata.appendChild(next)
+  for (const leftovers of reusable.values()) {
+    for (const element of leftovers) removeIdentifier(metadata, element)
+  }
 }


### PR DESCRIPTION
Split out of #586, which was doing two things at once. This is the format and container mapping; #586 becomes just the UI on top of it.

## What changes

`ArchiveMetadataPatch` carried a single `isbn`, so the writers could only ever touch one identifier, and only one they already recognized. It now carries **the identifiers the archive should end up with**, on any scheme.

**OPF** — `reconcileIdentifiers` matches the document's `<dc:identifier>` elements against the patched set:

- reuses the element of a scheme rather than replacing it, so its `id` and the `<meta refines>` entries pointing at it keep resolving
- never deletes the element `<package unique-identifier>` names, which is structural
- removes the refining metadata of an identifier it does delete
- creates elements and attributes through their namespace, so the output re-parses

**ComicInfo** — ISBN-bearing identifiers map onto `<GTIN>`, links onto `<Web>` including the catalogs that have a URL form. That last part is how a CBZ carries an identifier it has no field of its own for. `isComicInfoWritableIdentifierScheme` lets a caller check before offering ComicInfo as a target, since the writer silently has nothing to write for the rest.

Scheme vocabulary, the ONIX codelist 5 crosswalk and namespace prefix resolution all come from archive-reader (#603, #605, #607), so the writers agree with the reader about which element carries which scheme instead of re-deriving it.

## Behaviour change, not a refactor

The optimize screen still edits **only the ISBN** — no UI change. But the patch is a set, and an identifier left out of it is removed, so it now sends the whole set with that one value swapped in. Two consequences worth reviewing rather than waving through:

- **A scheme is rewritten in its canonical spelling** — an element saying `opf:scheme="isbn"` comes back as `ISBN`.
- **Identifiers other than the ISBN now propagate between the containers.** Which containers get written has not changed — ComicInfo always, the OPF when readable. What changed is that the patch now lists every identifier instead of just the ISBN, and the others were previously never written at all: they sat in whichever container happened to announce them.

  Concretely, for an EPUB whose OPF announces an ISBN and a DOI, alongside a ComicInfo, editing the ISBN:

  | | ComicInfo receives |
  |---|---|
  | before | `<GTIN>9783161484100</GTIN>` — the DOI stays only in the OPF |
  | after | `<GTIN>9783161484100</GTIN>` and `<Web>https://doi.org/10.1000/182</Web>` |

  And the reverse: a GTIN only ComicInfo announced now also becomes a `dc:identifier` in the OPF.

Both are the intended semantics: an archive whose containers disagree has no identifier the user can trust, and picking a winner per container was never the user's call.

## Testing

- `packages/archive-metadata`: **120 tests** — OPF reconciliation across container spellings, aliased namespace prefixes, refinement-typed schemes, empty and nested-text identifier elements, the unique-identifier guard, ComicInfo `<GTIN>`/`<Web>` mapping
- `apps/web`: **304 tests**, including four new cases on the adapter proving the identifiers it is *not* editing survive the patch, that an ISBN is appended when the book announced none, that clearing drops only the ISBN, and that a ComicInfo `<GTIN>` is edited as the ISBN it announces
- tsc clean on `archive-metadata`, `apps/web`, `apps/api`; biome clean

## Follows

#586 rebases onto this and keeps only the dynamic identifier list UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
