### PR TITLE
fix(optimize): stop planting a ComicInfo.xml in every EPUB

### DIFF
--- a/apps/web/src/books/optimize/apply/buildUpdateActions.ts
+++ b/apps/web/src/books/optimize/apply/buildUpdateActions.ts
@@ -1,6 +1,7 @@
 import type { WebArchiveUpdateAction } from "@oboku/archive-metadata/web"
 import type { FileInspection } from "../useFileInspection"
 import {
+  hasWritableMetadataTarget,
   resolveArchiveMetadataPatchPlan,
   resolveMetadataFixerFormValues,
   trimMetadataFixerFormValues,
@@ -15,6 +16,8 @@ const resolveMetadataPatchAction = (
   values: BookOptimizeFormValues,
   inspection: FileInspection,
 ): WebArchiveUpdateAction | undefined => {
+  if (!hasWritableMetadataTarget(inspection)) return undefined
+
   const trimmed = trimMetadataFixerFormValues(values)
   const resolved = resolveMetadataFixerFormValues(inspection)
 

--- a/apps/web/src/books/optimize/metadata/MetadataForm.tsx
+++ b/apps/web/src/books/optimize/metadata/MetadataForm.tsx
@@ -4,6 +4,7 @@ import { ControlledTextField } from "../../../common/forms/ControlledTextField"
 import type { BookOptimizeFormValues } from "../form"
 import { useBookOptimize } from "../BookOptimizeProvider"
 import { useIsApplyingLocally } from "../apply/useApplyLocally"
+import { hasWritableMetadataTarget } from "./targets"
 
 const validateIsbn = (raw: string | boolean): true | string => {
   if (typeof raw !== "string") return true
@@ -21,6 +22,7 @@ export function MetadataForm() {
   const { bookId, control, inspection, isUploading } = useBookOptimize()
   const isApplyingLocally = useIsApplyingLocally(bookId)
   const isApplying = isApplyingLocally || isUploading
+  const isStorable = hasWritableMetadataTarget(inspection)
 
   return (
     <Stack spacing={2}>
@@ -32,14 +34,16 @@ export function MetadataForm() {
         size="small"
         fullWidth
         helperText={
-          identifierValue(
-            inspection.resolvedArchive.metadata.identifiers,
-            "ISBN",
-          )
-            ? undefined
-            : "No ISBN found in this book yet."
+          isStorable
+            ? identifierValue(
+                inspection.resolvedArchive.metadata.identifiers,
+                "ISBN",
+              )
+              ? undefined
+              : "No ISBN found in this book yet."
+            : "This book has nowhere to store an ISBN."
         }
-        disabled={isApplying}
+        disabled={isApplying || !isStorable}
       />
     </Stack>
   )

--- a/apps/web/src/books/optimize/metadata/MetadataWarnings.tsx
+++ b/apps/web/src/books/optimize/metadata/MetadataWarnings.tsx
@@ -1,12 +1,11 @@
 import { Alert, Stack } from "@mui/material"
 import { memo } from "react"
 import { useBookOptimize } from "../BookOptimizeProvider"
-import { CONTAINER_LABELS, resolveMetadataTargets } from "./targets"
+import { CONTAINER_LABELS } from "./targets"
 
 export const MetadataWarnings = memo(function MetadataWarnings() {
   const { inspection } = useBookOptimize()
   const { unreadableSources } = inspection.resolvedArchive
-  const targets = resolveMetadataTargets(inspection)
 
   if (unreadableSources.length === 0) return null
 
@@ -15,17 +14,16 @@ export const MetadataWarnings = memo(function MetadataWarnings() {
       {unreadableSources.includes("opf") && (
         <Alert severity="warning" variant="standard">
           This book&apos;s {CONTAINER_LABELS.opf} could not be read, so none of
-          its own metadata could be recovered and saving cannot write to it.
-          {targets.comicInfo
-            ? ` Your values go to ${CONTAINER_LABELS.comicInfo} instead, which this book already carries.`
-            : " There is nowhere else in this book to store them, so they cannot be saved."}
+          its own metadata could be recovered and nothing can be saved back to
+          it. Editing it anyway would mean replacing it, which would cost the
+          book everything the document holds beyond what oboku understands.
         </Alert>
       )}
       {unreadableSources.includes("comicInfo") && (
         <Alert severity="warning" variant="standard">
-          This book's {CONTAINER_LABELS.comicInfo} could not be read. Saving
-          replaces it entirely with a new one holding only the fields oboku
-          supports — anything else it contained is lost.
+          This book&apos;s {CONTAINER_LABELS.comicInfo} could not be read, so
+          nothing can be saved back to it. Replacing it would lose whatever else
+          it contained.
         </Alert>
       )}
     </Stack>

--- a/apps/web/src/books/optimize/metadata/MetadataWarnings.tsx
+++ b/apps/web/src/books/optimize/metadata/MetadataWarnings.tsx
@@ -1,11 +1,12 @@
 import { Alert, Stack } from "@mui/material"
 import { memo } from "react"
 import { useBookOptimize } from "../BookOptimizeProvider"
-import { CONTAINER_LABELS } from "./targets"
+import { CONTAINER_LABELS, resolveMetadataTargets } from "./targets"
 
 export const MetadataWarnings = memo(function MetadataWarnings() {
   const { inspection } = useBookOptimize()
   const { unreadableSources } = inspection.resolvedArchive
+  const targets = resolveMetadataTargets(inspection)
 
   if (unreadableSources.length === 0) return null
 
@@ -13,11 +14,13 @@ export const MetadataWarnings = memo(function MetadataWarnings() {
     <Stack spacing={1}>
       {unreadableSources.includes("opf") && (
         <Alert severity="warning" variant="standard">
-          This book's {CONTAINER_LABELS.opf} could not be read, so none of its
-          own metadata could be recovered. You can still fix the book: saving
-          writes your values to {CONTAINER_LABELS.comicInfo}, which oboku reads.
-          The unreadable document is left untouched — it also holds the book's
-          reading order, which oboku cannot rebuild.
+          This book&apos;s {CONTAINER_LABELS.opf} could not be read, so none of
+          its own metadata could be recovered. It is left untouched rather than
+          replaced — it also holds the book&apos;s reading order, which oboku
+          cannot rebuild.
+          {targets.comicInfo
+            ? ` Saving writes your values to ${CONTAINER_LABELS.comicInfo}, which the book already carries and oboku reads.`
+            : ` This book carries no other place to record metadata, so saving cannot store your values. ${CONTAINER_LABELS.comicInfo} describes a comic archive and is not added to an EPUB.`}
         </Alert>
       )}
       {unreadableSources.includes("comicInfo") && (

--- a/apps/web/src/books/optimize/metadata/MetadataWarnings.tsx
+++ b/apps/web/src/books/optimize/metadata/MetadataWarnings.tsx
@@ -15,12 +15,10 @@ export const MetadataWarnings = memo(function MetadataWarnings() {
       {unreadableSources.includes("opf") && (
         <Alert severity="warning" variant="standard">
           This book&apos;s {CONTAINER_LABELS.opf} could not be read, so none of
-          its own metadata could be recovered. It is left untouched rather than
-          replaced — it also holds the book&apos;s reading order, which oboku
-          cannot rebuild.
+          its own metadata could be recovered and saving cannot write to it.
           {targets.comicInfo
-            ? ` Saving writes your values to ${CONTAINER_LABELS.comicInfo}, which the book already carries and oboku reads.`
-            : ` This book carries no other place to record metadata, so saving cannot store your values. ${CONTAINER_LABELS.comicInfo} describes a comic archive and is not added to an EPUB.`}
+            ? ` Your values go to ${CONTAINER_LABELS.comicInfo} instead, which this book already carries.`
+            : " There is nowhere else in this book to store them, so they cannot be saved."}
         </Alert>
       )}
       {unreadableSources.includes("comicInfo") && (

--- a/apps/web/src/books/optimize/metadata/inspection.fixture.ts
+++ b/apps/web/src/books/optimize/metadata/inspection.fixture.ts
@@ -1,0 +1,65 @@
+import {
+  arrayBufferFileAccessors,
+  createArchive,
+  resolveArchive,
+  type ArchiveRecord,
+} from "@prose-reader/archive-reader"
+import type { FileInspection } from "../useFileInspection"
+
+const toArrayBuffer = (body: string): ArrayBuffer => {
+  const bytes = new TextEncoder().encode(body)
+  const buffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(buffer).set(bytes)
+
+  return buffer
+}
+
+export const CONTAINER_XML =
+  '<?xml version="1.0" encoding="utf-8"?>' +
+  '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">' +
+  '<rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles>' +
+  "</container>"
+
+export const opf = (metadata: string): string =>
+  '<?xml version="1.0" encoding="utf-8"?>' +
+  '<package xmlns="http://www.idpf.org/2007/opf"' +
+  ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+  ' xmlns:opf="http://www.idpf.org/2007/opf"' +
+  ' version="3.0" unique-identifier="pub-id">' +
+  `<metadata>${metadata}</metadata><manifest/><spine/>` +
+  "</package>"
+
+export const comicInfo = (body: string): string =>
+  `<?xml version="1.0" encoding="utf-8"?><ComicInfo>${body}</ComicInfo>`
+
+export const inspect = async (
+  files: Record<string, string>,
+): Promise<FileInspection> => {
+  const records = Object.entries(files).map(
+    ([uri, body]): ArchiveRecord => ({
+      dir: false,
+      basename: uri.split("/").filter(Boolean).pop() ?? uri,
+      uri,
+      size: body.length,
+      ...arrayBufferFileAccessors(() => Promise.resolve(toArrayBuffer(body))),
+    }),
+  )
+  const archive = createArchive({
+    filename: "book.epub",
+    records,
+    close: () => Promise.resolve(),
+  })
+
+  return {
+    fileName: "book.epub",
+    fileSize: 0,
+    fileCount: records.length,
+    fileExtensions: [],
+    imageCount: 0,
+    imageBytes: 0,
+    averageImageResolution: undefined,
+    resolvedArchive: await resolveArchive(archive, {
+      include: ["metadata", "sources"],
+    }),
+  }
+}

--- a/apps/web/src/books/optimize/metadata/targets.test.ts
+++ b/apps/web/src/books/optimize/metadata/targets.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest"
+import { CONTAINER_XML, comicInfo, inspect, opf } from "./inspection.fixture"
+import { hasWritableMetadataTarget, resolveMetadataTargets } from "./targets"
+
+describe("resolveMetadataTargets", () => {
+  it("writes only the OPF of an EPUB that carries no ComicInfo", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
+    })
+
+    expect(resolveMetadataTargets(inspection)).toEqual({
+      comicInfo: false,
+      opf: true,
+    })
+  })
+
+  it("writes both when the EPUB already carries a ComicInfo", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
+      "ComicInfo.xml": comicInfo("<Title>Sample</Title>"),
+    })
+
+    expect(resolveMetadataTargets(inspection)).toEqual({
+      comicInfo: true,
+      opf: true,
+    })
+  })
+
+  it("synthesizes a ComicInfo for an archive with no OPF", async () => {
+    const inspection = await inspect({ "page-001.jpg": "binary" })
+
+    expect(resolveMetadataTargets(inspection)).toEqual({
+      comicInfo: true,
+      opf: false,
+    })
+  })
+
+  it("writes nowhere when the only container it carries cannot be parsed", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": "<package><metadata></wrong></package>",
+    })
+
+    expect(resolveMetadataTargets(inspection)).toEqual({
+      comicInfo: false,
+      opf: false,
+    })
+    expect(hasWritableMetadataTarget(inspection)).toBe(false)
+  })
+
+  it("still writes the ComicInfo of a book whose OPF cannot be parsed", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": "<package><metadata></wrong></package>",
+      "ComicInfo.xml": comicInfo("<Title>Sample</Title>"),
+    })
+
+    expect(resolveMetadataTargets(inspection)).toEqual({
+      comicInfo: true,
+      opf: false,
+    })
+    expect(hasWritableMetadataTarget(inspection)).toBe(true)
+  })
+
+  it("keeps writing an unreadable ComicInfo it would replace", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
+      "ComicInfo.xml": "<ComicInfo></wrong></ComicInfo>",
+    })
+
+    expect(resolveMetadataTargets(inspection)).toEqual({
+      comicInfo: true,
+      opf: true,
+    })
+  })
+})

--- a/apps/web/src/books/optimize/metadata/targets.test.ts
+++ b/apps/web/src/books/optimize/metadata/targets.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest"
 import { CONTAINER_XML, comicInfo, inspect, opf } from "./inspection.fixture"
 import { hasWritableMetadataTarget, resolveMetadataTargets } from "./targets"
 
+const UNPARSEABLE = "<root><child></wrong></root>"
+
 describe("resolveMetadataTargets", () => {
-  it("writes only the OPF of an EPUB that carries no ComicInfo", async () => {
+  it("writes only the OPF of an EPUB carrying nothing else", async () => {
     const inspection = await inspect({
       "META-INF/container.xml": CONTAINER_XML,
       "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
@@ -16,7 +18,7 @@ describe("resolveMetadataTargets", () => {
     })
   })
 
-  it("writes both when the EPUB already carries a ComicInfo", async () => {
+  it("writes both when the EPUB also carries a ComicInfo", async () => {
     const inspection = await inspect({
       "META-INF/container.xml": CONTAINER_XML,
       "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
@@ -29,7 +31,19 @@ describe("resolveMetadataTargets", () => {
     })
   })
 
-  it("synthesizes a ComicInfo for an archive with no OPF", async () => {
+  it("writes the ComicInfo an archive with no OPF carries", async () => {
+    const inspection = await inspect({
+      "ComicInfo.xml": comicInfo("<Title>Sample</Title>"),
+      "page-001.jpg": "binary",
+    })
+
+    expect(resolveMetadataTargets(inspection)).toEqual({
+      comicInfo: true,
+      opf: false,
+    })
+  })
+
+  it("creates a ComicInfo for an archive carrying no metadata at all", async () => {
     const inspection = await inspect({ "page-001.jpg": "binary" })
 
     expect(resolveMetadataTargets(inspection)).toEqual({
@@ -38,10 +52,10 @@ describe("resolveMetadataTargets", () => {
     })
   })
 
-  it("writes nowhere when the only container it carries cannot be parsed", async () => {
+  it("writes nothing when the OPF cannot be read", async () => {
     const inspection = await inspect({
       "META-INF/container.xml": CONTAINER_XML,
-      "OEBPS/content.opf": "<package><metadata></wrong></package>",
+      "OEBPS/content.opf": UNPARSEABLE,
     })
 
     expect(resolveMetadataTargets(inspection)).toEqual({
@@ -51,30 +65,42 @@ describe("resolveMetadataTargets", () => {
     expect(hasWritableMetadataTarget(inspection)).toBe(false)
   })
 
-  it("still writes the ComicInfo of a book whose OPF cannot be parsed", async () => {
+  it("writes nothing when the OPF cannot be read even alongside a ComicInfo", async () => {
     const inspection = await inspect({
       "META-INF/container.xml": CONTAINER_XML,
-      "OEBPS/content.opf": "<package><metadata></wrong></package>",
+      "OEBPS/content.opf": UNPARSEABLE,
       "ComicInfo.xml": comicInfo("<Title>Sample</Title>"),
     })
 
     expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: true,
+      comicInfo: false,
       opf: false,
     })
-    expect(hasWritableMetadataTarget(inspection)).toBe(true)
   })
 
-  it("keeps writing an unreadable ComicInfo it would replace", async () => {
+  it("writes nothing when the ComicInfo cannot be read", async () => {
     const inspection = await inspect({
-      "META-INF/container.xml": CONTAINER_XML,
-      "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
-      "ComicInfo.xml": "<ComicInfo></wrong></ComicInfo>",
+      "ComicInfo.xml": UNPARSEABLE,
+      "page-001.jpg": "binary",
     })
 
     expect(resolveMetadataTargets(inspection)).toEqual({
-      comicInfo: true,
-      opf: true,
+      comicInfo: false,
+      opf: false,
+    })
+    expect(hasWritableMetadataTarget(inspection)).toBe(false)
+  })
+
+  it("writes nothing when the ComicInfo cannot be read even alongside a readable OPF", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf("<dc:title>Sample</dc:title>"),
+      "ComicInfo.xml": UNPARSEABLE,
+    })
+
+    expect(resolveMetadataTargets(inspection)).toEqual({
+      comicInfo: false,
+      opf: false,
     })
   })
 })

--- a/apps/web/src/books/optimize/metadata/targets.ts
+++ b/apps/web/src/books/optimize/metadata/targets.ts
@@ -43,22 +43,50 @@ export const resolveMetadataFixerFormValues = (
 })
 
 /**
- * Writes the ISBN into every container the archive can carry: the OPF when it
- * is readable, plus ComicInfo.xml either patched or synthesized. Keeping them
- * in sync is the point — an archive whose containers disagree has no ISBN the
- * user can trust, and picking a winner per container was never their call.
+ * The containers a save should write. Every container the book already carries
+ * is written, so they cannot end up disagreeing about the same ISBN — picking a
+ * winner per container was never the user's call.
  *
- * An unreadable OPF is skipped rather than replaced: the package document
- * also carries the manifest and spine, so overwriting it with the fields
- * oboku knows about would cost the book its reading order.
+ * ComicInfo.xml is only ever created for an archive that carries no metadata of
+ * its own: a bare comic archive. A book that carries a package document is an
+ * EPUB and is never given one, whether or not that document turns out to be
+ * readable — ComicInfo describes a comic archive, and a broken OPF does not
+ * make a book into one.
+ *
+ * An unreadable OPF is skipped rather than replaced: the package document also
+ * carries the manifest and spine, so overwriting it with the fields oboku knows
+ * about would cost the book its reading order. An EPUB whose OPF cannot be
+ * parsed therefore has nowhere to record anything, which
+ * {@link hasWritableMetadataTarget} lets callers say out loud.
  */
+export const resolveMetadataTargets = ({
+  resolvedArchive,
+}: FileInspection): ArchiveMetadataTargets => {
+  const { sources, unreadableSources } = resolvedArchive
+  const carriesComicInfo =
+    sources.comicInfo !== undefined || unreadableSources.includes("comicInfo")
+  const carriesOpf =
+    sources.opf !== undefined || unreadableSources.includes("opf")
+
+  return {
+    comicInfo: carriesComicInfo || !carriesOpf,
+    opf: sources.opf !== undefined,
+  }
+}
+
+/** Whether a save has any container left to write the metadata into. */
+export const hasWritableMetadataTarget = (
+  inspection: FileInspection,
+): boolean => {
+  const { comicInfo, opf } = resolveMetadataTargets(inspection)
+
+  return comicInfo === true || opf === true
+}
+
 export const resolveArchiveMetadataPatchPlan = (
   values: MetadataFixerFormValues,
   inspection: FileInspection,
 ): ArchiveMetadataPatchPlan => ({
   patch: { isbn: normalizeFormIsbn(values.isbn) },
-  targets: {
-    comicInfo: true,
-    opf: inspection.resolvedArchive.sources.opf !== undefined,
-  },
+  targets: resolveMetadataTargets(inspection),
 })

--- a/apps/web/src/books/optimize/metadata/targets.ts
+++ b/apps/web/src/books/optimize/metadata/targets.ts
@@ -43,35 +43,35 @@ export const resolveMetadataFixerFormValues = (
 })
 
 /**
- * The containers a save should write. Every container the book already carries
- * is written, so they cannot end up disagreeing about the same ISBN — picking a
- * winner per container was never the user's call.
+ * The containers a save should write.
  *
- * ComicInfo.xml is only ever created for an archive that carries no metadata of
- * its own: a bare comic archive. A book that carries a package document is an
- * EPUB and is never given one, whether or not that document turns out to be
- * readable — ComicInfo describes a comic archive, and a broken OPF does not
- * make a book into one.
+ * A container the book carries but oboku cannot parse stops the save: it
+ * cannot be patched without being read, and replacing it would discard
+ * whatever it holds that oboku does not model. Falling back to the other
+ * container is not a fix either — a book with a package document is an EPUB
+ * whether or not that document parses, and a comic sidecar does not belong in
+ * one.
  *
- * An unreadable OPF is skipped rather than replaced: the package document also
- * carries the manifest and spine, so overwriting it with the fields oboku knows
- * about would cost the book its reading order. An EPUB whose OPF cannot be
- * parsed therefore has nowhere to record anything, which
- * {@link hasWritableMetadataTarget} lets callers say out loud.
+ * Otherwise every container the book already carries is written, so they cannot
+ * end up disagreeing about the same ISBN — picking a winner per container was
+ * never the user's call. ComicInfo.xml is created only for an archive that
+ * carries no metadata of its own: a bare comic archive.
  */
 export const resolveMetadataTargets = ({
   resolvedArchive,
 }: FileInspection): ArchiveMetadataTargets => {
   const { sources, unreadableSources } = resolvedArchive
-  const carriesComicInfo =
-    sources.comicInfo !== undefined || unreadableSources.includes("comicInfo")
-  const carriesOpf =
-    sources.opf !== undefined || unreadableSources.includes("opf")
 
-  return {
-    comicInfo: carriesComicInfo || !carriesOpf,
-    opf: sources.opf !== undefined,
+  if (
+    unreadableSources.includes("opf") ||
+    unreadableSources.includes("comicInfo")
+  ) {
+    return { comicInfo: false, opf: false }
   }
+
+  const opf = sources.opf !== undefined
+
+  return { comicInfo: sources.comicInfo !== undefined || !opf, opf }
 }
 
 /** Whether a save has any container left to write the metadata into. */

--- a/packages/archive-metadata/src/metadata/write.test.ts
+++ b/packages/archive-metadata/src/metadata/write.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest"
+import {
+  arrayBufferFileAccessors,
+  createArchive,
+  type ArchiveRecord,
+} from "@prose-reader/archive-reader"
+import { patchArchiveMetadata } from "./write"
+
+const toArrayBuffer = (body: string): ArrayBuffer => {
+  const bytes = new TextEncoder().encode(body)
+  const buffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(buffer).set(bytes)
+
+  return buffer
+}
+
+const record = (uri: string, body: string): ArchiveRecord => ({
+  dir: false,
+  basename: uri.split("/").filter(Boolean).pop() ?? uri,
+  uri,
+  size: body.length,
+  ...arrayBufferFileAccessors(() => Promise.resolve(toArrayBuffer(body))),
+})
+
+const CONTAINER_XML =
+  '<?xml version="1.0" encoding="utf-8"?>' +
+  '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">' +
+  '<rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles>' +
+  "</container>"
+
+const OPF =
+  '<?xml version="1.0" encoding="utf-8"?>' +
+  '<package xmlns="http://www.idpf.org/2007/opf"' +
+  ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+  ' xmlns:opf="http://www.idpf.org/2007/opf"' +
+  ' version="3.0" unique-identifier="pub-id">' +
+  '<metadata><dc:identifier id="pub-id">urn:uuid:abc</dc:identifier></metadata>' +
+  "<manifest/><spine/></package>"
+
+const epub = () =>
+  createArchive({
+    filename: "book.epub",
+    records: [
+      record("META-INF/container.xml", CONTAINER_XML),
+      record("OEBPS/content.opf", OPF),
+    ],
+    close: () => Promise.resolve(),
+  })
+
+const ISBN_PATCH = { isbn: "9783161484100" }
+
+describe("patchArchiveMetadata", () => {
+  it("refuses a patch with no container to write it into", async () => {
+    await expect(
+      patchArchiveMetadata(epub(), ISBN_PATCH, { comicInfo: false }),
+    ).rejects.toThrow(/requires at least one target/i)
+  })
+
+  it("writes only the containers it was asked for", async () => {
+    const patched = await patchArchiveMetadata(epub(), ISBN_PATCH, {
+      opf: true,
+    })
+
+    expect(
+      patched.entries.map(function toPath({ path }) {
+        return path
+      }),
+    ).toEqual(["OEBPS/content.opf"])
+  })
+
+  it("throws when asked for an OPF the archive does not carry", async () => {
+    const comic = createArchive({
+      filename: "book.cbz",
+      records: [record("page-001.jpg", "binary")],
+      close: () => Promise.resolve(),
+    })
+
+    await expect(
+      patchArchiveMetadata(comic, ISBN_PATCH, { opf: true }),
+    ).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Two bugs, one rule

**Every EPUB you optimized gained a `ComicInfo.xml`.** `resolveArchiveMetadataPatchPlan` returned `comicInfo: true` unconditionally, and `patchArchiveMetadata` synthesizes the file when the archive has none:

```ts
entries.push({ path: existingComicInfo?.uri ?? COMIC_INFO_FILENAME, xml })
```

Verified against a plain EPUB — the patch reports writing both `ComicInfo.xml` and `OEBPS/content.opf`. ComicInfo describes a comic archive; an EPUB has a package document and oboku reads that.

**An unreadable container was silently worked around.** An unreadable OPF earned the book a synthesized ComicInfo — a comic sidecar in an EPUB that a parse failure never proved was broken, and a failure as likely to be oboku's shortcoming as the book's. An unreadable ComicInfo was replaced wholesale, costing the book everything it held that oboku does not model.

Both pre-existing on develop, not introduced by the identifier work.

## The rule

**A container oboku cannot read is one it cannot patch, so the save is refused.** No falling back to the other container. Otherwise every container the book carries is written, and ComicInfo is created only for an archive carrying no metadata of its own.

| OPF | ComicInfo | writes |
|---|---|---|
| readable | absent | OPF |
| readable | readable | OPF + ComicInfo |
| absent | readable | ComicInfo |
| absent | absent | ComicInfo, created |
| **unreadable** | any | **nothing** |
| any | **unreadable** | **nothing** |

Writing both when both are present is unchanged — an archive whose containers disagree has no identifier the user can trust, and picking a winner per container was never the user's call.

## What the user sees

A book with nothing writable can't record an ISBN, so the field is disabled and says so, and no `patch-metadata` action is produced — rather than accepting a value that would be dropped. Both warnings now say the save is refused and why, instead of promising a fallback.

**Image compression is unaffected.** Only the metadata write is refused; a book with a broken OPF is still perfectly compressible, so the whole save is not failed — just the part that cannot be honoured.

`patchArchiveMetadata` already threw for a no-target patch; that invariant now has a test, since this change is the first thing to rely on it.

## Testing

- **8 cases on target selection**, one per row above plus both unreadable-container cases in combination with a readable partner. The first fails against the old always-true behaviour.
- **3 cases on `patchArchiveMetadata`**: refuses a no-target patch, writes only what it was asked for, throws for an OPF the archive lacks.
- `apps/web`: 308 tests pass; `archive-metadata`: 107; tsc and biome clean.

## Note for the stack

#609 and #586 still carry the old unconditional `comicInfo: true` and will want a rebase once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)