### PR TITLE
chore(archive-metadata): drop the unused legacy OPFS staging purge

### DIFF
--- a/packages/archive-metadata/src/update/opfsStaging.test.ts
+++ b/packages/archive-metadata/src/update/opfsStaging.test.ts
@@ -319,16 +319,6 @@ describe("purgeStagedFiles", () => {
     expect(findStagingDir(root)?.dirs.has(FIRST_SCOPE_ID)).toBe(false)
   })
 
-  it("drops the legacy staging directory outright", async () => {
-    const root = new FakeDirectoryHandle()
-    enableOpfs(root)
-    await root.getDirectoryHandle("oboku-tmp", { create: true })
-
-    await purgeStagedFiles()
-
-    expect(root.dirs.has("oboku-tmp")).toBe(false)
-  })
-
   it("stays best-effort when OPFS is unavailable", async () => {
     disableOpfs()
 

--- a/packages/archive-metadata/src/update/opfsStaging.ts
+++ b/packages/archive-metadata/src/update/opfsStaging.ts
@@ -2,7 +2,6 @@ import { report } from "../utils/report"
 import type { OpenStagingScope, OpenZipTarget, StageBytes } from "./staging"
 
 const STAGING_DIR = "prose-reader-archive-staging-v1"
-const LEGACY_STAGING_DIR = "oboku-tmp"
 
 const lockNameFor = (updateId: string) => `${STAGING_DIR}:${updateId}`
 
@@ -98,10 +97,6 @@ const removeScopeUnlessOwned = async (
 export const purgeStagedFiles = async (): Promise<void> => {
   try {
     const root = await navigator.storage.getDirectory()
-
-    await root
-      .removeEntry(LEGACY_STAGING_DIR, { recursive: true })
-      .catch(() => {})
 
     const staging = await root.getDirectoryHandle(STAGING_DIR).catch(() => null)
 


### PR DESCRIPTION
`purgeStagedFiles()` removed an OPFS directory named `oboku-tmp` from the storage root before purging its own staging directory. Nothing ever created it.

## Why it's dead

- `git log -S "oboku-tmp" --all` → exactly one commit, #451.
- `git log -S "navigator.storage.getDirectory" --all` → the same single commit.

#451 is the commit that introduced `opfsStaging.ts` and `STAGING_DIR` in the first place, and it is the only OPFS code this repository has ever had. So `LEGACY_STAGING_DIR` shipped alongside the thing it was supposedly a migration away from — no released version of oboku has ever written an `oboku-tmp` directory, which means the `removeEntry` call has never removed anything and `"drops the legacy staging directory outright"` was a test asserting that a dead branch works.

Removes the constant, its `removeEntry` call, and that test. No behavior change for any real storage state.

## Context

Found while scoping [#608](https://github.com/mbret/oboku/issues/608) (relocating this package to prose-reader as `@prose-reader/archive-writer`). `oboku-tmp` was one of only two oboku-named strings in `src/`, and a prose-reader package deleting an oboku-named directory from someone's OPFS would have been odd to carry upstream. With this gone, the port is verbatim apart from the `Report.namespace()` label.

## Verification

- `pnpm test` in `packages/archive-metadata` — 10 files, 100 tests passing
- `tsc --noEmit` — clean
- `biome check` on the touched directory — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKmmWkh26JDFtU6wPtFKxh)_