### PR TITLE
fix(archive-metadata): remove only the identifiers a patch names

### DIFF
--- a/apps/web/src/books/optimize/apply/buildUpdateActions.test.ts
+++ b/apps/web/src/books/optimize/apply/buildUpdateActions.test.ts
@@ -138,3 +138,61 @@ describe("buildUpdateActions, an ISBN both containers announce", () => {
     ])
   })
 })
+
+describe("buildUpdateActions, what it asks to be removed", () => {
+  it("names nothing when the edit only changes a value", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>' +
+          '<dc:identifier opf:scheme="DOI">10.1000/182</dc:identifier>',
+      ),
+    })
+
+    const { patch } = metadataPatch("9783161484100", inspection)
+
+    expect(patch.removedIdentifiers).toEqual([])
+    expect(patch.identifiers).toEqual([
+      { scheme: "ISBN", value: "9783161484100", unique: false },
+      { scheme: "DOI", value: "10.1000/182", unique: false },
+    ])
+  })
+
+  it("names the ISBN it dropped when the field is cleared", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>' +
+          '<dc:identifier opf:scheme="DOI">10.1000/182</dc:identifier>',
+      ),
+    })
+
+    const { patch } = metadataPatch("", inspection)
+
+    expect(patch.removedIdentifiers).toEqual([
+      { scheme: "ISBN", value: "9783161484100", unique: false },
+    ])
+    expect(patch.identifiers).toEqual([
+      { scheme: "DOI", value: "10.1000/182", unique: false },
+    ])
+  })
+
+  it("names both entries when the containers each announced the ISBN", async () => {
+    const inspection = await inspect({
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf": opf(
+        '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
+      ),
+      "ComicInfo.xml": comicInfo("<GTIN>9783161484100</GTIN>"),
+    })
+
+    const { patch } = metadataPatch("9780306406157", inspection)
+
+    expect(patch.identifiers).toEqual([
+      { scheme: "ISBN", value: "9780306406157", unique: false },
+    ])
+    expect(patch.removedIdentifiers).toEqual([
+      { scheme: "GTIN", value: "9783161484100", unique: false },
+    ])
+  })
+})

--- a/apps/web/src/books/optimize/apply/buildUpdateActions.ts
+++ b/apps/web/src/books/optimize/apply/buildUpdateActions.ts
@@ -1,5 +1,6 @@
 import type {
   ArchiveMetadataIdentifier,
+  ArchiveMetadataPatch,
   WebArchiveUpdateAction,
 } from "@oboku/archive-metadata/web"
 import { isIsbnBearingScheme } from "@prose-reader/archive-reader"
@@ -22,30 +23,30 @@ const announcesIsbn = ({ scheme }: ArchiveMetadataIdentifier): boolean =>
   isIsbnBearingScheme(scheme)
 
 /**
- * The identifiers the archive should end up carrying: the ones it already has,
- * with the edited ISBN in place of every one of them that announced an ISBN.
+ * What the archive should carry after the edit, and what the edit dropped.
  *
- * More than one usually does — a book whose OPF and ComicInfo both carry it is
- * read as an `ISBN` and a `GTIN` of the same value — and they are one fact, so
- * the edit replaces the first and drops the rest. Keeping the others would
- * leave the previous ISBN behind under the other scheme.
+ * The archive's own identifiers are the baseline, so the difference between
+ * them and the edited set is exactly what the user removed — which is the only
+ * thing the writer is asked to delete. An identifier neither list names is left
+ * alone, including ones the reader never reported and no one here could know
+ * about.
  *
- * The patch is the complete set rather than a delta, so every identifier the
- * book carries has to be listed for it to survive the write. Only the ISBN is
- * editable here; the rest are passed through as read.
+ * An ISBN is usually announced more than once: a book whose OPF and ComicInfo
+ * both carry it is read as an `ISBN` and a `GTIN` of the same value. They are
+ * one fact, so the edit lands on the first and the rest are dropped.
  */
-const patchIdentifiers = (
+const identifierPatch = (
   inspection: FileInspection,
   isbn: string | undefined,
-): ArchiveMetadataIdentifier[] => {
-  const identifiers = (
-    inspection.resolvedArchive.metadata.identifiers ?? []
-  ).map(function toPatchIdentifier({ scheme, value, unique }) {
-    return { scheme, value, unique: unique === true }
-  })
-  const editedIndex = identifiers.findIndex(announcesIsbn)
+): Pick<ArchiveMetadataPatch, "identifiers" | "removedIdentifiers"> => {
+  const announced = (inspection.resolvedArchive.metadata.identifiers ?? []).map(
+    function toPatchIdentifier({ scheme, value, unique }) {
+      return { scheme, value, unique: unique === true }
+    },
+  )
+  const editedIndex = announced.findIndex(announcesIsbn)
 
-  const carried = identifiers.flatMap(
+  const identifiers = announced.flatMap(
     function keepOrReplace(identifier, index) {
       if (!announcesIsbn(identifier)) return [identifier]
       if (index !== editedIndex || isbn === undefined) return []
@@ -54,9 +55,22 @@ const patchIdentifiers = (
     },
   )
 
-  return editedIndex === -1 && isbn !== undefined
-    ? [...carried, { scheme: "ISBN", value: isbn }]
-    : carried
+  const removedIdentifiers = announced.filter(
+    function wasDropped(identifier, index) {
+      return (
+        announcesIsbn(identifier) &&
+        (index !== editedIndex || isbn === undefined)
+      )
+    },
+  )
+
+  return {
+    identifiers:
+      editedIndex === -1 && isbn !== undefined
+        ? [...identifiers, { scheme: "ISBN", value: isbn }]
+        : identifiers,
+    removedIdentifiers,
+  }
 }
 
 const resolveMetadataPatchAction = (
@@ -73,7 +87,7 @@ const resolveMetadataPatchAction = (
 
   return {
     kind: "patch-metadata",
-    patch: { identifiers: patchIdentifiers(inspection, isbn) },
+    patch: identifierPatch(inspection, isbn),
     targets,
   }
 }

--- a/packages/archive-metadata/src/comicInfo/index.test.ts
+++ b/packages/archive-metadata/src/comicInfo/index.test.ts
@@ -221,14 +221,44 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     )
   })
 
-  it("removes the Web element when no URL identifier remains", async () => {
+  it("removes the Web element when the patch names its only link", async () => {
+    const archive = makeArchive({
+      "ComicInfo.xml": minimalComicInfo("<Web>https://example.com/a</Web>"),
+    })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [],
+      removedIdentifiers: [{ scheme: "URL", value: "https://example.com/a" }],
+    })
+
+    expect(xml).not.toContain("<Web")
+  })
+
+  it("keeps a link the patch names in neither list", async () => {
     const archive = makeArchive({
       "ComicInfo.xml": minimalComicInfo("<Web>https://example.com/a</Web>"),
     })
 
     const xml = await buildPatchedComicInfoXml(archive, { identifiers: [] })
 
-    expect(xml).not.toContain("<Web")
+    expect(xml).toContain("https://example.com/a")
+  })
+
+  it("keeps a Web token its reader does not report as an identifier", async () => {
+    const archive = makeArchive({
+      "ComicInfo.xml": minimalComicInfo(
+        "<Web>https://example.com/a not-a-url</Web>",
+      ),
+    })
+
+    const xml = await buildPatchedComicInfoXml(archive, {
+      identifiers: [{ scheme: "URL", value: "https://example.com/b" }],
+      removedIdentifiers: [{ scheme: "URL", value: "https://example.com/a" }],
+    })
+
+    expect(xml).toContain("not-a-url")
+    expect(xml).toContain("https://example.com/b")
+    expect(xml).not.toContain("https://example.com/a<")
   })
 
   it("stores a catalog identifier as its official Web link", async () => {
@@ -329,7 +359,7 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
     ).toEqual({ value: "zyTCAlFPjgYC", scheme: "GoogleBooks" })
   })
 
-  it("removes the GTIN element when the patch drops every ISBN-bearing identifier", async () => {
+  it("removes the GTIN element when the patch names what it held", async () => {
     const archive = makeArchive({
       "ComicInfo.xml": minimalComicInfo(
         "<Title>Sample</Title><GTIN>9783161484100</GTIN>",
@@ -338,6 +368,7 @@ describe("ComicInfo editing (buildPatchedComicInfoXml)", () => {
 
     const xml = await buildPatchedComicInfoXml(archive, {
       identifiers: [{ scheme: "DOI", value: "10.1000/182" }],
+      removedIdentifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     expect(xml).not.toContain("<GTIN")

--- a/packages/archive-metadata/src/comicInfo/index.ts
+++ b/packages/archive-metadata/src/comicInfo/index.ts
@@ -13,6 +13,7 @@ import type { ArchiveMetadataIdentifier } from "../metadata/write"
 import { URL_IDENTIFIER_SCHEME } from "../metadata/identifiers"
 import {
   type XmlDocument,
+  type XmlElement,
   parseXml,
   serializeXml,
   upsertChildElement,
@@ -20,6 +21,7 @@ import {
 
 type ComicInfoMetadataPatch = {
   identifiers: ReadonlyArray<ArchiveMetadataIdentifier>
+  removedIdentifiers?: ReadonlyArray<ArchiveMetadataIdentifier>
 }
 
 export { PROSE_COMIC_INFO_FILENAME as COMIC_INFO_FILENAME }
@@ -80,34 +82,77 @@ const tryParseExistingComicInfo = (xml: string): XmlDocument | undefined => {
   }
 }
 
+const childText = (root: XmlElement, tagName: string): string | undefined => {
+  const text = root.getElementsByTagName(tagName)[0]?.textContent?.trim()
+
+  return text !== undefined && text !== "" ? text : undefined
+}
+
+const webUrl = (identifier: ArchiveMetadataIdentifier): string | undefined =>
+  normalizeIdentifierScheme(identifier.scheme) === URL_IDENTIFIER_SCHEME
+    ? identifier.value
+    : catalogUrlFromIdentifier(identifier)
+
+/**
+ * `<GTIN>` holds one value, so the patched ISBN takes it. With none to write,
+ * the field only clears when a removal names what it currently holds —
+ * otherwise it is left as the book had it.
+ */
 const gtinValue = (
-  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>,
-): string | undefined =>
-  identifiers.find(function isGtinBearing({ scheme }) {
+  root: XmlElement,
+  { identifiers, removedIdentifiers }: ComicInfoMetadataPatch,
+): string | undefined => {
+  const patched = identifiers.find(function isGtinBearing({ scheme }) {
     return isIsbnBearingScheme(scheme)
   })?.value
 
-const webValue = (
-  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>,
-): string | undefined => {
-  const urls = identifiers.flatMap(function toWebUrl(identifier) {
-    if (
-      normalizeIdentifierScheme(identifier.scheme) === URL_IDENTIFIER_SCHEME
-    ) {
-      return [identifier.value]
-    }
+  if (patched !== undefined) return patched
 
-    const catalogUrl = catalogUrlFromIdentifier(identifier)
+  const existing = childText(root, "GTIN")
 
-    return catalogUrl === undefined ? [] : [catalogUrl]
+  return (removedIdentifiers ?? []).some(function names({ scheme, value }) {
+    return isIsbnBearingScheme(scheme) && value.trim() === existing
   })
+    ? undefined
+    : existing
+}
+
+/**
+ * `<Web>` is a space-separated list, and not every token in it is an identifier
+ * this writer can read back — the reader reports the links and drops the rest.
+ * So the field is edited rather than regenerated: what a removal names goes,
+ * the patched links are added, and every other token stays where the book put
+ * it.
+ */
+const webValue = (
+  root: XmlElement,
+  { identifiers, removedIdentifiers }: ComicInfoMetadataPatch,
+): string | undefined => {
+  const removedUrls = new Set(
+    (removedIdentifiers ?? []).flatMap(function toRemovedUrl(identifier) {
+      const url = webUrl(identifier)
+
+      return url === undefined ? [] : [url]
+    }),
+  )
+  const kept = (childText(root, "Web") ?? "")
+    .split(/\s+/)
+    .filter(function survives(token) {
+      return token !== "" && !removedUrls.has(token)
+    })
+  const patched = identifiers.flatMap(function toPatchedUrl(identifier) {
+    const url = webUrl(identifier)
+
+    return url === undefined ? [] : [url]
+  })
+  const urls = [...new Set([...kept, ...patched])]
 
   return urls.length > 0 ? urls.join(" ") : undefined
 }
 
 const serializeComicInfoXml = (
   existingXml: string | undefined | null,
-  { identifiers }: ComicInfoMetadataPatch,
+  patch: ComicInfoMetadataPatch,
 ): string => {
   const parsedExisting = existingXml
     ? tryParseExistingComicInfo(existingXml)
@@ -120,8 +165,8 @@ const serializeComicInfoXml = (
     throw new Error("ComicInfo.xml root element is not <ComicInfo>")
   }
 
-  upsertChildElement(doc, root, "GTIN", gtinValue(identifiers))
-  upsertChildElement(doc, root, "Web", webValue(identifiers))
+  upsertChildElement(doc, root, "GTIN", gtinValue(root, patch))
+  upsertChildElement(doc, root, "Web", webValue(root, patch))
 
   const serialized = serializeXml(doc)
 

--- a/packages/archive-metadata/src/metadata/write.ts
+++ b/packages/archive-metadata/src/metadata/write.ts
@@ -29,11 +29,19 @@ export type ArchiveMetadataIdentifier = {
  * Fields an archive patch may set. Expand in lockstep when a new field
  * becomes writable in at least one container.
  *
- * `identifiers` is the complete set the archive should end up with, not a
- * delta: an identifier the containers hold but the list omits is removed.
+ * `identifiers` are written into the containers, creating or updating as
+ * needed. `removedIdentifiers` are deleted, and **nothing else is** — an
+ * identifier named in neither list is left exactly as the archive holds it, so
+ * a patch that names no removals removes nothing.
+ *
+ * Naming removals rather than inferring them from absence is what keeps the
+ * writer from deleting something no one saw: it has no way to tell an
+ * identifier a caller chose to drop from one the caller never knew about,
+ * because its reader reports fewer elements than the document contains.
  */
 export type ArchiveMetadataPatch = {
   identifiers: ReadonlyArray<ArchiveMetadataIdentifier>
+  removedIdentifiers?: ReadonlyArray<ArchiveMetadataIdentifier>
 }
 
 /**

--- a/packages/archive-metadata/src/opf/write.test.ts
+++ b/packages/archive-metadata/src/opf/write.test.ts
@@ -160,6 +160,7 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
 
     const xml = await buildPatchedOpfXml(entry, {
       identifiers: [{ scheme: "Unknown", value: "custom-id" }],
+      removedIdentifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     expect(xml).toContain("<dc:identifier>custom-id</dc:identifier>")
@@ -168,7 +169,7 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
     ])
   })
 
-  it("removes the identifiers the patch leaves out", async () => {
+  it("removes only the identifiers the patch names", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf(
@@ -179,6 +180,7 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
 
     const xml = await buildPatchedOpfXml(entry, {
       identifiers: [{ scheme: "DOI", value: "10.1000/182" }],
+      removedIdentifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     expect(readOpfIdentifiers(xml)).toEqual([
@@ -187,13 +189,16 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
     expect(xml).not.toContain("9783161484100")
   })
 
-  it("removes every identifier when the patch carries none", async () => {
+  it("removes every identifier the patch names", async () => {
     const entry = makeEntry(
       "OEBPS/content.opf",
       opf('<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>'),
     )
 
-    const xml = await buildPatchedOpfXml(entry, { identifiers: [] })
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [],
+      removedIdentifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
 
     expect(readOpfIdentifiers(xml)).toEqual([])
   })
@@ -317,6 +322,7 @@ describe("OPF editing (buildPatchedOpfXml)", () => {
 
     const xml = await buildPatchedOpfXml(entry, {
       identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+      removedIdentifiers: [{ scheme: "DOI", value: "10.1000/182" }],
     })
 
     expect(xml).not.toContain("10.1000/182")
@@ -627,6 +633,7 @@ describe("OPF editing under an aliased namespace prefix", () => {
 
     const xml = await buildPatchedOpfXml(entry, {
       identifiers: [{ scheme: "Unknown", value: "catalog-42" }],
+      removedIdentifiers: [{ scheme: "ISBN", value: "9783161484100" }],
     })
 
     expect(xml).not.toContain("scheme=")
@@ -712,5 +719,64 @@ describe("OPF editing an identifier that states no scheme", () => {
     expect(xml).toContain(UUID_IDENTIFIER)
     expect(readOpfIsbn(xml)).toBe("9783161484100")
     expect(readOpfIdentifiers(xml)).toHaveLength(2)
+  })
+})
+
+describe("OPF editing leaves unnamed identifiers alone", () => {
+  it("keeps an element the patch names in neither list", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>' +
+          '<dc:identifier opf:scheme="DOI">10.1000/182</dc:identifier>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
+
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: "9783161484100", scheme: "ISBN" },
+      { value: "10.1000/182", scheme: "DOI" },
+    ])
+  })
+
+  it("keeps the elements its reader never reported", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        `<dc:identifier id="pub-id">${UUID_IDENTIFIER}</dc:identifier>` +
+          "<dc:identifier><span>hidden</span></dc:identifier>" +
+          "<dc:identifier></dc:identifier>" +
+          '<dc:identifier opf:scheme="ISBN">0000000000</dc:identifier>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [
+        { scheme: "Unknown", value: UUID_IDENTIFIER, unique: true },
+        { scheme: "ISBN", value: "9783161484100" },
+      ],
+    })
+
+    expect(xml).toContain("<span>hidden</span>")
+    expect(xml).toContain("<dc:identifier/>")
+    expect(readOpfIsbn(xml)).toBe("9783161484100")
+  })
+
+  it("declines to remove the element the package points at", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(`<dc:identifier id="pub-id">${UUID_IDENTIFIER}</dc:identifier>`),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [],
+      removedIdentifiers: [{ scheme: "Unknown", value: UUID_IDENTIFIER }],
+    })
+
+    expect(xml).toContain(UUID_IDENTIFIER)
+    expect(xml).toContain('id="pub-id"')
   })
 })

--- a/packages/archive-metadata/src/opf/write.test.ts
+++ b/packages/archive-metadata/src/opf/write.test.ts
@@ -780,3 +780,23 @@ describe("OPF editing leaves unnamed identifiers alone", () => {
     expect(xml).toContain('id="pub-id"')
   })
 })
+
+describe("OPF editing a document with duplicate identifiers", () => {
+  it("removes the duplicate the unique element shadows", async () => {
+    const entry = makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        '<dc:identifier id="pub-id" opf:scheme="ISBN">9783161484100</dc:identifier>' +
+          '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
+      ),
+    )
+
+    const xml = await buildPatchedOpfXml(entry, {
+      identifiers: [{ scheme: "ISBN", value: "9783161484100", unique: true }],
+      removedIdentifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
+
+    expect(xml).toContain('id="pub-id"')
+    expect(xml.match(/<dc:identifier/g)).toHaveLength(1)
+  })
+})

--- a/packages/archive-metadata/src/opf/write.test.ts
+++ b/packages/archive-metadata/src/opf/write.test.ts
@@ -800,3 +800,42 @@ describe("OPF editing a document with duplicate identifiers", () => {
     expect(xml.match(/<dc:identifier/g)).toHaveLength(1)
   })
 })
+
+describe("OPF editing around an element its reader passed over", () => {
+  const hiddenBeforeIsbn = () =>
+    makeEntry(
+      "OEBPS/content.opf",
+      opf(
+        `<dc:identifier id="pub-id">${UUID_IDENTIFIER}</dc:identifier>` +
+          "<dc:identifier><span>9783161484100</span></dc:identifier>" +
+          '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
+      ),
+    )
+
+  it("does not write the edit into it", async () => {
+    const xml = await buildPatchedOpfXml(hiddenBeforeIsbn(), {
+      identifiers: [
+        { scheme: "Unknown", value: UUID_IDENTIFIER, unique: true },
+        { scheme: "ISBN", value: "9780306406157" },
+      ],
+    })
+
+    expect(xml).toContain("<span>9783161484100</span>")
+    expect(readOpfIdentifiers(xml)).toEqual([
+      { value: UUID_IDENTIFIER, scheme: "Unknown", unique: true },
+      { value: "9780306406157", scheme: "ISBN" },
+    ])
+  })
+
+  it("does not remove it when a removal names what it appears to hold", async () => {
+    const xml = await buildPatchedOpfXml(hiddenBeforeIsbn(), {
+      identifiers: [
+        { scheme: "Unknown", value: UUID_IDENTIFIER, unique: true },
+      ],
+      removedIdentifiers: [{ scheme: "ISBN", value: "9783161484100" }],
+    })
+
+    expect(xml).toContain("<span>9783161484100</span>")
+    expect(readOpfIsbn(xml)).toBeUndefined()
+  })
+})

--- a/packages/archive-metadata/src/opf/write.ts
+++ b/packages/archive-metadata/src/opf/write.ts
@@ -98,6 +98,37 @@ const listChildrenByLocalName = (
     return localName(child.tagName) === name
   })
 
+/**
+ * An element's own text, excluding any nested element's — the value the parser
+ * reads, and what it decides by. `textContent` would fold descendants in, and
+ * an element the parser passed over must not look to this writer like one it
+ * reported.
+ */
+const directText = (element: XmlElement): string =>
+  Array.from(element.childNodes)
+    .filter(function isTextual(node) {
+      return (
+        node.nodeType === Node.TEXT_NODE ||
+        node.nodeType === Node.CDATA_SECTION_NODE
+      )
+    })
+    .map(function nodeText(node) {
+      return node.nodeValue ?? ""
+    })
+    .join("")
+
+/**
+ * The identifier elements the parser reports: the ones stating a value of their
+ * own. An element it passes over is named by no patch, so this writer neither
+ * removes nor reuses it — it is left exactly as the book wrote it.
+ */
+const reportedIdentifierElements = (metadata: XmlElement): XmlElement[] =>
+  listChildrenByLocalName(metadata, "identifier").filter(
+    function statesAValue(element) {
+      return directText(element).trim() !== ""
+    },
+  )
+
 const findChildByLocalName = (
   parent: XmlElement,
   name: string,
@@ -183,7 +214,7 @@ const elementScheme = (metadata: XmlElement, element: XmlElement): string => {
 
   switch (sink?.kind) {
     case undefined:
-      return inferIdentifierScheme(element.textContent ?? "")
+      return inferIdentifierScheme(directText(element))
     case "namespaced":
       return element.getAttributeNS(OPF_NAMESPACE, sink.localName)?.trim() ?? ""
     case "attribute":
@@ -338,11 +369,9 @@ const removableElements = (
   metadata: XmlElement,
   uniqueElement: XmlElement | undefined,
 ): XmlElement[] =>
-  listChildrenByLocalName(metadata, "identifier").filter(
-    function isRemovable(element) {
-      return element !== uniqueElement
-    },
-  )
+  reportedIdentifierElements(metadata).filter(function isRemovable(element) {
+    return element !== uniqueElement
+  })
 
 /**
  * Rewrites the document's identifiers: the removals go, the patched ones are
@@ -374,7 +403,7 @@ const reconcileIdentifiers = (
     if (element !== undefined) removeIdentifier(metadata, element)
   }
 
-  const remaining = listChildrenByLocalName(metadata, "identifier")
+  const remaining = reportedIdentifierElements(metadata)
   const uniqueIdentifier = identifiers.find(function isPinnedToUniqueElement({
     unique,
   }) {

--- a/packages/archive-metadata/src/opf/write.ts
+++ b/packages/archive-metadata/src/opf/write.ts
@@ -29,6 +29,7 @@ import {
  */
 export type OpfMetadataPatch = {
   identifiers: ReadonlyArray<ArchiveMetadataIdentifier>
+  removedIdentifiers?: ReadonlyArray<ArchiveMetadataIdentifier>
 }
 
 const OPF_LABEL = "OPF"
@@ -71,7 +72,7 @@ const serializeOpfXml = (xml: string, patch: OpfMetadataPatch): string => {
     throw new Error("OPF document has no <metadata> element")
   }
 
-  reconcileIdentifiers(doc, root, metadata, patch.identifiers)
+  reconcileIdentifiers(doc, root, metadata, patch)
 
   const serialized = serializeXml(doc)
 
@@ -310,14 +311,61 @@ const findUniqueIdentifierElement = (
  * it — an element may be the target of `<meta refines>` entries, and its `id`
  * has to survive an edit for those to keep resolving.
  */
+/**
+ * The element an identifier was read from: the one carrying both its scheme and
+ * its value. Matched on both because a removal names an identifier the reader
+ * reported, and nothing else should be mistaken for it.
+ */
+const findIdentifierElement = (
+  metadata: XmlElement,
+  elements: ReadonlyArray<XmlElement>,
+  { scheme, value }: ArchiveMetadataIdentifier,
+): XmlElement | undefined =>
+  elements.find(function carriesIdentifier(element) {
+    return (
+      element.textContent?.trim() === value.trim() &&
+      schemeKey(elementScheme(metadata, element)) === schemeKey(scheme)
+    )
+  })
+
+/**
+ * Rewrites the document's identifiers: the removals go, the patched ones are
+ * written, and every other element is left alone — including the ones the
+ * reader never reported, which no caller could have known to keep.
+ *
+ * An identifier being written reuses the existing element of its scheme rather
+ * than replacing it: that element may be the target of `<meta refines>`
+ * entries, and its `id` has to survive an edit for those to keep resolving.
+ */
 const reconcileIdentifiers = (
   doc: XmlDocument,
   root: XmlElement,
   metadata: XmlElement,
-  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>,
+  { identifiers, removedIdentifiers }: OpfMetadataPatch,
 ): void => {
-  const elements = listChildrenByLocalName(metadata, "identifier")
-  const uniqueElement = findUniqueIdentifierElement(root, elements)
+  const uniqueElement = findUniqueIdentifierElement(
+    root,
+    listChildrenByLocalName(metadata, "identifier"),
+  )
+
+  for (const identifier of removedIdentifiers ?? []) {
+    const element = findIdentifierElement(
+      metadata,
+      listChildrenByLocalName(metadata, "identifier"),
+      identifier,
+    )
+
+    /**
+     * The element `<package unique-identifier>` names is structural: removing
+     * it would leave the reference dangling, so a caller asking for it is
+     * declined rather than obeyed.
+     */
+    if (element !== undefined && element !== uniqueElement) {
+      removeIdentifier(metadata, element)
+    }
+  }
+
+  const remaining = listChildrenByLocalName(metadata, "identifier")
   const uniqueIdentifier = identifiers.find(function isPinnedToUniqueElement({
     unique,
   }) {
@@ -330,7 +378,7 @@ const reconcileIdentifiers = (
 
   const reusable = groupBySchemeKey(
     metadata,
-    elements.filter(function isReconcilable(element) {
+    remaining.filter(function isReconcilable(element) {
       return element !== uniqueElement
     }),
   )
@@ -345,9 +393,5 @@ const reconcileIdentifiers = (
       )
 
     writeIdentifier(metadata, element, identifier)
-  }
-
-  for (const leftovers of reusable.values()) {
-    for (const element of leftovers) removeIdentifier(metadata, element)
   }
 }

--- a/packages/archive-metadata/src/opf/write.ts
+++ b/packages/archive-metadata/src/opf/write.ts
@@ -329,6 +329,22 @@ const findIdentifierElement = (
   })
 
 /**
+ * The elements a removal may name. The one `<package unique-identifier>` points
+ * at is left out rather than found and declined: it is never removable, and a
+ * document holding a second element of the same scheme and value would
+ * otherwise have that duplicate shadowed by it and survive.
+ */
+const removableElements = (
+  metadata: XmlElement,
+  uniqueElement: XmlElement | undefined,
+): XmlElement[] =>
+  listChildrenByLocalName(metadata, "identifier").filter(
+    function isRemovable(element) {
+      return element !== uniqueElement
+    },
+  )
+
+/**
  * Rewrites the document's identifiers: the removals go, the patched ones are
  * written, and every other element is left alone — including the ones the
  * reader never reported, which no caller could have known to keep.
@@ -351,18 +367,11 @@ const reconcileIdentifiers = (
   for (const identifier of removedIdentifiers ?? []) {
     const element = findIdentifierElement(
       metadata,
-      listChildrenByLocalName(metadata, "identifier"),
+      removableElements(metadata, uniqueElement),
       identifier,
     )
 
-    /**
-     * The element `<package unique-identifier>` names is structural: removing
-     * it would leave the reference dangling, so a caller asking for it is
-     * declined rather than obeyed.
-     */
-    if (element !== undefined && element !== uniqueElement) {
-      removeIdentifier(metadata, element)
-    }
+    if (element !== undefined) removeIdentifier(metadata, element)
   }
 
   const remaining = listChildrenByLocalName(metadata, "identifier")


### PR DESCRIPTION
## The bug

`ArchiveMetadataPatch.identifiers` was the complete set the archive should end up with, so anything missing from it was deleted. That is fine for an identifier the user removed — and wrong for one they never saw.

archive-reader reports fewer `<dc:identifier>` elements than a document can contain: an empty one is dropped, and so is one whose text sits inside a child element. Those never reach the form, so they are never in the patch, so they were swept on save:

```xml
<!-- before -->                                          <!-- after saving -->
<dc:identifier id="pub-id">urn:uuid:abc</...>            <dc:identifier id="pub-id">urn:uuid:abc</...>
<dc:identifier id="nested"><span>hidden</span></...>     <dc:identifier opf:scheme="ISBN">978…</...>
<dc:identifier></dc:identifier>
<dc:identifier opf:scheme="ISBN">978…</...>
```

Two elements deleted that the user was never shown and never touched.

## The fix

**Removals are named. Nothing else goes.**

```ts
export type ArchiveMetadataPatch = {
  identifiers: ReadonlyArray<ArchiveMetadataIdentifier>
  removedIdentifiers?: ReadonlyArray<ArchiveMetadataIdentifier>
}
```

Optional on purpose: a patch that names no removals removes nothing, so leaving an identifier alone is the default rather than something a caller has to know to ask for.

The caller holds the archive's own identifiers *and* the edited set, so the difference between them is exactly what the user dropped. That is the structural part — a removal list computed that way can only ever name an identifier the reader reported, so **the writer no longer has to guess what its reader would have shown.** That guess is what produced the two bugs fixed in #605: first document order, then xmldoc's text semantics. This removes the need for it rather than refining it again.

Removals are matched on scheme *and* value, so nothing else can be mistaken for the named identifier. The `<package unique-identifier>` element is still declined even when named, since removing it would leave the reference dangling.

## Testing

**Five existing tests failed on the semantics change** — every one that relied on omission implying removal — and now name their removals explicitly. That is the change working, not a regression.

Three new cases pin the new guarantee:

- an identifier named in neither list survives untouched
- **the elements the reader never reported survive** — the empty one and the nested-text one, which is the bug above
- a removal naming the unique-identifier element is declined

Plus three on the caller's diff: nothing named when only a value changes, the ISBN named when the field is cleared, and both entries named when the OPF and ComicInfo each announced it.

`archive-metadata`: 128 tests. `apps/web`: 317. tsc clean on all three packages; biome clean.

## Note for the stack

#586 carries its own copy of this patch-building and will want the same diff computation when it rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)