### PR TITLE
docs(self-hosting): correct what losing the JWT key pair costs

### DIFF
--- a/gitbook/self-hosting/installation.md
+++ b/gitbook/self-hosting/installation.md
@@ -54,7 +54,7 @@ POSTGRES_PASSWORD=createastrongpassword
 oboku signs its sessions with an RSA key pair. CouchDB generates one into `./secrets` the first time the stack starts, so a normal install has nothing to do here.
 
 {% hint style="warning" %}
-Keep `./secrets` across upgrades and include it in your backups. The pair is only ever created when missing, so restarts keep signing with the same keys. If you lose it a new pair is generated, and while signed-in users are not logged out — sessions refresh against tokens held server side — any sign-up or magic link already sent out stops working.
+Keep `./secrets` across upgrades and include it in your backups. The pair is only ever created when missing, so restarts keep signing with the same keys. If you lose it a new pair is generated. Signed-in readers are not logged out, because their sessions refresh against tokens held server side, but the admin panel signs its own tokens with this pair, so administrators have to sign in again — and any sign-up or magic link already sent out stops working.
 {% endhint %}
 
 To use your own key pair instead, create it before the first start and it will be left alone:

--- a/gitbook/self-hosting/installation.md
+++ b/gitbook/self-hosting/installation.md
@@ -54,7 +54,7 @@ POSTGRES_PASSWORD=createastrongpassword
 oboku signs its sessions with an RSA key pair. CouchDB generates one into `./secrets` the first time the stack starts, so a normal install has nothing to do here.
 
 {% hint style="warning" %}
-Keep `./secrets` across upgrades and include it in your backups. The pair is only ever created when missing, so restarts keep signing with the same keys — but lose it and a new pair is generated, which signs every user out.
+Keep `./secrets` across upgrades and include it in your backups. The pair is only ever created when missing, so restarts keep signing with the same keys. If you lose it a new pair is generated, and while signed-in users are not logged out — sessions refresh against tokens held server side — any sign-up or magic link already sent out stops working.
 {% endhint %}
 
 To use your own key pair instead, create it before the first start and it will be left alone:


### PR DESCRIPTION
Follow-up to #620, fixing a claim I got wrong in that PR's docs.

## The claim

`installation.md` warned that losing `./secrets` "signs every user out". It does not.

## Why

Sessions do not depend on the pair:

- Refresh tokens are opaque `randomBytes(48)` stored hashed in Postgres (`refreshTokens.service.ts`), not JWTs — nothing about them derives from the signing key.
- `auth.controller.ts:251` reads the refresh token from its cookie and hands it to `authService.refreshToken`, which validates it against the database and the session's bound public key. Nothing in that path verifies the old access token, and `getJwt*` appears nowhere in `refreshTokens.service.ts`.
- So after a regenerated pair, in-flight access tokens fail for up to their 5 minute lifetime, clients refresh transparently, and the API mints a new access token signed with the new key.

The keys are only ever used to sign and verify JWTs — access tokens, sign-up tokens, magic-link tokens, admin tokens. Nothing is encrypted at rest with them (the only `createCipheriv` in the API uses the refresh service's in-memory successor key, unrelated to these).

What a regenerated pair actually invalidates is narrow: sign-up links (1h) and magic links (15m) already sent out stop verifying, since `verifySignUpToken` / `verifyMagicLinkToken` check them against the key.

## Change

One sentence in the warning. `./secrets` is still worth backing up; the consequence of losing it is just much smaller than stated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KhTyYzqyWqBtz3kDoLzLJd)_