### PR TITLE
docs(self-hosting): document session revocation and key rotation

### DIFF
--- a/gitbook/self-hosting/admin.md
+++ b/gitbook/self-hosting/admin.md
@@ -5,3 +5,22 @@ The admin panel is available by default at port `3003` . You have to setup a log
 ## User account creation
 
 Visit the [user-accounts.md](user-accounts.md "mention") section
+
+## Security
+
+The **Security** section lists the refresh tokens currently issued and lets you revoke them, either for every user or for specific email addresses. Revoked tokens are deleted outright, so the affected users have to sign in again.
+
+### Rotating the JWT key pair
+
+Sessions and the JWT key pair are deliberately independent, so replacing the pair is **not** a way to sign everyone out:
+
+* The pair signs access tokens, sign-up links, magic links, and the admin panel's own tokens. Replacing it invalidates all of those immediately.
+* A reader's session does not depend on it. Refresh tokens are random values stored server side and bound to a key held by that browser, so clients simply refresh and carry on with tokens signed by the new pair.
+
+Which of the two you need depends on what leaked:
+
+* **The private key leaked.** Replace the pair. Forged tokens stop validating as soon as the new one is in place. Sessions can keep running, since the leak does not expose refresh tokens or the browser-held keys they are bound to.
+* **A session leaked, or you want everyone signed out.** Revoke the tokens from the Security section. This is the only action that ends sessions.
+* **You are unsure, or the server itself was compromised.** Do both, in that order.
+
+To replace the pair, stop the stack, delete the files in `./secrets`, and start it again — a new pair is generated on start. See [installation.md](installation.md "mention").


### PR DESCRIPTION
## Problem

Replacing the JWT key pair and revoking sessions address different compromises, and neither substitutes for the other — but nothing said so. An operator who rotated the pair after a suspected leak would reasonably have believed every session was ended. It is not: reader sessions carry on.

The admin panel has had a **Security** section for this (`AdminSecuritySection.tsx` — "Inspect issued refresh tokens and revoke sessions when a compromise is suspected", revoking for all users or by email), and the docs never mentioned it.

## Why the two are independent

- The pair signs access tokens, sign-up links, magic links, and — via `signAdminTokens` — the admin panel's own access and refresh tokens. Replacing it invalidates all of those at once.
- A reader's session does not depend on it. Refresh tokens are `randomBytes(48)` stored hashed in Postgres and bound at sign-in to a public key whose private half stays in the browser; `authService.refreshToken` validates against the database and that bound key, never against the JWT pair. So clients refresh and carry on with tokens signed by the new pair.

This decoupling is a feature — it means the signing key can be replaced without a mass logout — but it needs stating, because the intuition runs the other way.

## Change

A **Security** section in `admin.md` covering what the panel's Security page does, and a short runbook keyed on what actually leaked:

- private key leaked → replace the pair (forged tokens die immediately; sessions may keep running, since the leak exposes neither refresh tokens nor the browser-held keys they are bound to)
- a session leaked, or you want everyone out → revoke from the Security section, the only action that ends sessions
- unsure, or the server itself was compromised → both, in that order

Docs only.

## Related

Follow-up to #620 and #621. #621 corrects the neighbouring claim in `installation.md` about what losing `./secrets` costs, and now also notes that administrators specifically do have to sign in again.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KhTyYzqyWqBtz3kDoLzLJd)_