### PR TITLE
feat(metadata): rank covers by certainty, then by source priority

### DIFF
--- a/apps/api/src/features/metadata/pickCoverMetadata.test.ts
+++ b/apps/api/src/features/metadata/pickCoverMetadata.test.ts
@@ -1,0 +1,68 @@
+import type { BookMetadata } from "@oboku/shared"
+import { describe, expect, it } from "vitest"
+import { pickCoverMetadata } from "./pickCoverMetadata"
+
+const FILE: BookMetadata = {
+  type: "file",
+  contentType: "application/x-cbz",
+  coverLink: "BLAME! - c001 (v01) - p001.avif",
+}
+const GOOGLE: BookMetadata = {
+  type: "googleBookApi",
+  coverLink: "https://books.google.com/books/content?id=Ebb6DQAAQBAJ",
+}
+
+describe("pickCoverMetadata", () => {
+  it("prefers the archive over the catalog by default", () => {
+    expect(pickCoverMetadata([GOOGLE, FILE], undefined)).toBe(FILE)
+  })
+
+  it("honors a reordered priority", () => {
+    expect(pickCoverMetadata([GOOGLE, FILE], ["googleBookApi", "file"])).toBe(
+      GOOGLE,
+    )
+  })
+
+  it("skips a source carrying no cover", () => {
+    expect(pickCoverMetadata([{ type: "file" }, GOOGLE], undefined)).toBe(
+      GOOGLE,
+    )
+  })
+
+  it("prefers the stated volume's cover over the archive's", () => {
+    expect(
+      pickCoverMetadata([GOOGLE, FILE], undefined, {
+        googleVolumeId: "Ebb6DQAAQBAJ",
+      }),
+    ).toBe(GOOGLE)
+  })
+
+  it("prefers the stated volume's cover over a file-first priority", () => {
+    expect(
+      pickCoverMetadata([GOOGLE, FILE], ["file", "googleBookApi"], {
+        googleVolumeId: "Ebb6DQAAQBAJ",
+      }),
+    ).toBe(GOOGLE)
+  })
+
+  it("falls back to the archive when the stated volume yielded no cover", () => {
+    expect(
+      pickCoverMetadata([FILE], undefined, {
+        googleVolumeId: "Ebb6DQAAQBAJ",
+      }),
+    ).toBe(FILE)
+  })
+
+  it("ignores an absent volume id", () => {
+    expect(
+      pickCoverMetadata([GOOGLE, FILE], undefined, {
+        googleVolumeId: undefined,
+      }),
+    ).toBe(FILE)
+  })
+
+  it("returns nothing for an empty list", () => {
+    expect(pickCoverMetadata([], undefined)).toBeUndefined()
+    expect(pickCoverMetadata(undefined, undefined)).toBeUndefined()
+  })
+})

--- a/apps/api/src/features/metadata/pickCoverMetadata.test.ts
+++ b/apps/api/src/features/metadata/pickCoverMetadata.test.ts
@@ -2,67 +2,116 @@ import type { BookMetadata } from "@oboku/shared"
 import { describe, expect, it } from "vitest"
 import { pickCoverMetadata } from "./pickCoverMetadata"
 
-const FILE: BookMetadata = {
+const VOLUME_ID = "Ebb6DQAAQBAJ"
+
+const firstPage: BookMetadata = {
   type: "file",
   contentType: "application/x-cbz",
   coverLink: "BLAME! - c001 (v01) - p001.avif",
+  coverIsDeclared: false,
 }
-const GOOGLE: BookMetadata = {
+const declaredCover: BookMetadata = {
+  type: "file",
+  contentType: "application/epub+zip",
+  coverLink: "OEBPS/cover.jpg",
+  coverIsDeclared: true,
+}
+const googleCover: BookMetadata = {
   type: "googleBookApi",
-  coverLink: "https://books.google.com/books/content?id=Ebb6DQAAQBAJ",
+  coverLink: `https://books.google.com/books/content?id=${VOLUME_ID}`,
 }
 
-describe("pickCoverMetadata", () => {
-  it("prefers the archive over the catalog by default", () => {
-    expect(pickCoverMetadata([GOOGLE, FILE], undefined)).toBe(FILE)
+describe("pickCoverMetadata, with no source certain of its cover", () => {
+  it("takes the highest-priority cover", () => {
+    expect(pickCoverMetadata([googleCover, firstPage], undefined)).toBe(
+      firstPage,
+    )
   })
 
   it("honors a reordered priority", () => {
-    expect(pickCoverMetadata([GOOGLE, FILE], ["googleBookApi", "file"])).toBe(
-      GOOGLE,
-    )
+    expect(
+      pickCoverMetadata([googleCover, firstPage], ["googleBookApi", "file"]),
+    ).toBe(googleCover)
   })
 
   it("skips a source carrying no cover", () => {
-    expect(pickCoverMetadata([{ type: "file" }, GOOGLE], undefined)).toBe(
-      GOOGLE,
+    expect(pickCoverMetadata([{ type: "file" }, googleCover], undefined)).toBe(
+      googleCover,
     )
   })
 
-  it("prefers the stated volume's cover over the archive's", () => {
-    expect(
-      pickCoverMetadata([GOOGLE, FILE], undefined, {
-        googleVolumeId: "Ebb6DQAAQBAJ",
-      }),
-    ).toBe(GOOGLE)
-  })
-
-  it("prefers the stated volume's cover over a file-first priority", () => {
-    expect(
-      pickCoverMetadata([GOOGLE, FILE], ["file", "googleBookApi"], {
-        googleVolumeId: "Ebb6DQAAQBAJ",
-      }),
-    ).toBe(GOOGLE)
-  })
-
-  it("falls back to the archive when the stated volume yielded no cover", () => {
-    expect(
-      pickCoverMetadata([FILE], undefined, {
-        googleVolumeId: "Ebb6DQAAQBAJ",
-      }),
-    ).toBe(FILE)
-  })
-
-  it("ignores an absent volume id", () => {
-    expect(
-      pickCoverMetadata([GOOGLE, FILE], undefined, {
-        googleVolumeId: undefined,
-      }),
-    ).toBe(FILE)
-  })
-
-  it("returns nothing for an empty list", () => {
+  it("returns nothing when nothing carries a cover", () => {
+    expect(pickCoverMetadata([{ type: "file" }], undefined)).toBeUndefined()
     expect(pickCoverMetadata([], undefined)).toBeUndefined()
     expect(pickCoverMetadata(undefined, undefined)).toBeUndefined()
+  })
+})
+
+describe("pickCoverMetadata, when one source is certain", () => {
+  it("prefers a stated volume over the archive's first page", () => {
+    expect(
+      pickCoverMetadata([googleCover, firstPage], undefined, {
+        googleVolumeId: VOLUME_ID,
+      }),
+    ).toBe(googleCover)
+  })
+
+  it("prefers a declared cover over an unaddressed catalog match", () => {
+    expect(
+      pickCoverMetadata(
+        [googleCover, declaredCover],
+        ["googleBookApi", "file"],
+      ),
+    ).toBe(declaredCover)
+  })
+
+  it("falls back to the guess when the certain source has no cover", () => {
+    expect(
+      pickCoverMetadata([{ type: "googleBookApi" }, firstPage], undefined, {
+        googleVolumeId: VOLUME_ID,
+      }),
+    ).toBe(firstPage)
+  })
+})
+
+describe("pickCoverMetadata, when both sources are certain", () => {
+  it("defers to the priority order", () => {
+    expect(
+      pickCoverMetadata([googleCover, declaredCover], undefined, {
+        googleVolumeId: VOLUME_ID,
+      }),
+    ).toBe(declaredCover)
+
+    expect(
+      pickCoverMetadata(
+        [googleCover, declaredCover],
+        ["googleBookApi", "file"],
+        {
+          googleVolumeId: VOLUME_ID,
+        },
+      ),
+    ).toBe(googleCover)
+  })
+})
+
+describe("pickCoverMetadata, when the archive never stated its cover", () => {
+  const unknownCover: BookMetadata = {
+    type: "file",
+    contentType: "application/x-cbz",
+    coverLink: "page-001.jpg",
+  }
+
+  it("does not treat an unanswered cover as declared", () => {
+    expect(
+      pickCoverMetadata([googleCover, unknownCover], undefined, {
+        googleVolumeId: VOLUME_ID,
+      }),
+    ).toBe(googleCover)
+  })
+
+  it("still uses it when no source is certain", () => {
+    expect(pickCoverMetadata([googleCover, unknownCover], undefined)).toBe(
+      unknownCover,
+    )
   })
 })

--- a/apps/api/src/features/metadata/pickCoverMetadata.test.ts
+++ b/apps/api/src/features/metadata/pickCoverMetadata.test.ts
@@ -2,23 +2,21 @@ import type { BookMetadata } from "@oboku/shared"
 import { describe, expect, it } from "vitest"
 import { pickCoverMetadata } from "./pickCoverMetadata"
 
-const VOLUME_ID = "Ebb6DQAAQBAJ"
-
 const firstPage: BookMetadata = {
   type: "file",
   contentType: "application/x-cbz",
   coverLink: "BLAME! - c001 (v01) - p001.avif",
-  coverIsDeclared: false,
+  coverConfidence: "assumed",
 }
 const declaredCover: BookMetadata = {
   type: "file",
   contentType: "application/epub+zip",
   coverLink: "OEBPS/cover.jpg",
-  coverIsDeclared: true,
+  coverConfidence: "derived",
 }
 const googleCover: BookMetadata = {
   type: "googleBookApi",
-  coverLink: `https://books.google.com/books/content?id=${VOLUME_ID}`,
+  coverLink: "https://books.google.com/books/content?id=Ebb6DQAAQBAJ",
 }
 
 describe("pickCoverMetadata, with no source certain of its cover", () => {
@@ -48,15 +46,15 @@ describe("pickCoverMetadata, with no source certain of its cover", () => {
 })
 
 describe("pickCoverMetadata, when one source is certain", () => {
-  it("prefers a stated volume over the archive's first page", () => {
+  it("prefers a confirmed catalog match over the archive's first page", () => {
     expect(
       pickCoverMetadata([googleCover, firstPage], undefined, {
-        googleVolumeId: VOLUME_ID,
+        catalogIdentityIsConfirmed: true,
       }),
     ).toBe(googleCover)
   })
 
-  it("prefers a declared cover over an unaddressed catalog match", () => {
+  it("prefers a declared cover over an unconfirmed catalog match", () => {
     expect(
       pickCoverMetadata(
         [googleCover, declaredCover],
@@ -68,7 +66,7 @@ describe("pickCoverMetadata, when one source is certain", () => {
   it("falls back to the guess when the certain source has no cover", () => {
     expect(
       pickCoverMetadata([{ type: "googleBookApi" }, firstPage], undefined, {
-        googleVolumeId: VOLUME_ID,
+        catalogIdentityIsConfirmed: true,
       }),
     ).toBe(firstPage)
   })
@@ -78,7 +76,7 @@ describe("pickCoverMetadata, when both sources are certain", () => {
   it("defers to the priority order", () => {
     expect(
       pickCoverMetadata([googleCover, declaredCover], undefined, {
-        googleVolumeId: VOLUME_ID,
+        catalogIdentityIsConfirmed: true,
       }),
     ).toBe(declaredCover)
 
@@ -87,7 +85,7 @@ describe("pickCoverMetadata, when both sources are certain", () => {
         [googleCover, declaredCover],
         ["googleBookApi", "file"],
         {
-          googleVolumeId: VOLUME_ID,
+          catalogIdentityIsConfirmed: true,
         },
       ),
     ).toBe(googleCover)
@@ -104,7 +102,7 @@ describe("pickCoverMetadata, when the archive never stated its cover", () => {
   it("does not treat an unanswered cover as declared", () => {
     expect(
       pickCoverMetadata([googleCover, unknownCover], undefined, {
-        googleVolumeId: VOLUME_ID,
+        catalogIdentityIsConfirmed: true,
       }),
     ).toBe(googleCover)
   })

--- a/apps/api/src/features/metadata/pickCoverMetadata.ts
+++ b/apps/api/src/features/metadata/pickCoverMetadata.ts
@@ -2,7 +2,21 @@ import {
   type BookDocType,
   type BookMetadata,
   getOrderedBookMetadataSources,
+  type ReorderableBookMetadataSource,
 } from "@oboku/shared"
+
+/**
+ * A Google volume id addresses exactly one Google Books record, where an ISBN
+ * can match several printings — so a book that states one has already told us
+ * which record it is, and that record's cover outranks the archive's whatever
+ * the display priority says. What it outranks is usually a guess: a comic
+ * archive declares no cover, so archive-reader reports its first page under
+ * `confidence: "assumed"`.
+ */
+const STATED_GOOGLE_VOLUME_COVER_PRIORITY: ReorderableBookMetadataSource[] = [
+  "googleBookApi",
+  "file",
+]
 
 /**
  * Picks the metadata entry that should provide the cover, honoring the
@@ -12,15 +26,19 @@ import {
  *
  * Mirrors the merge precedence used on the web in
  * {@link getMetadataFromBook} so the cached cover image stays consistent
- * with the metadata fields surfaced in the UI.
+ * with the metadata fields surfaced in the UI — except when the book states
+ * a Google volume id, see {@link STATED_GOOGLE_VOLUME_COVER_PRIORITY}.
  */
 export const pickCoverMetadata = (
   metadataList: ReadonlyArray<BookMetadata> | undefined,
   priority: BookDocType["metadataSourcePriority"],
+  { googleVolumeId }: { googleVolumeId?: string | undefined } = {},
 ): BookMetadata | undefined => {
   if (!metadataList?.length) return undefined
 
-  const orderedSources = getOrderedBookMetadataSources(priority)
+  const orderedSources = getOrderedBookMetadataSources(
+    googleVolumeId ? STATED_GOOGLE_VOLUME_COVER_PRIORITY : priority,
+  )
 
   for (const source of orderedSources) {
     const match = metadataList.find(

--- a/apps/api/src/features/metadata/pickCoverMetadata.ts
+++ b/apps/api/src/features/metadata/pickCoverMetadata.ts
@@ -2,32 +2,48 @@ import {
   type BookDocType,
   type BookMetadata,
   getOrderedBookMetadataSources,
-  type ReorderableBookMetadataSource,
 } from "@oboku/shared"
 
 /**
- * A Google volume id addresses exactly one Google Books record, where an ISBN
- * can match several printings — so a book that states one has already told us
- * which record it is, and that record's cover outranks the archive's whatever
- * the display priority says. What it outranks is usually a guess: a comic
- * archive declares no cover, so archive-reader reports its first page under
- * `confidence: "assumed"`.
+ * Whether the source is certain this image is *this book's* cover, rather
+ * than the best guess available:
+ *
+ *  - `googleBookApi` — only when the lookup was addressed by volume id. A
+ *    volume id resolves to exactly one Google Books record, where an ISBN
+ *    can match several printings and a title match nothing in particular.
+ *  - `file` — only when the container names the image as its cover. A comic
+ *    archive names none, so its cover is its first page by convention.
+ *
+ * Certainty must be asserted; an entry that does not answer is not certain.
  */
-const STATED_GOOGLE_VOLUME_COVER_PRIORITY: ReorderableBookMetadataSource[] = [
-  "googleBookApi",
-  "file",
-]
+const statesTheBooksCover = (
+  metadata: BookMetadata,
+  googleVolumeId: string | undefined,
+): boolean => {
+  if (!metadata.coverLink) return false
+
+  switch (metadata.type) {
+    case "googleBookApi":
+      return googleVolumeId !== undefined
+    case "file":
+      return metadata.coverIsDeclared === true
+    default:
+      return false
+  }
+}
 
 /**
- * Picks the metadata entry that should provide the cover, honoring the
- * user-defined source priority persisted on the book
- * (`metadataSourcePriority`). Sources are walked highest → lowest
- * priority; the first entry that actually carries a `coverLink` wins.
+ * Picks the metadata entry that should provide the cover.
  *
- * Mirrors the merge precedence used on the web in
- * {@link getMetadataFromBook} so the cached cover image stays consistent
- * with the metadata fields surfaced in the UI — except when the book states
- * a Google volume id, see {@link STATED_GOOGLE_VOLUME_COVER_PRIORITY}.
+ * Certainty outranks priority, and the user-defined source priority
+ * persisted on the book (`metadataSourcePriority`) orders the sources
+ * within each tier: a cover the source is certain about wins, and only
+ * when no source is certain does the highest-priority guess apply.
+ *
+ * The priority itself is never reordered, so this stays consistent with
+ * the merge precedence used on the web in {@link getMetadataFromBook} —
+ * which needs no tier of its own, since a field is either stated or
+ * absent.
  */
 export const pickCoverMetadata = (
   metadataList: ReadonlyArray<BookMetadata> | undefined,
@@ -36,17 +52,28 @@ export const pickCoverMetadata = (
 ): BookMetadata | undefined => {
   if (!metadataList?.length) return undefined
 
-  const orderedSources = getOrderedBookMetadataSources(
-    googleVolumeId ? STATED_GOOGLE_VOLUME_COVER_PRIORITY : priority,
-  )
+  const orderedSources = getOrderedBookMetadataSources(priority)
 
-  for (const source of orderedSources) {
-    const match = metadataList.find(
-      (metadata) => metadata.type === source && metadata.coverLink,
-    )
+  const highestPriorityCover = (
+    isEligible: (metadata: BookMetadata) => boolean,
+  ) => {
+    for (const source of orderedSources) {
+      const match = metadataList.find(
+        (metadata) => metadata.type === source && isEligible(metadata),
+      )
 
-    if (match) return match
+      if (match) return match
+    }
+
+    return undefined
   }
 
-  return undefined
+  return (
+    highestPriorityCover(function statesIt(metadata) {
+      return statesTheBooksCover(metadata, googleVolumeId)
+    }) ??
+    highestPriorityCover(function hasOne(metadata) {
+      return !!metadata.coverLink
+    })
+  )
 }

--- a/apps/api/src/features/metadata/pickCoverMetadata.ts
+++ b/apps/api/src/features/metadata/pickCoverMetadata.ts
@@ -4,33 +4,47 @@ import {
   getOrderedBookMetadataSources,
 } from "@oboku/shared"
 
+type CoverCertainty = {
+  /**
+   * Whether the catalog match describes *this* book rather than a plausible
+   * neighbour. Today the lookup either addressed one Google Books volume id
+   * or it searched; `@prose-reader/metadata-fetcher` states it as a 0–1
+   * score that an agreeing ISBN, GTIN or shared identifier pins to 1.
+   */
+  catalogIdentityIsConfirmed?: boolean
+}
+
 /**
- * Whether the source is certain this image is *this book's* cover, rather
- * than the best guess available:
+ * Whether the source is certain this image is *this book's* cover. Two
+ * independent questions both have to answer yes, and each source can only
+ * answer one of them for free:
  *
- *  - `googleBookApi` — only when the lookup was addressed by volume id. A
- *    volume id resolves to exactly one Google Books record, where an ISBN
- *    can match several printings and a title match nothing in particular.
- *  - `file` — only when the container names the image as its cover. A comic
- *    archive names none, so its cover is its first page by convention.
+ *  - does the source describe this book? An archive *is* the book; a catalog
+ *    is only as sure as its identity match ({@link CoverCertainty}).
+ *  - does the source name this image as the cover? An archive answers with
+ *    `coverConfidence`, `assumed` being the first page of a container that
+ *    names none. A catalog's cover is always its own declaration.
  *
- * Certainty must be asserted; an entry that does not answer is not certain.
+ * Certainty must be asserted, so a source that does not answer is not
+ * certain.
  */
-const statesTheBooksCover = (
+const isCertainCover = (
   metadata: BookMetadata,
-  googleVolumeId: string | undefined,
+  { catalogIdentityIsConfirmed }: CoverCertainty,
 ): boolean => {
   if (!metadata.coverLink) return false
 
   switch (metadata.type) {
     case "googleBookApi":
-      return googleVolumeId !== undefined
+      return catalogIdentityIsConfirmed === true
     case "file":
-      return metadata.coverIsDeclared === true
+      return metadata.coverConfidence === "derived"
     default:
       return false
   }
 }
+
+const hasCover = (metadata: BookMetadata): boolean => !!metadata.coverLink
 
 /**
  * Picks the metadata entry that should provide the cover.
@@ -48,7 +62,7 @@ const statesTheBooksCover = (
 export const pickCoverMetadata = (
   metadataList: ReadonlyArray<BookMetadata> | undefined,
   priority: BookDocType["metadataSourcePriority"],
-  { googleVolumeId }: { googleVolumeId?: string | undefined } = {},
+  certainty: CoverCertainty = {},
 ): BookMetadata | undefined => {
   if (!metadataList?.length) return undefined
 
@@ -69,11 +83,8 @@ export const pickCoverMetadata = (
   }
 
   return (
-    highestPriorityCover(function statesIt(metadata) {
-      return statesTheBooksCover(metadata, googleVolumeId)
-    }) ??
-    highestPriorityCover(function hasOne(metadata) {
-      return !!metadata.coverLink
-    })
+    highestPriorityCover(function isCertain(metadata) {
+      return isCertainCover(metadata, certainty)
+    }) ?? highestPriorityCover(hasCover)
   )
 }

--- a/apps/api/src/features/metadata/retrieveMetadataAndSaveCover.ts
+++ b/apps/api/src/features/metadata/retrieveMetadataAndSaveCover.ts
@@ -369,6 +369,7 @@ export const retrieveMetadataAndSaveCover = async (
       tmpFilePath,
       coversService,
       force: ctx.force,
+      googleVolumeId: lookupGoogleVolumeId,
     })
 
     console.log(

--- a/apps/api/src/features/metadata/retrieveMetadataAndSaveCover.ts
+++ b/apps/api/src/features/metadata/retrieveMetadataAndSaveCover.ts
@@ -369,7 +369,7 @@ export const retrieveMetadataAndSaveCover = async (
       tmpFilePath,
       coversService,
       force: ctx.force,
-      googleVolumeId: lookupGoogleVolumeId,
+      catalogIdentityIsConfirmed: lookupGoogleVolumeId !== undefined,
     })
 
     console.log(

--- a/apps/api/src/features/metadata/updateCover.ts
+++ b/apps/api/src/features/metadata/updateCover.ts
@@ -25,6 +25,7 @@ export const updateCover = async ({
   tmpFilePath,
   coversService,
   force = false,
+  googleVolumeId,
 }: {
   ctx: Context
   book: BookDocType
@@ -37,11 +38,14 @@ export const updateCover = async ({
    * already matches the picked source and the blob exists.
    */
   force?: boolean
+  /** The volume id the Google Books lookup was addressed with, if any. */
+  googleVolumeId?: string | undefined
 }): Promise<UpdateCoverResult> => {
   const coverObjectKey = getBookCoverKey(ctx.userNameHex, ctx.book._id)
   const metadataForCover = pickCoverMetadata(
     metadataList,
     book.metadataSourcePriority,
+    { googleVolumeId },
   )
   const expectedBucketCoverKey = metadataForCover?.coverLink
     ? buildBookBucketCoverKey({

--- a/apps/api/src/features/metadata/updateCover.ts
+++ b/apps/api/src/features/metadata/updateCover.ts
@@ -25,7 +25,7 @@ export const updateCover = async ({
   tmpFilePath,
   coversService,
   force = false,
-  googleVolumeId,
+  catalogIdentityIsConfirmed,
 }: {
   ctx: Context
   book: BookDocType
@@ -38,14 +38,14 @@ export const updateCover = async ({
    * already matches the picked source and the blob exists.
    */
   force?: boolean
-  /** The volume id the Google Books lookup was addressed with, if any. */
-  googleVolumeId?: string | undefined
+  /** Whether the catalog match is known to describe this exact book. */
+  catalogIdentityIsConfirmed?: boolean
 }): Promise<UpdateCoverResult> => {
   const coverObjectKey = getBookCoverKey(ctx.userNameHex, ctx.book._id)
   const metadataForCover = pickCoverMetadata(
     metadataList,
     book.metadataSourcePriority,
-    { googleVolumeId },
+    { catalogIdentityIsConfirmed },
   )
   const expectedBucketCoverKey = metadataForCover?.coverLink
     ? buildBookBucketCoverKey({

--- a/apps/api/src/lib/books/metadata/getMetadataFromArchive.test.ts
+++ b/apps/api/src/lib/books/metadata/getMetadataFromArchive.test.ts
@@ -29,13 +29,10 @@ const opfWith = (identifiers: string): string =>
   "<manifest/><spine/>" +
   "</package>"
 
-const archiveWith = (opf: string) =>
+const archiveOf = (filename: string, entries: Record<string, string>) =>
   createArchive({
-    filename: "book.epub",
-    records: [
-      { uri: "META-INF/container.xml", body: CONTAINER_XML },
-      { uri: "OEBPS/content.opf", body: opf },
-    ].map(function toRecord({ uri, body }) {
+    filename,
+    records: Object.entries(entries).map(function toRecord([uri, body]) {
       return {
         dir: false,
         basename: uri.split("/").pop() ?? uri,
@@ -49,6 +46,12 @@ const archiveWith = (opf: string) =>
     close: function closeArchive() {
       return Promise.resolve()
     },
+  })
+
+const archiveWith = (opf: string) =>
+  archiveOf("book.epub", {
+    "META-INF/container.xml": CONTAINER_XML,
+    "OEBPS/content.opf": opf,
   })
 
 const EPUB_CONTENT_TYPE = "application/epub+zip"
@@ -102,5 +105,52 @@ describe("getMetadataFromArchive", () => {
     const metadata = await getMetadataFromArchive(archive, EPUB_CONTENT_TYPE)
 
     expect(metadata.googleVolumeId).toBeUndefined()
+  })
+})
+
+describe("getMetadataFromArchive, the cover it reports", () => {
+  const COMIC_CONTENT_TYPE = "application/x-cbz"
+
+  it("declares a cover the package names", async () => {
+    const archive = archiveOf("book.epub", {
+      "META-INF/container.xml": CONTAINER_XML,
+      "OEBPS/content.opf":
+        '<?xml version="1.0" encoding="utf-8"?>' +
+        '<package xmlns="http://www.idpf.org/2007/opf"' +
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"' +
+        ' version="3.0" unique-identifier="pub-id">' +
+        "<metadata><dc:title>Sample</dc:title></metadata>" +
+        '<manifest><item id="cover" href="cover.jpg" media-type="image/jpeg"' +
+        ' properties="cover-image"/></manifest><spine/>' +
+        "</package>",
+      "OEBPS/cover.jpg": "binary",
+    })
+
+    const metadata = await getMetadataFromArchive(archive, EPUB_CONTENT_TYPE)
+
+    expect(metadata.coverLink).toBe("OEBPS/cover.jpg")
+    expect(metadata.coverIsDeclared).toBe(true)
+  })
+
+  it("does not declare the first page of an archive that names none", async () => {
+    const archive = archiveOf("book.cbz", {
+      "page-001.jpg": "binary",
+      "page-002.jpg": "binary",
+    })
+
+    const metadata = await getMetadataFromArchive(archive, COMIC_CONTENT_TYPE)
+
+    expect(metadata.coverLink).toBe("page-001.jpg")
+    expect(metadata.coverIsDeclared).toBe(false)
+  })
+
+  it("answers nothing when no cover is derivable", async () => {
+    const metadata = await getMetadataFromArchive(
+      archiveWith(opfWith("")),
+      EPUB_CONTENT_TYPE,
+    )
+
+    expect(metadata.coverLink).toBeUndefined()
+    expect(metadata.coverIsDeclared).toBeUndefined()
   })
 })

--- a/apps/api/src/lib/books/metadata/getMetadataFromArchive.test.ts
+++ b/apps/api/src/lib/books/metadata/getMetadataFromArchive.test.ts
@@ -129,7 +129,7 @@ describe("getMetadataFromArchive, the cover it reports", () => {
     const metadata = await getMetadataFromArchive(archive, EPUB_CONTENT_TYPE)
 
     expect(metadata.coverLink).toBe("OEBPS/cover.jpg")
-    expect(metadata.coverIsDeclared).toBe(true)
+    expect(metadata.coverConfidence).toBe("derived")
   })
 
   it("does not declare the first page of an archive that names none", async () => {
@@ -141,7 +141,7 @@ describe("getMetadataFromArchive, the cover it reports", () => {
     const metadata = await getMetadataFromArchive(archive, COMIC_CONTENT_TYPE)
 
     expect(metadata.coverLink).toBe("page-001.jpg")
-    expect(metadata.coverIsDeclared).toBe(false)
+    expect(metadata.coverConfidence).toBe("assumed")
   })
 
   it("answers nothing when no cover is derivable", async () => {
@@ -151,6 +151,6 @@ describe("getMetadataFromArchive, the cover it reports", () => {
     )
 
     expect(metadata.coverLink).toBeUndefined()
-    expect(metadata.coverIsDeclared).toBeUndefined()
+    expect(metadata.coverConfidence).toBeUndefined()
   })
 })

--- a/apps/api/src/lib/books/metadata/getMetadataFromArchive.ts
+++ b/apps/api/src/lib/books/metadata/getMetadataFromArchive.ts
@@ -27,17 +27,6 @@ const toMutableList = (
 ): string[] | undefined =>
   values && values.length > 0 ? [...values] : undefined
 
-/**
- * archive-reader reports a cover the container names as `derived`, and the
- * first page of an archive that names none as `assumed`. Undefined when no
- * cover was reported at all, so the distinction is never asserted about a
- * cover that does not exist.
- */
-const declaresItsCover = (metadata: ResolvedMetadata): boolean | undefined =>
-  metadata.cover === undefined
-    ? undefined
-    : metadata.cover.confidence === "derived"
-
 export const getMetadataFromArchive = async (
   archive: Archive,
   contentType: string,
@@ -71,7 +60,7 @@ export const getMetadataFromArchive = async (
     date: metadata.publication?.edition?.date,
     subjects: toMutableList(metadata.subjects),
     coverLink: metadata.cover?.uri,
-    coverIsDeclared: declaresItsCover(metadata),
+    coverConfidence: metadata.cover?.confidence,
     pageCount: metadata.numberOfPages,
     isbn,
     googleVolumeId,

--- a/apps/api/src/lib/books/metadata/getMetadataFromArchive.ts
+++ b/apps/api/src/lib/books/metadata/getMetadataFromArchive.ts
@@ -27,6 +27,17 @@ const toMutableList = (
 ): string[] | undefined =>
   values && values.length > 0 ? [...values] : undefined
 
+/**
+ * archive-reader reports a cover the container names as `derived`, and the
+ * first page of an archive that names none as `assumed`. Undefined when no
+ * cover was reported at all, so the distinction is never asserted about a
+ * cover that does not exist.
+ */
+const declaresItsCover = (metadata: ResolvedMetadata): boolean | undefined =>
+  metadata.cover === undefined
+    ? undefined
+    : metadata.cover.confidence === "derived"
+
 export const getMetadataFromArchive = async (
   archive: Archive,
   contentType: string,
@@ -60,6 +71,7 @@ export const getMetadataFromArchive = async (
     date: metadata.publication?.edition?.date,
     subjects: toMutableList(metadata.subjects),
     coverLink: metadata.cover?.uri,
+    coverIsDeclared: declaresItsCover(metadata),
     pageCount: metadata.numberOfPages,
     isbn,
     googleVolumeId,

--- a/apps/web/src/books/details/metadataSource/FileSourceContent.tsx
+++ b/apps/web/src/books/details/metadataSource/FileSourceContent.tsx
@@ -5,7 +5,7 @@ import { MetadataFieldRow } from "./MetadataFieldRow"
 import { BOOK_METADATA_FIELD_LABELS as L } from "./fieldLabels"
 import {
   formatBookMetadataDate,
-  formatCoverOrigin,
+  formatCoverConfidence,
   formatList,
 } from "./formatters"
 
@@ -33,8 +33,8 @@ export const FileSourceContent = ({ metadata }: Props) => (
     />
     <MetadataFieldRow label={L.coverLink} value={metadata?.coverLink} />
     <MetadataFieldRow
-      label={L.coverIsDeclared}
-      value={formatCoverOrigin(metadata?.coverIsDeclared)}
+      label={L.coverConfidence}
+      value={formatCoverConfidence(metadata?.coverConfidence)}
     />
     <MetadataFieldRow
       label={L.pageCount}

--- a/apps/web/src/books/details/metadataSource/FileSourceContent.tsx
+++ b/apps/web/src/books/details/metadataSource/FileSourceContent.tsx
@@ -3,7 +3,11 @@ import type { FileMetadata } from "@oboku/shared"
 import type { DeepReadonlyObject } from "rxdb"
 import { MetadataFieldRow } from "./MetadataFieldRow"
 import { BOOK_METADATA_FIELD_LABELS as L } from "./fieldLabels"
-import { formatBookMetadataDate, formatList } from "./formatters"
+import {
+  formatBookMetadataDate,
+  formatCoverOrigin,
+  formatList,
+} from "./formatters"
 
 type Props = {
   metadata: DeepReadonlyObject<FileMetadata> | undefined
@@ -28,6 +32,10 @@ export const FileSourceContent = ({ metadata }: Props) => (
       value={formatList(metadata?.subjects)}
     />
     <MetadataFieldRow label={L.coverLink} value={metadata?.coverLink} />
+    <MetadataFieldRow
+      label={L.coverIsDeclared}
+      value={formatCoverOrigin(metadata?.coverIsDeclared)}
+    />
     <MetadataFieldRow
       label={L.pageCount}
       value={

--- a/apps/web/src/books/details/metadataSource/fieldLabels.ts
+++ b/apps/web/src/books/details/metadataSource/fieldLabels.ts
@@ -10,6 +10,7 @@ export const BOOK_METADATA_FIELD_LABELS = {
   formatType: "Format types",
   rating: "Rating",
   coverLink: "Cover link",
+  coverIsDeclared: "Cover origin",
   pageCount: "Page count",
   contentType: "Content type",
   date: "Date",

--- a/apps/web/src/books/details/metadataSource/fieldLabels.ts
+++ b/apps/web/src/books/details/metadataSource/fieldLabels.ts
@@ -10,7 +10,7 @@ export const BOOK_METADATA_FIELD_LABELS = {
   formatType: "Format types",
   rating: "Rating",
   coverLink: "Cover link",
-  coverIsDeclared: "Cover origin",
+  coverConfidence: "Cover origin",
   pageCount: "Page count",
   contentType: "Content type",
   date: "Date",

--- a/apps/web/src/books/details/metadataSource/formatters.ts
+++ b/apps/web/src/books/details/metadataSource/formatters.ts
@@ -41,6 +41,19 @@ const formatScalar = (
   value === undefined || value === "" ? undefined : String(value)
 
 /**
+ * Names where a file's cover came from, since the two cases carry very
+ * different weight: one is the container's own declaration, the other the
+ * first page of an archive that declares none.
+ */
+export const formatCoverOrigin = (
+  coverIsDeclared: boolean | undefined,
+): string | undefined => {
+  if (coverIsDeclared === undefined) return undefined
+
+  return coverIsDeclared ? "Declared by the file" : "First page"
+}
+
+/**
  * Project a single metadata field into a short human-readable string for
  * caption-style previews. Returns `undefined` when the field is absent or
  * empty so callers can compose preference-ordered fallback lists.

--- a/apps/web/src/books/details/metadataSource/formatters.ts
+++ b/apps/web/src/books/details/metadataSource/formatters.ts
@@ -1,5 +1,6 @@
 import {
   type BookMetadata,
+  type BookMetadataFields,
   type BOOK_METADATA_FIELDS_BY_SOURCE,
   assertNever,
   formatBytes,
@@ -41,16 +42,21 @@ const formatScalar = (
   value === undefined || value === "" ? undefined : String(value)
 
 /**
- * Names where a file's cover came from, since the two cases carry very
- * different weight: one is the container's own declaration, the other the
- * first page of an archive that declares none.
+ * Names where a cover came from, since the two cases carry very different
+ * weight: one is the container's own declaration, the other the first page
+ * of an archive that declares none.
  */
-export const formatCoverOrigin = (
-  coverIsDeclared: boolean | undefined,
+export const formatCoverConfidence = (
+  coverConfidence: BookMetadataFields["coverConfidence"],
 ): string | undefined => {
-  if (coverIsDeclared === undefined) return undefined
-
-  return coverIsDeclared ? "Declared by the file" : "First page"
+  switch (coverConfidence) {
+    case "derived":
+      return "Declared by the file"
+    case "assumed":
+      return "First page"
+    default:
+      return undefined
+  }
 }
 
 /**

--- a/packages/shared/src/metadata/index.ts
+++ b/packages/shared/src/metadata/index.ts
@@ -18,6 +18,13 @@ export type BookMetadataFields = {
   formatType?: ("book" | "comics" | "manga" | "audio")[]
   rating?: number
   coverLink?: string
+  /**
+   * Whether the container names {@link coverLink} as its cover, as opposed
+   * to it being the first page of an archive that declares none. Only the
+   * `file` source can answer it, and only for a cover it actually reports;
+   * absent means "not known", never "not declared".
+   */
+  coverIsDeclared?: boolean
   pageCount?: number
   contentType?: string
   date?: { year?: number; month?: number; day?: number }
@@ -87,6 +94,7 @@ export type FileMetadata = BookMetadataVariant<
   | "date"
   | "subjects"
   | "coverLink"
+  | "coverIsDeclared"
   | "pageCount"
   | "contentType"
   | "isbn"

--- a/packages/shared/src/metadata/index.ts
+++ b/packages/shared/src/metadata/index.ts
@@ -19,12 +19,13 @@ export type BookMetadataFields = {
   rating?: number
   coverLink?: string
   /**
-   * Whether the container names {@link coverLink} as its cover, as opposed
-   * to it being the first page of an archive that declares none. Only the
-   * `file` source can answer it, and only for a cover it actually reports;
-   * absent means "not known", never "not declared".
+   * How {@link coverLink} was determined, in archive-reader's vocabulary:
+   * `derived` when the container names the image as its cover, `assumed`
+   * when it names none and this is its first page. Only the `file` source
+   * can answer it, and only for a cover it actually reports; absent means
+   * "not known", never "not derived".
    */
-  coverIsDeclared?: boolean
+  coverConfidence?: "derived" | "assumed"
   pageCount?: number
   contentType?: string
   date?: { year?: number; month?: number; day?: number }
@@ -94,7 +95,7 @@ export type FileMetadata = BookMetadataVariant<
   | "date"
   | "subjects"
   | "coverLink"
-  | "coverIsDeclared"
+  | "coverConfidence"
   | "pageCount"
   | "contentType"
   | "isbn"


### PR DESCRIPTION
## The rule

A cover can't merge — one image, one source — so `pickCoverMetadata` elects one. It used to walk the display priority (`user > file > googleBookApi > link`) and stop at the first source carrying any `coverLink`, which meant a *guess* could beat a *statement*.

Certainty is now a tier above priority, and priority orders the sources **within** each tier:

1. is any source certain this is *this book's* cover? highest-priority one of those wins
2. otherwise, highest-priority cover of any kind

The priority itself is never reordered, so the pane keeps telling the truth.

## Two axes, kept separate

Certainty needs two independent questions to both answer yes, and each source only answers one of them for free:

| | does the source describe **this book**? | does it **name** this image as the cover? |
| --- | --- | --- |
| `file` | an archive *is* the book | `coverConfidence` — `derived` when the container names it, `assumed` for the first page of one that names none |
| `googleBookApi` | `catalogIdentityIsConfirmed` — today, whether the lookup addressed one volume id | a catalog's cover is always its own declaration |
| `link`, `user` | — | never: their variants type `coverLink` as `never` |

Keeping them apart is what makes this survive `@prose-reader/metadata-fetcher`, which states identity as a 0–1 score that an agreeing ISBN, GTIN or provider-confirmed shared identifier pins to `1`. That score is what `catalogIdentityIsConfirmed` becomes — a call-site change, no signature churn — while `coverConfidence` stays the orthogonal question. A remote cover already arrives as `confidence: "derived"`, so adding `"coverConfidence"` to the `googleBookApi` variant is then a one-word change.

Certainty must be asserted. A cover extracted before `coverConfidence` existed doesn't answer, so it counts as a guess rather than being assumed either way.

## Behaviour

- comic + confirmed catalog identity → the catalog's cover (**the reported bug**: `BLAME! Vol 1`'s title beside the archive's own page one)
- comic, unconfirmed identity → its first page, exactly as before
- EPUB declaring its cover + confirmed identity → **keeps its own cover**, so it stays coherent with its own title
- both certain → the priority order decides, in either direction
- certain source has no cover → falls back to the guess
- every field other than the cover → merge precedence untouched

## Representation

`FileMetadata.coverConfidence?: "derived" | "assumed"` — archive-reader's own `ResolvedConfidence` values, so the extraction boundary is a pass-through (`coverConfidence: metadata.cover?.confidence`) with no mapping to get wrong. `@oboku/shared` depends on `zod` alone, so the union is mirrored rather than imported; both its values are cover-reachable, making the mirror complete.

No migration: `metadata` is an untyped array in the RxDB schema. The pane counts populated keys generically, so the field gets a **Cover origin** row ("Declared by the file" / "First page") — which happens to answer the question that started this, *why is my comic showing its own page one?*

## Known limitation

An EPUB whose cover was extracted before this ships, carrying a `[oboku~google-volume-id~…]` directive, is treated as a guess and gets the catalog's cover until its next re-extraction. Adding the directive is a rename, which needn't bump `modifiedAt`, so this doesn't always self-heal; `force` is the remediation. Narrow, and degraded rather than wrong — the alternative is assuming a declaration nobody made.

## Verification

- `pickCoverMetadata.test.ts` — 10 cases across all four tiers, both priority directions, unknown-confidence covers, and empty input
- `getMetadataFromArchive.test.ts` — 3 new cases pinning `coverConfidence` to real archive-reader output: `derived` for an OPF `cover-image`, `assumed` for a CBZ's first page, absent for an EPUB with no derivable cover
- `tsc --noEmit` clean for api, web and shared
- api `vitest run src/features/metadata src/lib/books/metadata` → 17 passed; web → 340 passed
- `biome check` → no new findings (the 6 `useLiteralKeys` in `refreshTokens.service.spec.ts` and the `suppressions/unused` warnings pre-exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)