### PR TITLE
feat(metadata): make the catalog cover link clickable

### DIFF
--- a/apps/web/src/books/details/metadataSource/GoogleBookApiSourceContent.test.tsx
+++ b/apps/web/src/books/details/metadataSource/GoogleBookApiSourceContent.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { GoogleBookApiSourceContent } from "./GoogleBookApiSourceContent"
+
+const COVER_URL =
+  "https://books.google.com/books/publisher/content?id=Ebb6DQAAQBAJ&printsec=frontcover&img=1&zoom=0&source=gbs_api"
+
+afterEach(cleanup)
+
+describe("GoogleBookApiSourceContent, the cover link it renders", () => {
+  it("opens the cover in a new tab without leaking the referrer", () => {
+    render(
+      <GoogleBookApiSourceContent
+        metadata={{ type: "googleBookApi", coverLink: COVER_URL }}
+      />,
+    )
+
+    const link = screen.getByRole("link")
+
+    expect(link.getAttribute("href")).toBe(COVER_URL)
+    expect(link.getAttribute("target")).toBe("_blank")
+    expect(link.getAttribute("rel")).toContain("noopener")
+  })
+
+  it("keeps the whole url reachable on hover", () => {
+    render(
+      <GoogleBookApiSourceContent
+        metadata={{ type: "googleBookApi", coverLink: COVER_URL }}
+      />,
+    )
+
+    expect(screen.getByRole("link").getAttribute("title")).toBe(COVER_URL)
+  })
+
+  it("renders no link when the volume advertises no cover", () => {
+    render(
+      <GoogleBookApiSourceContent
+        metadata={{ type: "googleBookApi", title: "BLAME! Vol 1" }}
+      />,
+    )
+
+    expect(screen.queryByRole("link")).toBeNull()
+  })
+})

--- a/apps/web/src/books/details/metadataSource/GoogleBookApiSourceContent.test.tsx
+++ b/apps/web/src/books/details/metadataSource/GoogleBookApiSourceContent.test.tsx
@@ -24,14 +24,17 @@ describe("GoogleBookApiSourceContent, the cover link it renders", () => {
     expect(link.getAttribute("rel")).toContain("noopener")
   })
 
-  it("keeps the whole url reachable on hover", () => {
+  it("keeps the url out of the label and reachable on hover", () => {
     render(
       <GoogleBookApiSourceContent
         metadata={{ type: "googleBookApi", coverLink: COVER_URL }}
       />,
     )
 
-    expect(screen.getByRole("link").getAttribute("title")).toBe(COVER_URL)
+    const link = screen.getByRole("link")
+
+    expect(link.textContent).toBe("Open image")
+    expect(link.getAttribute("title")).toBe(COVER_URL)
   })
 
   it("renders no link when the volume advertises no cover", () => {

--- a/apps/web/src/books/details/metadataSource/GoogleBookApiSourceContent.tsx
+++ b/apps/web/src/books/details/metadataSource/GoogleBookApiSourceContent.tsx
@@ -1,16 +1,9 @@
-import { Link, List, ListSubheader, styled } from "@mui/material"
+import { Link, List, ListSubheader } from "@mui/material"
 import type { GoogleBookApiMetadata } from "@oboku/shared"
 import type { DeepReadonlyObject } from "rxdb"
 import { MetadataFieldRow } from "./MetadataFieldRow"
 import { BOOK_METADATA_FIELD_LABELS as L } from "./fieldLabels"
 import { formatBookMetadataDate, formatList } from "./formatters"
-
-const CoverUriLink = styled(Link)({
-  display: "block",
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-})
 
 type Props = {
   metadata: DeepReadonlyObject<GoogleBookApiMetadata> | undefined
@@ -37,14 +30,14 @@ export const GoogleBookApiSourceContent = ({ metadata }: Props) => (
       label={L.coverLink}
       value={
         metadata?.coverLink ? (
-          <CoverUriLink
+          <Link
             href={metadata.coverLink}
             target="_blank"
             rel="noopener noreferrer"
             title={metadata.coverLink}
           >
-            {metadata.coverLink}
-          </CoverUriLink>
+            Open image
+          </Link>
         ) : undefined
       }
     />

--- a/apps/web/src/books/details/metadataSource/GoogleBookApiSourceContent.tsx
+++ b/apps/web/src/books/details/metadataSource/GoogleBookApiSourceContent.tsx
@@ -1,9 +1,16 @@
-import { List, ListSubheader } from "@mui/material"
+import { Link, List, ListSubheader, styled } from "@mui/material"
 import type { GoogleBookApiMetadata } from "@oboku/shared"
 import type { DeepReadonlyObject } from "rxdb"
 import { MetadataFieldRow } from "./MetadataFieldRow"
 import { BOOK_METADATA_FIELD_LABELS as L } from "./fieldLabels"
 import { formatBookMetadataDate, formatList } from "./formatters"
+
+const CoverUriLink = styled(Link)({
+  display: "block",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+})
 
 type Props = {
   metadata: DeepReadonlyObject<GoogleBookApiMetadata> | undefined
@@ -26,7 +33,21 @@ export const GoogleBookApiSourceContent = ({ metadata }: Props) => (
       label={L.rating}
       value={metadata?.rating !== undefined ? `${metadata.rating}` : undefined}
     />
-    <MetadataFieldRow label={L.coverLink} value={metadata?.coverLink} />
+    <MetadataFieldRow
+      label={L.coverLink}
+      value={
+        metadata?.coverLink ? (
+          <CoverUriLink
+            href={metadata.coverLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={metadata.coverLink}
+          >
+            {metadata.coverLink}
+          </CoverUriLink>
+        ) : undefined
+      }
+    />
     <MetadataFieldRow
       label={L.pageCount}
       value={


### PR DESCRIPTION
## Why

A Google Books content url runs past 200 characters, so **Cover link** wrapped over four lines of the source detail screen — and wasn't openable, which is the one thing you'd want from it when checking whether the catalog picked the right cover.

## What

A plain MUI `Link` reading **Open image**, in the Google Books pane only. The url lives in `href` and `title`, so it stays copyable and visible on hover without occupying the row.

No styling: rendering the url as the link text is what made it long, so the fix is not to render it. An earlier revision clipped it with `display: block` + `white-space: nowrap` + `overflow: hidden` + `text-overflow: ellipsis` — four properties spent hiding text nobody reads.

Only the *catalog's* cover link becomes an anchor. A `file` entry addresses its cover in the container's own space, so `page-001.jpg` is a record uri with nowhere to navigate; it stays plain text.

## Verification

- 3 new cases in `GoogleBookApiSourceContent.test.tsx` — the anchor's `href`/`target`/`rel`, the label text with the full url on `title`, and no link at all when the volume advertises no cover
- `tsc --noEmit -p apps/web` clean
- web `vitest run` → 343 passed (64 files)
- `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)