### PR TITLE
refactor(shared): host the legacy resourceId migration in one place

### DIFF
--- a/apps/api/src/migrations/migration.service.ts
+++ b/apps/api/src/migrations/migration.service.ts
@@ -1,4 +1,8 @@
-import { type CollectionDocType, getCollectionCoverKey } from "@oboku/shared"
+import {
+  type CollectionDocType,
+  getCollectionCoverKey,
+  migrateResourceIdToData,
+} from "@oboku/shared"
 import { Injectable, Logger } from "@nestjs/common"
 import { InjectRepository } from "@nestjs/typeorm"
 import { Repository } from "typeorm"
@@ -119,14 +123,6 @@ const toCanonicalWebdavResourceId = (resourceId: string) => {
   return generateCanonicalWebdavResourceIdForMigration(filePath)
 }
 
-function safeDecodeURIComponent(value: string): string {
-  try {
-    return decodeURIComponent(value)
-  } catch {
-    return value
-  }
-}
-
 /**
  * Older CouchDB installs may store `data` / `linkData` as a JSON-encoded
  * string rather than an object. This normalises either representation into
@@ -155,75 +151,6 @@ function normalizeDataField(value: unknown): Record<string, unknown> | null {
     return value as Record<string, unknown>
   }
   return null
-}
-
-/**
- * Parses a legacy resourceId / linkResourceId string and returns the identity
- * fields to merge into data / linkData for the given provider type.
- * Returns null if there is nothing to migrate.
- */
-function migrateResourceIdToData(
-  type: string,
-  resourceId: string,
-  existingData: Record<string, unknown> | null,
-): Record<string, unknown> | null {
-  const base = existingData ?? {}
-
-  switch (type) {
-    case "DRIVE": {
-      const fileId = resourceId.startsWith("drive-")
-        ? resourceId.substring("drive-".length)
-        : resourceId
-      return { ...base, fileId }
-    }
-
-    case "dropbox": {
-      const fileId = resourceId.startsWith("dropbox-")
-        ? resourceId.substring("dropbox-".length)
-        : resourceId
-      return { ...base, fileId }
-    }
-
-    case "webdav": {
-      const withoutPrefix = resourceId.startsWith("webdav://")
-        ? resourceId.substring("webdav://".length)
-        : resourceId
-      // Strip the host portion from the legacy "webdav://host:encodedPath"
-      // format. Must stay in sync with the client-side migration in
-      // apps/web/src/rxdb/collections/utils.ts.
-      const encodedFilePath = withoutPrefix.includes(":")
-        ? withoutPrefix.substring(withoutPrefix.lastIndexOf(":") + 1)
-        : withoutPrefix
-      return { ...base, filePath: safeDecodeURIComponent(encodedFilePath) }
-    }
-
-    case "synology-drive": {
-      const withoutPrefix = resourceId.startsWith("synology-drive://")
-        ? resourceId.substring("synology-drive://".length)
-        : resourceId
-      return { ...base, fileId: safeDecodeURIComponent(withoutPrefix) }
-    }
-
-    case "server": {
-      const withoutPrefix = resourceId.startsWith("server://")
-        ? resourceId.substring("server://".length)
-        : resourceId
-      return { ...base, filePath: safeDecodeURIComponent(withoutPrefix) }
-    }
-
-    case "URI": {
-      const url = resourceId.startsWith("oboku-link-")
-        ? resourceId.substring("oboku-link-".length)
-        : resourceId
-      return { ...base, url }
-    }
-
-    case "file":
-      return null
-
-    default:
-      return null
-  }
 }
 
 /**

--- a/apps/web/src/rxdb/collections/utils.ts
+++ b/apps/web/src/rxdb/collections/utils.ts
@@ -1,12 +1,6 @@
-export const generateId = () => crypto.randomUUID()
+import { migrateResourceIdToData as extractLegacyResourceIdData } from "@oboku/shared"
 
-function safeDecodeURIComponent(value: string): string {
-  try {
-    return decodeURIComponent(value)
-  } catch {
-    return value
-  }
-}
+export const generateId = () => crypto.randomUUID()
 
 /**
  * Parses a legacy resourceId string and returns the identity fields to merge
@@ -26,61 +20,5 @@ export function migrateResourceIdToData(
 
   if (!resourceId) return base
 
-  switch (type) {
-    case "DRIVE": {
-      const fileId = resourceId.startsWith("drive-")
-        ? resourceId.substring("drive-".length)
-        : resourceId
-      return { ...base, fileId }
-    }
-
-    case "dropbox": {
-      const fileId = resourceId.startsWith("dropbox-")
-        ? resourceId.substring("dropbox-".length)
-        : resourceId
-      return { ...base, fileId }
-    }
-
-    case "webdav": {
-      const withoutPrefix = resourceId.startsWith("webdav://")
-        ? resourceId.substring("webdav://".length)
-        : resourceId
-      // Strip the host portion from the legacy "webdav://host:encodedPath"
-      // format. Must stay in sync with the server-side migration in
-      // migration.service.ts so both produce the same filePath.
-      const encodedFilePath = withoutPrefix.includes(":")
-        ? withoutPrefix.substring(withoutPrefix.lastIndexOf(":") + 1)
-        : withoutPrefix
-      return { ...base, filePath: safeDecodeURIComponent(encodedFilePath) }
-    }
-
-    case "synology-drive": {
-      const withoutPrefix = resourceId.startsWith("synology-drive://")
-        ? resourceId.substring("synology-drive://".length)
-        : resourceId
-      const fileId = safeDecodeURIComponent(withoutPrefix)
-      return { ...base, fileId }
-    }
-
-    case "server": {
-      const withoutPrefix = resourceId.startsWith("server://")
-        ? resourceId.substring("server://".length)
-        : resourceId
-      const filePath = safeDecodeURIComponent(withoutPrefix)
-      return { ...base, filePath }
-    }
-
-    case "URI": {
-      const url = resourceId.startsWith("oboku-link-")
-        ? resourceId.substring("oboku-link-".length)
-        : resourceId
-      return { ...base, url }
-    }
-
-    case "file":
-      return base
-
-    default:
-      return base
-  }
+  return extractLegacyResourceIdData(type, resourceId, base) ?? base
 }

--- a/packages/shared/src/db/migrateResourceIdToData.ts
+++ b/packages/shared/src/db/migrateResourceIdToData.ts
@@ -1,0 +1,65 @@
+const safeDecodeURIComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+const stripPrefix = (value: string, prefix: string) =>
+  value.startsWith(prefix) ? value.substring(prefix.length) : value
+
+/**
+ * Parses a legacy `resourceId` / `linkResourceId` string and returns the
+ * identity fields to merge into `data` / `linkData` for the given provider
+ * type.
+ *
+ * @returns `null` when the provider type carries no identity in its legacy
+ * resourceId, meaning there is nothing to migrate.
+ */
+export function migrateResourceIdToData(
+  type: string,
+  resourceId: string,
+  existingData: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  const base = existingData ?? {}
+
+  switch (type) {
+    case "DRIVE":
+      return { ...base, fileId: stripPrefix(resourceId, "drive-") }
+
+    case "dropbox":
+      return { ...base, fileId: stripPrefix(resourceId, "dropbox-") }
+
+    case "webdav": {
+      const withoutPrefix = stripPrefix(resourceId, "webdav://")
+      // Legacy ids came as `webdav://{host}:{encoded filePath}`, with the host
+      // portion later dropped from the format.
+      const encodedFilePath = withoutPrefix.includes(":")
+        ? withoutPrefix.substring(withoutPrefix.lastIndexOf(":") + 1)
+        : withoutPrefix
+
+      return { ...base, filePath: safeDecodeURIComponent(encodedFilePath) }
+    }
+
+    case "synology-drive":
+      return {
+        ...base,
+        fileId: safeDecodeURIComponent(
+          stripPrefix(resourceId, "synology-drive://"),
+        ),
+      }
+
+    case "server":
+      return {
+        ...base,
+        filePath: safeDecodeURIComponent(stripPrefix(resourceId, "server://")),
+      }
+
+    case "URI":
+      return { ...base, url: stripPrefix(resourceId, "oboku-link-") }
+
+    default:
+      return null
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * as directives from "./directives"
 
 export * from "./db/docTypes"
 export * from "./db/books"
+export * from "./db/migrateResourceIdToData"
 
 export * from "./covers"
 export * from "./dataSources"


### PR DESCRIPTION
## Legacy `resourceId` → link data parser

**What was duplicated**

- `apps/api/src/migrations/migration.service.ts` — `migrateResourceIdToData()` + a local `safeDecodeURIComponent()`, used by the `resourceId` → `data` / `linkData` CouchDB migration.
- `apps/web/src/rxdb/collections/utils.ts` — `migrateResourceIdToData()` + its own copy of `safeDecodeURIComponent()`, used by the rxdb v1 schema migration strategies for `link` and `obokucollection`.

Both parsed the same legacy id formats (`drive-`, `dropbox-`, `webdav://`, `synology-drive://`, `server://`, `oboku-link-`) into the same identity fields, and both carried a comment pointing at the other:

```ts
// Must stay in sync with the client-side migration in
// apps/web/src/rxdb/collections/utils.ts.
```
```ts
// Must stay in sync with the server-side migration in
// migration.service.ts so both produce the same filePath.
```

That is the duplication this PR removes: two copies of one wire-format parser that must agree, or the same document ends up with different `data` depending on whether the server or the client migrated it first.

**What it became**

`packages/shared/src/db/migrateResourceIdToData.ts`, exported from `@oboku/shared`. It keeps the api contract verbatim — `null` means "this provider carries no identity in its legacy resourceId", which is what the api migration uses to skip a document.

- The api migration imports it and drops its local copy.
- `apps/web/src/rxdb/collections/utils.ts` keeps its own exported `migrateResourceIdToData` and its contract (tolerates a missing `resourceId`, tolerates a non-object `data`, returns the untouched base for providers with nothing to extract), now as a one-line wrapper: `extractLegacyResourceIdData(type, resourceId, base) ?? base`.

Web's public behavior is unchanged, so `apps/web/src/rxdb/collections/link.test.ts` (54 cases covering every provider prefix and the fallbacks) still passes untouched and now guards the single shared implementation.

**Net LOC**: −143 / +9 in the three touched files, +63 for the new shared module → **−71 lines**.

**Why they are the same concept**: both decode one legacy id format that the two runtimes must agree on, byte for byte. The only difference was defensive input handling at the edges (web is fed raw rxdb documents, api is fed raw CouchDB documents), which stays where it belongs — in the web wrapper — rather than being pushed into the shared parser as a mode flag.

## Behavior

Behavior-preserving. Per branch:

| provider | before (api / web) | after |
| --- | --- | --- |
| `DRIVE`, `dropbox`, `webdav`, `synology-drive`, `server`, `URI` | identical in both copies | unchanged |
| `file`, unknown | api `null` (doc skipped) / web `base` | api `null`, web `?? base` → `base` |

The api's separate `extractFilePathFromWebdavResourceIdForMigration()` snapshot parser is deliberately left alone — it returns `null` on a decode failure rather than the raw value, and its doc comment states it should not follow shared runtime helpers.

## Gates

Run with node 22 (the environment has no node 24; `.nvmrc` asks for v24), baseline recorded on a clean `develop` first:

| gate | baseline | after |
| --- | --- | --- |
| `pnpm run lint` | pass | pass |
| `pnpm run tsc` | pass | pass |
| `pnpm run test` (web) | 3 files / 15 tests failing | same 3 files / 15 tests |
| `pnpm run test` (api) | 8 suites fail to resolve `@oboku/shared` | identical |
| `pnpm run build` | fails in `@oboku/shared` (`rollup-plugin-node-externals`: `TypeError: undefined is not a function`) | not reached |

No new failures. The build failure and both test-failure sets reproduce unchanged on a clean `develop` checkout in this environment and are unrelated to this diff.

## Other candidates found, not taken

Left for a future pass so this PR stays one story:

- `apps/web/src/problems/useRepair.ts` — three near-identical branches removing dangling ids from a document array field, differing only in collection name, field name and confirm text; plus the repeated "docs with dangling items" reduce in `useFixableBooks.ts` / `useFixableCollections.ts`.
- `apps/web/src/plugins/*/DownloadBook.tsx` and `*/UpsertFile.tsx` — the same `useMutation$` + `takeUntil(merge(fromAbortSignal(signal), onUnmount$))` + `throwIfEmpty(() => new CancelError())` + `useEffectWithUnmount$(scheduleDelayedEffect(...))` scaffold across ~7 plugins, with only the source observable differing.
- `apps/web/src/problems/BookDanglingCollections.tsx` / `BookDanglingLinks.tsx` / `CollectionDanglingBooks.tsx` — one `ListItemButton` + `LinkOffRounded` shell, three copies, differing only in the primary/secondary text.

Deliberately rejected: `useDataSourceIncrementalModify` / `useDataSourceIncrementalPatch` (different rxdb operations), `useArchiveNotification` / `useMarkNotificationAsSeen` (already share `createNotificationMutationOptions`; the optimistic updates genuinely differ), and the two `buildTree` implementations in `apps/api/src/plugins/google/sync.ts` / `apps/web/src/common/FileTreeView/buildTree.ts` (multi-parent vs single `parentId`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EW8KrMmpGLB15tyJRUrjFM)_