### PR TITLE
fix(metadata): extract the calendar day and 1-based month from published dates

### DIFF
--- a/apps/api/src/lib/metadata/extractDateComponents.spec.ts
+++ b/apps/api/src/lib/metadata/extractDateComponents.spec.ts
@@ -1,0 +1,32 @@
+import { extractDateComponents } from "./extractDateComponents"
+
+describe("extractDateComponents", () => {
+  it("extracts the calendar day and 1-based month from a full date", () => {
+    expect(extractDateComponents("2015-10-21")).toEqual({
+      year: 2015,
+      month: 10,
+      day: 21,
+    })
+  })
+
+  it("keeps a year-only value as just the year", () => {
+    expect(extractDateComponents("2015")).toEqual({
+      year: 2015,
+      month: undefined,
+      day: undefined,
+    })
+  })
+
+  it("returns no components for an empty or unparseable value", () => {
+    expect(extractDateComponents("")).toEqual({
+      year: undefined,
+      month: undefined,
+      day: undefined,
+    })
+    expect(extractDateComponents("not a real date")).toEqual({
+      year: undefined,
+      month: undefined,
+      day: undefined,
+    })
+  })
+})

--- a/apps/api/src/lib/metadata/extractDateComponents.ts
+++ b/apps/api/src/lib/metadata/extractDateComponents.ts
@@ -11,9 +11,10 @@ export function extractDateComponents(dateStr: string | undefined = "") {
   } else if (!Number.isNaN(Date.parse(dateStr))) {
     const date = new Date(dateStr)
 
-    day = date.getDay()
-    month = date.getMonth()
-    year = date.getFullYear()
+    // Date-only strings parse as UTC midnight, so UTC getters keep the calendar date.
+    day = date.getUTCDate()
+    month = date.getUTCMonth() + 1
+    year = date.getUTCFullYear()
   }
 
   return { year, month, day }


### PR DESCRIPTION
## The bug

Every book whose metadata comes from Google Books shows a wrong publication date. `extractDateComponents` (`apps/api/src/lib/metadata/extractDateComponents.ts`) reads:

- `date.getDay()` — the **day of the week** (0–6), not the day of the month, and
- `date.getMonth()` — **0-based**,

while its only consumer, `formatBookMetadataDate` in the web app, rebuilds the date as `new Date(`${year} ${month} ${day}`)`, i.e. it expects a 1-based month and a calendar day.

**How to observe:** a Google Books `publishedDate` of `2015-10-21` is stored as `{ year: 2015, month: 9, day: 3 }` (3 = Wednesday) and the book details screen renders **"Thu Sep 03 2015"** instead of Oct 21, 2015. Year-month dates like `2015-10` render with the wrong month too.

## Root cause

`getDay()` was used where `getDate()` semantics were intended, and the 0-based `getMonth()` was stored without the `+1` the formatter expects.

## The fix

Use the UTC calendar getters — `getUTCDate()`, `getUTCMonth() + 1`, `getUTCFullYear()`. UTC rather than local because date-only strings such as `2015-10-21` parse as UTC midnight, so local getters would report the previous day on servers west of UTC.

## Verification

- New regression test `apps/api/src/lib/metadata/extractDateComponents.spec.ts`: fails on the previous code (`{ month: 9, day: 3 }` observed) and passes after the fix, alongside year-only and unparseable-input cases.
- API jest suite: 22 suites / 134 tests passing (baseline before the fix: 21 / 131, all passing).
- `pnpm run lint` and the API build pass.

## Other findings (not addressed in this PR)

Confirmed by executing the real code paths, left for future runs:

- **`packages/shared/src/directives.ts:43`** — the directive regex `/(\[oboku~[^\]]*\])+/gi` matches *adjacent* directives (`[oboku~tags~scifi][oboku~ignore]`) as one blob, and the non-global `replace` cleanup strips only the first wrapper: the result is a garbage tag `scifi[oboku~ignore]` and the second directive silently lost.
- **`packages/synology/src/client.ts:549`** — `Number("")` is `0`, so a NAS returning an empty `modified_at` string yields a permanent `1970-01-01` timestamp instead of falling back to "now"; an out-of-range numeric (e.g. microsecond mtimes) throws `RangeError` out of `mapSynologyDriveItemToMetadata`.
- **`apps/web/src/search/useCollectionsForSearch.ts:8`** — `REGEXP_SPECIAL_CHAR` omits `?` and `\`, so a search beginning with `?` (or ending with `\`) makes `new RegExp(search, "i")` throw during render and the app falls to the global error screen.
- **`packages/shared/src/contentType.ts:1`** — `getUrlExtension` on a dotless name returns the whole name (`isFileSupported({ name: "epub" })` → `true`), contradicting the intent encoded in `contentType.test.ts`'s `no-extension` case.

---
_Generated by [Claude Code](https://claude.ai/code/session_019iSXCYB3DLhgEkHBSZSfrC)_